### PR TITLE
feat(moonrun): expose SQLite database mutex operations

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -161,7 +161,7 @@ another execution implementation exists.
 _Avoid_: Host Process, process adapter interface, virtual process
 
 **Handle**:
-An opaque value held by MoonBit code that names a moonrun-owned object, such as a Resource, Job, Worker, poll instance, Host Buffer, address-info result, Completion Source, SQLite Database, or SQLite Statement.
+An opaque value held by MoonBit code that names a moonrun-owned object, such as a Resource, Job, Worker, poll instance, Host Buffer, address-info result, Completion Source, SQLite Database, SQLite Database Mutex, or SQLite Statement.
 _Avoid_: Host Handle, Guest Handle, raw fd, pointer, id
 
 **Runtime**:
@@ -271,18 +271,25 @@ raw signal operation in Async Sys.
 _Avoid_: `moonbitlang/async` source mirror
 
 **SQLite API**:
-The V8-facing `moonbitlang/sqlite` adapter that lowers SQLite-shaped calls into the portable wasm ABI, borrows Guest Memory for synchronous native calls, and reports ABI contract violations as traps. Native SQLite pointers never cross this interface: SQLite objects and the reserved VFS parameter use opaque `u64` Handles with one runtime-discovered null Host Key. UTF-8 filenames use a backing Bytes value plus its byte length; the adapter bounds the read by that length, validates the encoding and absence of interior NULs, then copies it into a NUL-terminated Host Buffer for SQLite. UTF-16 SQL uses a backing String plus code-unit offset and length; `pzTail` is returned as an absolute code-unit offset in that same String so a StringView can contain multiple statements. Bound UTF-16 and blob views use `SQLITE_TRANSIENT`, so SQLite copies them before the Guest Memory borrow ends. Borrowed error messages, column names, and text/blob columns use length-and-copy imports instead of exposing SQLite-owned pointers.
+The V8-facing `moonbitlang/sqlite` adapter that lowers SQLite-shaped calls into the portable wasm ABI, borrows Guest Memory for synchronous native calls, and reports ABI contract violations as traps. Native SQLite pointers never cross this interface: SQLite objects and the reserved VFS parameter use opaque `u64` Handles with one runtime-discovered null Host Key. A SQLite Database Mutex is a stable, lifetime-checked Handle owned by its Database; the null Handle preserves SQLite's mutex no-op behavior when a connection has no mutex. UTF-8 filenames use a backing Bytes value plus its byte length; the adapter bounds the read by that length, validates the encoding and absence of interior NULs, then copies it into a NUL-terminated Host Buffer for SQLite. UTF-16 SQL uses a backing String plus code-unit offset and length; `pzTail` is returned as an absolute code-unit offset in that same String so a StringView can contain multiple statements. Bound UTF-16 and blob views use `SQLITE_TRANSIENT`, so SQLite copies them before the Guest Memory borrow ends. Borrowed error messages, column names, and text/blob columns use length-and-copy imports instead of exposing SQLite-owned pointers.
 _Avoid_: SQLite Host, SQLite wrapper SDK
 
 **SQLite Host**:
 The backend-neutral SQLite implementation owned by one Runtime. It owns SQLite
 admission rules and operations, uses the Runtime's shared Host Key namespace,
-and contains the Database and Statement pointer maps, teardown, and leak
-accounting. File-backed admission currently asks the Host Filesystem to
-interpret and authorize its filesystem intents before SQLite's default VFS
-reinterprets the filename; SQLite flags, VFS selection, authorizer behavior,
-and FFI remain SQLite Host semantics. Wasm runtime adapters lower their own
-memory and scalar representations before crossing its interface.
+and contains the Database, Database Mutex, and Statement state, teardown, and
+leak accounting. Its Database Mutex depth counts recursive entries made through
+the SQLite Host interface, not SQLite's internal mutex ownership. This protects
+the Database lifetime from unbalanced guest calls: the Host rejects unmatched
+leaves and Database close while entries remain, and releases those entries
+during same-thread Runtime teardown before SQLite destroys the mutex.
+File-backed admission currently asks the Host Filesystem to interpret and
+authorize its filesystem intents before SQLite's default VFS reinterprets the
+filename; SQLite flags, VFS selection, authorizer behavior, and FFI remain
+SQLite Host semantics. The Host forces `SQLITE_OPEN_FULLMUTEX` so callers get a
+serialized connection without coordinating SQLite open flags themselves. Wasm
+runtime adapters lower their own memory and scalar representations before
+crossing its interface.
 _Avoid_: SQLite API, Async Host, V8 SQLite
 
 **Async Sys**:

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -71,6 +71,7 @@ pub(crate) enum HostResourceKind {
     #[cfg(windows)]
     IoResult,
     SqliteDatabase,
+    SqliteDatabaseMutex,
     SqliteStatement,
 }
 

--- a/crates/moonrun/src/sqlite/connection.rs
+++ b/crates/moonrun/src/sqlite/connection.rs
@@ -22,9 +22,9 @@ use std::ptr::{self, NonNull};
 use libsqlite3_sys as ffi;
 use slotmap::Key;
 
-use super::policy::{ensure_open_flags, ensure_valid_database, install_authorizer};
+use super::policy::{ensure_valid_database, install_authorizer, normalize_open_flags};
 use super::{SqliteHost, SqliteHostError, SqliteHostResult};
-use crate::runtime::{HostResourceKind, null_handle};
+use crate::runtime::{HostKey, HostResourceKind, null_handle};
 
 // `libsqlite3-sys` intentionally omits SQLite's UTF-16 convenience APIs from
 // its generated bindings. The bundled SQLite library still exports them.
@@ -35,21 +35,49 @@ unsafe extern "C" {
 #[derive(Clone, Copy)]
 pub(super) enum Database {
     /// The connection opened and the Host policy was installed.
-    Ready(NonNull<ffi::sqlite3>),
+    Ready {
+        pointer: NonNull<ffi::sqlite3>,
+        mutex: Option<HostKey>,
+    },
     /// SQLite returned a connection together with an error. It remains valid
     /// only for reading the error and closing the connection.
     Failed(NonNull<ffi::sqlite3>),
 }
 
 impl Database {
+    fn ready(pointer: NonNull<ffi::sqlite3>) -> Self {
+        Self::Ready {
+            pointer,
+            mutex: None,
+        }
+    }
+
     pub(super) fn pointer(self) -> NonNull<ffi::sqlite3> {
         match self {
-            Self::Ready(pointer) | Self::Failed(pointer) => pointer,
+            Self::Ready { pointer, .. } | Self::Failed(pointer) => pointer,
         }
     }
 
     pub(super) fn is_ready(self) -> bool {
-        matches!(self, Self::Ready(_))
+        matches!(self, Self::Ready { .. })
+    }
+
+    pub(super) fn mutex(self) -> Option<HostKey> {
+        match self {
+            Self::Ready { mutex, .. } => mutex,
+            Self::Failed(_) => None,
+        }
+    }
+
+    pub(super) fn set_mutex(&mut self, mutex: HostKey) {
+        let Self::Ready {
+            mutex: database_mutex,
+            ..
+        } = self
+        else {
+            unreachable!("failed database cannot have a mutex Handle");
+        };
+        *database_mutex = Some(mutex);
     }
 }
 
@@ -63,7 +91,7 @@ pub(crate) struct OpenOutcome {
 
 impl SqliteHost {
     pub(crate) fn open_v2(&self, filename: &CStr, flags: i32, vfs: u64) -> OpenOutcome {
-        let flags = ensure_open_flags(flags);
+        let flags = normalize_open_flags(flags);
         if let Err(code) = ensure_valid_database(&self.filesystem, filename, flags, vfs) {
             return OpenOutcome {
                 code,
@@ -88,7 +116,7 @@ impl SqliteHost {
         };
 
         let database = if code == ffi::SQLITE_OK {
-            Database::Ready(database)
+            Database::ready(database)
         } else {
             Database::Failed(database)
         };
@@ -146,6 +174,9 @@ impl SqliteHost {
         }
         let database_handle = database;
         let database = self.database(database_handle)?;
+        if self.database_mutex_is_entered(database) {
+            return Err(SqliteHostError::InvalidInput);
+        }
         let pointer = database.pointer();
         let code = unsafe { ffi::sqlite3_close(pointer.as_ptr()) };
         if code == ffi::SQLITE_OK {
@@ -165,12 +196,15 @@ impl SqliteHost {
         key.data().as_ffi()
     }
 
-    pub(super) fn database(&self, handle: u64) -> SqliteHostResult<Database> {
-        let key = self
-            .keys
+    pub(super) fn database_key(&self, handle: u64) -> SqliteHostResult<HostKey> {
+        self.keys
             .borrow()
             .key(handle, HostResourceKind::SqliteDatabase)
-            .ok_or(SqliteHostError::InvalidHandle)?;
+            .ok_or(SqliteHostError::InvalidHandle)
+    }
+
+    pub(super) fn database(&self, handle: u64) -> SqliteHostResult<Database> {
+        let key = self.database_key(handle)?;
         self.databases
             .borrow()
             .get(key)
@@ -179,16 +213,13 @@ impl SqliteHost {
     }
 
     fn remove_database(&self, handle: u64) -> SqliteHostResult<Database> {
-        let key = self
-            .keys
-            .borrow()
-            .key(handle, HostResourceKind::SqliteDatabase)
-            .ok_or(SqliteHostError::InvalidHandle)?;
+        let key = self.database_key(handle)?;
         let database = self
             .databases
             .borrow_mut()
             .remove(key)
             .ok_or(SqliteHostError::InvalidHandle)?;
+        self.remove_database_mutex(database);
         let removed = self.keys.borrow_mut().remove(key);
         debug_assert_eq!(removed, Some(HostResourceKind::SqliteDatabase));
         Ok(database)

--- a/crates/moonrun/src/sqlite/mod.rs
+++ b/crates/moonrun/src/sqlite/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod v8;
 mod bind;
 mod column;
 mod connection;
+mod mutex;
 mod policy;
 mod statement;
 
@@ -65,6 +66,7 @@ pub(crate) struct SqliteHost {
     filesystem: Arc<HostFs>,
     keys: Rc<RefCell<HostKeys>>,
     databases: RefCell<SecondaryMap<HostKey, Database>>,
+    mutexes: RefCell<SecondaryMap<HostKey, mutex::DatabaseMutex>>,
     statements: RefCell<SecondaryMap<HostKey, Statement>>,
 }
 
@@ -74,6 +76,7 @@ impl SqliteHost {
             filesystem,
             keys,
             databases: RefCell::new(SecondaryMap::new()),
+            mutexes: RefCell::new(SecondaryMap::new()),
             statements: RefCell::new(SecondaryMap::new()),
         }
     }
@@ -95,6 +98,9 @@ impl SqliteHost {
 
 impl Drop for SqliteHost {
     fn drop(&mut self) {
+        // A guest may terminate between a balanced enter/leave pair. Release
+        // those recursive entries before SQLite destroys connection mutexes.
+        self.release_entered_mutexes();
         // Statements hold their connections open, so destroy them first.
         for statement in self.statements.get_mut().values() {
             unsafe { ffi::sqlite3_finalize(statement.pointer.as_ptr()) };

--- a/crates/moonrun/src/sqlite/mutex.rs
+++ b/crates/moonrun/src/sqlite/mutex.rs
@@ -1,0 +1,177 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ptr::NonNull;
+
+use libsqlite3_sys as ffi;
+use slotmap::Key;
+
+use super::connection::Database;
+use super::{SqliteHost, SqliteHostError, SqliteHostResult};
+use crate::runtime::{HostKey, HostResourceKind, null_handle};
+
+pub(super) struct DatabaseMutex {
+    database_key: HostKey,
+    /// Recursive entries made through this Host that have not been left.
+    ///
+    /// This is not SQLite's complete mutex ownership state: SQLite may enter
+    /// the same mutex internally. It protects the Database lifetime from
+    /// unbalanced guest calls by rejecting unmatched leaves and close, and by
+    /// releasing outstanding guest entries before Runtime teardown.
+    mutex_depth: u64,
+}
+
+impl SqliteHost {
+    /// Return a stable Handle for the SQLite-owned mutex of `database`.
+    ///
+    /// The payload retains the owning Database key rather than SQLite's raw
+    /// mutex pointer, so every operation revalidates the connection lifetime.
+    pub(crate) fn db_mutex(&self, database: u64) -> SqliteHostResult<u64> {
+        let database_key = self.database_key(database)?;
+        let database = self.database(database)?;
+        if !database.is_ready() {
+            return Err(SqliteHostError::InvalidInput);
+        }
+        if unsafe { ffi::sqlite3_db_mutex(database.pointer().as_ptr()) }.is_null() {
+            return Ok(null_handle());
+        }
+        if let Some(mutex) = database.mutex() {
+            return Ok(mutex.data().as_ffi());
+        }
+
+        let mutex = self
+            .keys
+            .borrow_mut()
+            .insert(HostResourceKind::SqliteDatabaseMutex);
+        let replaced = self.mutexes.borrow_mut().insert(
+            mutex,
+            DatabaseMutex {
+                database_key,
+                mutex_depth: 0,
+            },
+        );
+        debug_assert!(replaced.is_none());
+        self.databases
+            .borrow_mut()
+            .get_mut(database_key)
+            .expect("validated database disappeared")
+            .set_mutex(mutex);
+        Ok(mutex.data().as_ffi())
+    }
+
+    pub(crate) fn mutex_enter(&self, mutex: u64) -> SqliteHostResult<()> {
+        self.update_mutex_depth(mutex, |pointer, mutex_depth| {
+            let mutex_depth = mutex_depth
+                .checked_add(1)
+                .ok_or(SqliteHostError::Overflow)?;
+            unsafe { ffi::sqlite3_mutex_enter(pointer.as_ptr()) };
+            Ok(mutex_depth)
+        })
+    }
+
+    pub(crate) fn mutex_leave(&self, mutex: u64) -> SqliteHostResult<()> {
+        self.update_mutex_depth(mutex, |pointer, mutex_depth| {
+            let mutex_depth = mutex_depth
+                .checked_sub(1)
+                .ok_or(SqliteHostError::InvalidInput)?;
+            unsafe { ffi::sqlite3_mutex_leave(pointer.as_ptr()) };
+            Ok(mutex_depth)
+        })
+    }
+
+    pub(super) fn database_mutex_is_entered(&self, database: Database) -> bool {
+        database.mutex().is_some_and(|mutex| {
+            self.mutexes
+                .borrow()
+                .get(mutex)
+                .is_some_and(|mutex| mutex.mutex_depth != 0)
+        })
+    }
+
+    pub(super) fn remove_database_mutex(&self, database: Database) {
+        let Some(mutex) = database.mutex() else {
+            return;
+        };
+        let removed = self.mutexes.borrow_mut().remove(mutex);
+        debug_assert!(removed.is_some());
+        let removed = self.keys.borrow_mut().remove(mutex);
+        debug_assert_eq!(removed, Some(HostResourceKind::SqliteDatabaseMutex));
+    }
+
+    pub(super) fn release_entered_mutexes(&mut self) {
+        // SqliteHost contains the Runtime's Rc-backed Host Keys and therefore
+        // cannot move across threads; SQLite requires leave on the enter thread.
+        for mutex in self.mutexes.get_mut().values_mut() {
+            let database = *self
+                .databases
+                .get_mut()
+                .get(mutex.database_key)
+                .expect("live mutex lost its database");
+            let pointer =
+                NonNull::new(unsafe { ffi::sqlite3_db_mutex(database.pointer().as_ptr()) })
+                    .expect("live database lost its mutex");
+            for _ in 0..mutex.mutex_depth {
+                unsafe { ffi::sqlite3_mutex_leave(pointer.as_ptr()) };
+            }
+            mutex.mutex_depth = 0;
+        }
+    }
+
+    fn update_mutex_depth(
+        &self,
+        mutex: u64,
+        operation: impl FnOnce(NonNull<ffi::sqlite3_mutex>, u64) -> SqliteHostResult<u64>,
+    ) -> SqliteHostResult<()> {
+        if mutex == null_handle() {
+            return Ok(());
+        }
+        let mutex_key = self.mutex_key(mutex)?;
+        let (database_key, mutex_depth) = self
+            .mutexes
+            .borrow()
+            .get(mutex_key)
+            .map(|mutex| (mutex.database_key, mutex.mutex_depth))
+            .ok_or(SqliteHostError::InvalidHandle)?;
+        let pointer = self.native_mutex(database_key)?;
+        let mutex_depth = operation(pointer, mutex_depth)?;
+        self.mutexes
+            .borrow_mut()
+            .get_mut(mutex_key)
+            .expect("validated mutex disappeared")
+            .mutex_depth = mutex_depth;
+        Ok(())
+    }
+
+    fn mutex_key(&self, handle: u64) -> SqliteHostResult<HostKey> {
+        self.keys
+            .borrow()
+            .key(handle, HostResourceKind::SqliteDatabaseMutex)
+            .ok_or(SqliteHostError::InvalidHandle)
+    }
+
+    fn native_mutex(&self, database_key: HostKey) -> SqliteHostResult<NonNull<ffi::sqlite3_mutex>> {
+        let database = self
+            .databases
+            .borrow()
+            .get(database_key)
+            .copied()
+            .ok_or(SqliteHostError::InvalidHandle)?;
+        NonNull::new(unsafe { ffi::sqlite3_db_mutex(database.pointer().as_ptr()) })
+            .ok_or(SqliteHostError::InvalidHandle)
+    }
+}

--- a/crates/moonrun/src/sqlite/policy.rs
+++ b/crates/moonrun/src/sqlite/policy.rs
@@ -70,9 +70,11 @@ pub(super) fn ensure_valid_database(
     Ok(())
 }
 
-/// Preserve SQLite's access-mode bits and remove every extension flag.
-pub(super) fn ensure_open_flags(flags: i32) -> i32 {
+/// Preserve SQLite's access-mode bits, force serialized connection access, and
+/// remove every other extension flag.
+pub(super) fn normalize_open_flags(flags: i32) -> i32 {
     flags & (ffi::SQLITE_OPEN_READONLY | ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE)
+        | ffi::SQLITE_OPEN_FULLMUTEX
 }
 
 /// Install the complete MVP SQL policy before guest SQL can be prepared.
@@ -138,7 +140,7 @@ mod tests {
     }
 
     #[test]
-    fn open_flags_preserve_only_access_modes() {
+    fn open_flags_preserve_access_modes_and_strip_unknown_bits() {
         for flags in [
             ffi::SQLITE_OPEN_READONLY,
             ffi::SQLITE_OPEN_READWRITE,
@@ -146,13 +148,23 @@ mod tests {
             ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE | 0x4000_0000,
         ] {
             assert_eq!(
-                ensure_open_flags(flags),
+                normalize_open_flags(flags),
                 flags
                     & (ffi::SQLITE_OPEN_READONLY
                         | ffi::SQLITE_OPEN_READWRITE
                         | ffi::SQLITE_OPEN_CREATE)
+                    | ffi::SQLITE_OPEN_FULLMUTEX
             );
         }
+    }
+
+    #[test]
+    fn open_flags_replace_no_mutex_with_full_mutex() {
+        let flags = ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_NOMUTEX;
+        assert_eq!(
+            normalize_open_flags(flags),
+            ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_FULLMUTEX
+        );
     }
 
     #[test]

--- a/crates/moonrun/src/sqlite/v8/registry.rs
+++ b/crates/moonrun/src/sqlite/v8/registry.rs
@@ -48,6 +48,9 @@ declare_sqlite_imports! {
     SqliteHost::extended_errcode(database: u64)
         -> i32 => "sqlite3_extended_errcode";
     SqliteHost::changes64(database: u64) -> i64 => "sqlite3_changes64";
+    SqliteHost::db_mutex(database: u64) -> u64 => "sqlite3_db_mutex";
+    SqliteHost::mutex_enter(mutex: u64) -> void => "sqlite3_mutex_enter";
+    SqliteHost::mutex_leave(mutex: u64) -> void => "sqlite3_mutex_leave";
     SqliteHost::close(database: u64) -> i32 => "sqlite3_close";
 
     statement::prepare16_v2(

--- a/crates/moonrun/src/sqlite/v8/registry_macros.rs
+++ b/crates/moonrun/src/sqlite/v8/registry_macros.rs
@@ -61,42 +61,35 @@ macro_rules! decode_sqlite_args {
     }};
 }
 
+macro_rules! set_sqlite_import_return {
+    ($scope:ident, $ret:ident, i32, $value:expr) => {
+        $ret.set_int32($value)
+    };
+    ($scope:ident, $ret:ident, u32, $value:expr) => {
+        $ret.set_int32($value as i32)
+    };
+    ($scope:ident, $ret:ident, i64, $value:expr) => {
+        $ret.set(v8::BigInt::new_from_i64($scope, $value).into())
+    };
+    ($scope:ident, $ret:ident, f64, $value:expr) => {
+        $ret.set(v8::Number::new($scope, $value).into())
+    };
+    ($scope:ident, $ret:ident, u64, $value:expr) => {
+        $ret.set(v8::BigInt::new_from_u64($scope, $value).into())
+    };
+    ($scope:ident, $ret:ident, void, $value:expr) => {{
+        // Keep the generated callback uniform; wasm ignores the JavaScript
+        // return value for a void import.
+        let _ = ($value, &mut $ret);
+    }};
+}
+
 macro_rules! finish_sqlite_import {
-    ($scope:ident, $ret:ident, $name:expr, i32, $result:expr) => {
+    ($scope:ident, $ret:ident, $name:expr, $ret_ty:ident, $result:expr) => {
         match $result {
-            Ok(value) => $ret.set_int32(value),
-            Err(error) => {
-                crate::v8::context::throw_import_error($scope, MOONBIT_SQLITE_MODULE, $name, error)
-            }
-        }
-    };
-    ($scope:ident, $ret:ident, $name:expr, u32, $result:expr) => {
-        match $result {
-            Ok(value) => $ret.set_int32(value as i32),
-            Err(error) => {
-                crate::v8::context::throw_import_error($scope, MOONBIT_SQLITE_MODULE, $name, error)
-            }
-        }
-    };
-    ($scope:ident, $ret:ident, $name:expr, i64, $result:expr) => {
-        match $result {
-            Ok(value) => $ret.set(v8::BigInt::new_from_i64($scope, value).into()),
-            Err(error) => {
-                crate::v8::context::throw_import_error($scope, MOONBIT_SQLITE_MODULE, $name, error)
-            }
-        }
-    };
-    ($scope:ident, $ret:ident, $name:expr, f64, $result:expr) => {
-        match $result {
-            Ok(value) => $ret.set(v8::Number::new($scope, value).into()),
-            Err(error) => {
-                crate::v8::context::throw_import_error($scope, MOONBIT_SQLITE_MODULE, $name, error)
-            }
-        }
-    };
-    ($scope:ident, $ret:ident, $name:expr, u64, $result:expr) => {
-        match $result {
-            Ok(value) => $ret.set(v8::BigInt::new_from_u64($scope, value).into()),
+            Ok(value) => $crate::sqlite::v8::registry_macros::set_sqlite_import_return!(
+                $scope, $ret, $ret_ty, value
+            ),
             Err(error) => {
                 crate::v8::context::throw_import_error($scope, MOONBIT_SQLITE_MODULE, $name, error)
             }
@@ -240,5 +233,5 @@ macro_rules! declare_sqlite_imports {
 
 pub(super) use {
     declare_sqlite_imports, decode_sqlite_args, decode_wasm_arg, finish_sqlite_import,
-    invoke_sqlite_import, register_sqlite_import, wasm_arg_count,
+    invoke_sqlite_import, register_sqlite_import, set_sqlite_import_return, wasm_arg_count,
 };

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -860,6 +860,16 @@ Sandbox policy blocked file read: "denied/database.sqlite"
 Error: moonbitlang/sqlite.sqlite3_close failed: InvalidHandle
 [..]
 "#]]);
+
+    let entered_mutex_wasm = dir.join("_build/wasm/debug/build/entered_mutex/entered_mutex.wasm");
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(&entered_mutex_wasm)
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: moonbitlang/sqlite.sqlite3_close failed: Fault
+[..]
+"#]]);
 }
 
 #[test]

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/entered_mutex/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/entered_mutex/main.mbt
@@ -1,0 +1,70 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+///|
+const SQLITE_OK = 0
+
+///|
+const SQLITE_OPEN_READWRITE = 0x00000002
+
+///|
+const SQLITE_OPEN_CREATE = 0x00000004
+
+///|
+fn sqlite3_null_handle() -> UInt64 = "moonbitlang/sqlite" "sqlite3_null_handle"
+
+///|
+#unsafe_skip_stub_check
+#borrow(filename, database)
+fn sqlite3_open_v2(
+  filename : Bytes,
+  filename_length : Int,
+  database : Ref[UInt64],
+  flags : Int,
+  vfs : UInt64,
+) -> Int = "moonbitlang/sqlite" "sqlite3_open_v2"
+
+///|
+fn sqlite3_db_mutex(database : UInt64) -> UInt64 = "moonbitlang/sqlite" "sqlite3_db_mutex"
+
+///|
+fn sqlite3_mutex_enter(mutex : UInt64) -> Unit = "moonbitlang/sqlite" "sqlite3_mutex_enter"
+
+///|
+fn sqlite3_close(database : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_close"
+
+///|
+fn main raise {
+  let null_handle = sqlite3_null_handle()
+  let database = Ref(null_handle)
+  let filename = b":memory:"
+  assert_true(
+    sqlite3_open_v2(
+      filename,
+      filename.length(),
+      database,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+      null_handle,
+    ) ==
+    SQLITE_OK,
+  )
+  let database = database.val
+  let mutex = sqlite3_db_mutex(database)
+  sqlite3_mutex_enter(mutex)
+  ignore(sqlite3_close(database))
+}

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/entered_mutex/moon.pkg
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/entered_mutex/moon.pkg
@@ -1,0 +1,1 @@
+options("is-main": true)

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
@@ -110,6 +110,15 @@ fn sqlite3_extended_errcode(database : UInt64) -> Int = "moonbitlang/sqlite" "sq
 fn sqlite3_changes64(database : UInt64) -> Int64 = "moonbitlang/sqlite" "sqlite3_changes64"
 
 ///|
+fn sqlite3_db_mutex(database : UInt64) -> UInt64 = "moonbitlang/sqlite" "sqlite3_db_mutex"
+
+///|
+fn sqlite3_mutex_enter(mutex : UInt64) -> Unit = "moonbitlang/sqlite" "sqlite3_mutex_enter"
+
+///|
+fn sqlite3_mutex_leave(mutex : UInt64) -> Unit = "moonbitlang/sqlite" "sqlite3_mutex_leave"
+
+///|
 fn sqlite3_close(database : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_close"
 
 ///|
@@ -272,6 +281,8 @@ fn execute(
 ///|
 fn main raise {
   let null_handle = sqlite3_null_handle()
+  sqlite3_mutex_enter(null_handle)
+  sqlite3_mutex_leave(null_handle)
   assert_true(
     sqlite3_close(null_handle) == SQLITE_OK,
     msg="sqlite3_close(NULL) failed",
@@ -385,6 +396,19 @@ fn main raise {
     database != null_handle,
     msg="memory database returned a null handle",
   )
+  let database_mutex = sqlite3_db_mutex(database)
+  assert_true(
+    database_mutex != null_handle,
+    msg="serialized database returned a null mutex",
+  )
+  assert_true(
+    sqlite3_db_mutex(database) == database_mutex,
+    msg="database mutex handle was not stable",
+  )
+  sqlite3_mutex_enter(database_mutex)
+  sqlite3_mutex_enter(database_mutex)
+  sqlite3_mutex_leave(database_mutex)
+  sqlite3_mutex_leave(database_mutex)
 
   execute(database, "PRAGMA encoding='UTF-16le'", null_handle)
 


### PR DESCRIPTION
## Why
Moonrun needs SQLite database-mutex primitives so callers can explicitly coordinate access to a connection. Returning native mutex pointers directly would break the opaque-handle model and allow stale access after database close.

## What
- expose sqlite3_db_mutex, sqlite3_mutex_enter, and sqlite3_mutex_leave
- force SQLITE_OPEN_FULLMUTEX for serialized connection access
- track unmatched recursive host entries so invalid leaves and close attempts are rejected
- unwind outstanding host entries before runtime teardown
- preserve SQLite null-mutex no-op behavior

## Why this is correct
Mutex handles retain the owning database key and resolve the native mutex for every operation, revalidating the connection lifetime. The tracked depth covers only entries made through Moonrun; it does not claim to represent SQLite internal ownership. Cleanup occurs on the runtime thread that performed the entries.

## Scope
This PR is limited to synchronous SQLite mutex support. Async SQLite jobs remain a separate design.