### PR TITLE
feat(moonrun): virtualize signal delivery per run

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -235,6 +235,34 @@ _Avoid_: Run Termination, Host Error, implicit exit request
 A per-Wasm-run outcome requested by guest code, either an exit code or termination by signal. A runtime adapter records Run Termination and interrupts guest execution without terminating its embedding process; only the outer CLI adapter applies the outcome after guest and host state have been torn down.
 _Avoid_: Host exit, import-side exit, process-global termination state
 
+**Run Signals**:
+The destination for signals injected into one Run. It owns that guest's
+cancellation-signal selection and a channel shared with that Run's virtual
+signal-wait Job. A Signal Sender selects one Run by owning the sending half; it
+never raises an operating-system signal. On Unix the channel is a nonblocking
+self-pipe with a pending-signal mask: the pipe wakes the Job, the mask coalesces
+standard signals, and the Job publishes them to the Run's Completion target.
+The virtual Job supplies the thread pool's native-shaped optional cancellation
+hook, which records cancellation and wakes the same pipe without a timing race.
+Ordinary Unix Jobs retain the default `SIGUSR2` interruption path. Signals sent
+before the guest registration and virtual waiter are ready are not retained.
+Forced interruption and broader Run lifecycle belong to a later control layer
+rather than this delivery seam.
+_Avoid_: process signal handler, global completion target, Run lifecycle
+
+**Process Signals**:
+The CLI-only adapter that owns process-global operating-system signal capture.
+It is installed once before Engine initialization and lives until process
+exit. On Unix, the CLI blocks its managed signals before creating other
+threads, a dedicated `sigwait` thread consumes them, and child processes use
+the signal mask preserved before broker installation. On Windows, one
+console-control handler performs the same forwarding role. The adapter
+directly forwards each captured signal to the CLI Run's Signal Sender. If that
+Run does not accept the signal, the adapter
+applies the process's existing platform behavior. The library Engine never
+installs this adapter.
+_Avoid_: Runtime signal handler, Engine signal handler, global Run target
+
 **Loaded Module**:
 A shareable, immutable guest program prepared once by one Engine. Multiple Runs
 can execute one Loaded Module without preparing its source again. It carries
@@ -265,9 +293,9 @@ _Avoid_: Host state, native-stub implementation
 
 **Async Host**:
 Moonrun-owned async state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Runtime's shared Host Key namespace, materializes its reserved standard-stream Resources from the Runtime Stdio, and contains no SQLite state.
-It also owns guest cancellation-signal registration and the completion target
-used for signal delivery. It constructs Unix signal-wait Jobs backed by the
-raw signal operation in Async Sys.
+It owns one Run Signal receiver, translates guest cancellation registration
+into that receiver's interest, and constructs the Unix virtual signal-wait Job
+against the Run's Completion target.
 _Avoid_: `moonbitlang/async` source mirror
 
 **SQLite API**:
@@ -296,16 +324,15 @@ _Avoid_: SQLite API, Async Host, V8 SQLite
 The V8-free native-stub port layer. Ports carry provenance for the native source
 path and symbol they track. Reusable operating-system operations remain here;
 Job implementations live with their owning domain. Poller files are direct
-ports behind the wasm `poll/*` imports. Process-global signal masks, the Unix
-signal-wait primitive, and Windows console handler mechanisms are raw ports;
-guest cancellation registration and delivery coordination belong to Async Host.
+ports behind the wasm `poll/*` imports. Signal support here is limited to
+platform signal values and Unix signal-mask operations; process capture
+belongs to the CLI and guest delivery belongs to Run Signals.
 _Avoid_: V8 adapter, placeholder unsupported imports
 
 **Thread Pool**:
 The shared host facility that schedules Jobs outside the guest coroutine loop.
 It owns the common Job result envelope, Workers, and Completion delivery. It
-does not interpret Filesystem, Network, or Process Job semantics, and does not
-implement the Unix signal-wait primitive.
+does not interpret Filesystem, Network, Process, or Run Signal semantics.
 _Avoid_: Filesystem executor, Network executor, Process executor, SQLite executor
 
 **Host Poller**:

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -68,16 +68,30 @@ let module = engine.compile("server.wasm", wasm_bytes).unwrap();
 ```
 
 The current implementation remains V8-backed and still inherits process stdio,
-environment, working directory, and signal compatibility behavior. A Run can
-make its working-directory selection explicit with
+environment, and working-directory behavior. The library does not install an
+operating-system signal handler. Callers may create a `signal_channel`, pass
+its receiver to `Engine::run_with_signal_receiver`, and send signals to that
+Run after its guest async handler is ready. This is cooperative delivery only:
+signals are not retained before registration and cannot yet forcibly interrupt
+guest execution. The `moonrun` CLI owns a process-lifetime adapter and forwards
+accepted signals directly through such a channel. On Unix it blocks its managed
+signals before creating the Engine and receives them on a `sigwait` thread;
+spawned guest processes retain the signal mask from before that block. Each
+Run's guest signal-wait Job is virtual: it receives forwarded signals through
+the Run channel rather than competing for process-wide signals. It supplies the
+same optional cancellation hook supported by the native Job model, recording
+cancellation before waking its blocking pipe read. Ordinary Unix Jobs retain
+the thread pool's `pthread_kill(SIGUSR2)` path. If the Run does not accept a
+signal, the adapter applies the process's existing signal behavior.
+
+A Run can make its working-directory selection explicit with
 `WorkingDirectory::Ambient`, which is also the default and preserves the
 existing process-global behavior. No isolated or captured working-directory
 mode is available yet. Compiled modules reuse their prepared representation
 while each run currently creates a fresh Runtime that owns its environment,
 policy, working-directory selection, and domain state alongside fresh guest
 execution state. Thread placement and lifecycle tracking remain the caller's
-responsibility. Moonrun does not yet expose an interruption mechanism for a
-running guest.
+responsibility.
 
 ## Memory Leak Reporting
 

--- a/crates/moonrun/src/async_api/signal.rs
+++ b/crates/moonrun/src/async_api/signal.rs
@@ -40,6 +40,8 @@ pub(super) fn set_global_cancellation_signals(
     signals: u32,
     signals_len: u32,
 ) -> crate::async_host::AsyncHostResult<()> {
+    // "global" is the upstream guest ABI name. Moonrun scopes the resulting
+    // registration to this Import Context's Run.
     let all_signals = context.with_memory_mut(|memory| read_i32_array(memory, all_signals, all_signals_len))?;
     let signals = context.with_memory_mut(|memory| read_i32_array(memory, signals, signals_len))?;
     context

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -57,6 +57,7 @@ use crate::guest_memory::{GuestMemory, GuestMemoryError};
 use crate::network::HostNetwork;
 use crate::process::HostProcess;
 use crate::resource::{Resource, ResourceClass, ResourcePublication, ResourceRef};
+use crate::run_signal::SignalReceiver;
 pub(crate) use crate::runtime::HostKey as HandleKey;
 use crate::runtime::{Env, HostKeys, HostResourceKind as HandleKind, Stdio, StdioStream};
 
@@ -1173,18 +1174,22 @@ pub(crate) struct AsyncHost {
     process_envs: RefCell<SecondaryMap<HandleKey, HostProcessEnv>>,
     process_env_builders: RefCell<SecondaryMap<HandleKey, HostProcessEnvBuilder>>,
     process: HostProcess,
+    #[cfg(unix)]
+    child_signal_mask: libc::sigset_t,
     #[cfg(windows)]
     io_results: RefCell<IoResultTable>,
     jobs: RefCell<JobTable>,
     workers: InstanceWorkers,
     polls: RefCell<PollTable>,
     thread_pool_completions: RefCell<ThreadPoolCompletions>,
+    signals: SignalReceiver,
     handles: RefCell<HandleTable>,
     tls_connections: RefCell<SecondaryMap<HandleKey, tls::TlsHandle>>,
     tls_error: RefCell<Option<String>>,
 }
 
 impl AsyncHost {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         environment: Arc<Env>,
         stdio: &Stdio,
@@ -1192,6 +1197,8 @@ impl AsyncHost {
         network: HostNetwork,
         process: HostProcess,
         keys: Rc<RefCell<HostKeys>>,
+        signals: SignalReceiver,
+        #[cfg(unix)] child_signal_mask: libc::sigset_t,
     ) -> Self {
         Self {
             filesystem,
@@ -1207,12 +1214,15 @@ impl AsyncHost {
             process_envs: RefCell::new(SecondaryMap::new()),
             process_env_builders: RefCell::new(SecondaryMap::new()),
             process,
+            #[cfg(unix)]
+            child_signal_mask,
             #[cfg(windows)]
             io_results: RefCell::new(IoResultTable::default()),
             jobs: RefCell::new(JobTable::default()),
             workers: InstanceWorkers::new(),
             polls: RefCell::new(PollTable::default()),
             thread_pool_completions: RefCell::new(ThreadPoolCompletions::default()),
+            signals,
             handles: RefCell::new(HandleTable::with_keys(keys, stdio)),
             tls_connections: RefCell::new(SecondaryMap::new()),
             tls_error: RefCell::new(None),
@@ -1699,23 +1709,23 @@ impl AsyncHost {
         })
     }
 
-    /// Apply the guest's cancellation-signal selection.
-    ///
-    /// The current raw implementation is process-global. Keeping that detail
-    /// behind the Async Host lets the guest adapter remain unchanged when
-    /// signal interest and delivery become per-Run state.
     pub(crate) fn set_cancellation_signals(
         &self,
         all_signals: &[i32],
         signals: &[i32],
     ) -> AsyncHostResult<()> {
-        crate::async_sys::signal::set_global_cancellation_signals(all_signals, signals)
+        crate::async_sys::signal::set_global_cancellation_signals(
+            &self.signals,
+            all_signals,
+            signals,
+        )
     }
 
     #[cfg(unix)]
     pub(crate) fn make_sigwait_job(&self, signals: Vec<i32>) -> AsyncHostResult<HostHandle> {
         let notifier = self.thread_pool_notifier()?;
-        self.insert_job(crate::async_sys::signal::SigwaitJob::new(signals, notifier))
+        let job = crate::async_sys::signal::make_sigwait_job(&self.signals, &signals, notifier)?;
+        self.insert_job(job)
     }
 
     #[cfg(windows)]
@@ -1725,7 +1735,11 @@ impl AsyncHost {
         } else {
             None
         };
-        crate::async_sys::signal::set_console_control_handler(enabled, completion_target)
+        crate::async_sys::signal::set_console_control_handler(
+            &self.signals,
+            enabled,
+            completion_target,
+        )
     }
 
     pub(crate) fn init_thread_pool(&self, poll_handle: u64) -> AsyncHostResult<HostHandle> {
@@ -3783,7 +3797,9 @@ impl AsyncHost {
     pub(crate) fn thread_pool_child_signal_mask(&self) -> AsyncHostResult<libc::sigset_t> {
         self.thread_pool_completions
             .borrow()
-            .old_signal_mask
+            .source
+            .is_some()
+            .then_some(self.child_signal_mask)
             .ok_or(AsyncHostError::Badf)
     }
 
@@ -4404,6 +4420,12 @@ mod tests {
             working_directory,
             Arc::clone(&stdio),
         );
+        #[cfg(unix)]
+        let child_signal_mask = {
+            let mut mask = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+            assert_eq!(unsafe { libc::sigemptyset(&mut mask) }, 0);
+            mask
+        };
         AsyncHost::new(
             environment,
             &stdio,
@@ -4411,6 +4433,9 @@ mod tests {
             network,
             process,
             Rc::new(RefCell::new(HostKeys::default())),
+            crate::signal_channel().1,
+            #[cfg(unix)]
+            child_signal_mask,
         )
     }
 
@@ -5106,6 +5131,37 @@ mod tests {
 
         #[cfg(windows)]
         assert_eq!(crate::async_sys::internal::event_loop::io::cleanup_wsa(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn thread_pool_exposes_its_concrete_child_signal_mask_only_while_active() {
+        let mut child_signal_mask = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+        assert_eq!(unsafe { libc::sigemptyset(&mut child_signal_mask) }, 0);
+        assert_eq!(
+            unsafe { libc::sigaddset(&mut child_signal_mask, libc::SIGINT) },
+            0
+        );
+
+        let mut host = default_host();
+        host.child_signal_mask = child_signal_mask;
+        assert!(matches!(
+            host.thread_pool_child_signal_mask(),
+            Err(AsyncHostError::Badf)
+        ));
+
+        let poll = host.poll_create().unwrap();
+        host.init_thread_pool(poll).unwrap();
+
+        let child = host.thread_pool_child_signal_mask().unwrap();
+        assert_eq!(unsafe { libc::sigismember(&child, libc::SIGINT) }, 1);
+        assert_eq!(unsafe { libc::sigismember(&child, libc::SIGTERM) }, 0);
+
+        host.destroy_thread_pool();
+        assert!(matches!(
+            host.thread_pool_child_signal_mask(),
+            Err(AsyncHostError::Badf)
+        ));
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_host/workers.rs
+++ b/crates/moonrun/src/async_host/workers.rs
@@ -194,6 +194,63 @@ mod tests {
         )
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn signal_wait_worker_cancellation_is_durable_before_the_job_waits() {
+        use std::os::fd::RawFd;
+        use std::sync::Arc;
+
+        let workers = InstanceWorkers::new();
+        let worker = key(1);
+        let (_sender, receiver) = crate::signal_channel();
+        let (notifier, notifier_fd): (_, RawFd) =
+            crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier::new().unwrap();
+        let wait_job = crate::async_sys::signal::make_sigwait_job(
+            &receiver,
+            &[libc::SIGINT],
+            Arc::new(notifier),
+        )
+        .unwrap();
+        let worker_job =
+            HostWorkerJob::new(WorkerCompletionId::from_abi(7), key(2), wait_job.into());
+        let (completed, completion) = mpsc::channel();
+        let (started, worker_started) = mpsc::sync_channel(0);
+        let (proceed, worker_may_proceed) = mpsc::sync_channel(0);
+
+        workers
+            .spawn(
+                worker,
+                worker_job,
+                move |job| {
+                    started.send(()).unwrap();
+                    worker_may_proceed.recv().unwrap();
+                    thread_pool::run_host_job(&mut job.job);
+                },
+                move |completion_id| completed.send(completion_id).unwrap(),
+            )
+            .unwrap();
+
+        worker_started.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(workers.cancel(worker), Ok(0));
+        proceed.send(()).unwrap();
+
+        let first_completion = completion.recv_timeout(Duration::from_secs(1));
+        if first_completion.is_err() {
+            // Release the old implementation so a failing assertion does not
+            // leave its Worker blocked in read(2).
+            assert_eq!(workers.cancel(worker), Ok(0));
+            completion.recv_timeout(Duration::from_secs(1)).unwrap();
+        }
+        let completion_id = first_completion.expect("the first cancellation was lost");
+        assert_eq!(completion_id, WorkerCompletionId::from_abi(7));
+        let result = workers.try_recv_completed().unwrap();
+        assert_eq!(result.job.ret(), 0);
+        assert_eq!(result.job.err(), 0);
+
+        drop(workers.destroy());
+        assert_eq!(unsafe { libc::close(notifier_fd) }, 0);
+    }
+
     #[test]
     fn worker_handles_are_scoped_to_one_instance() {
         let first = InstanceWorkers::new();

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -27,6 +27,8 @@ pub(crate) use jobs::{
 };
 pub(crate) use runner::run_host_job;
 pub(crate) use types::{HostHandle, Job, JobPayload, ResourceTable};
+#[cfg(unix)]
+pub(crate) use types::{JobCancellation, JobCancellationOverride};
 pub(crate) use worker::{
     HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WorkerCompletionId, cancel_worker,
     free_worker, spawn_worker, wake_worker, worker_enter_idle,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -23,9 +23,23 @@ use crate::async_sys::signal::SigwaitJob;
 use crate::filesystem::Job as FilesystemJob;
 use crate::network::Job as NetworkJob;
 use crate::process::Job as ProcessJob;
+#[cfg(unix)]
+use std::sync::Arc;
 
 pub(crate) type ResourceHandle = u64;
 pub(crate) type HostHandle = ResourceHandle;
+
+/// A Job-specific replacement for the platform's default Worker cancellation.
+///
+/// This is the Rust equivalent of native `struct job::cancel_handler`: most
+/// Jobs do not provide one and are cancelled through the Worker thread.
+#[cfg(unix)]
+pub(crate) trait JobCancellationOverride: std::fmt::Debug + Send + Sync {
+    fn cancel(&self) -> AsyncHostResult<i32>;
+}
+
+#[cfg(unix)]
+pub(crate) type JobCancellation = Arc<dyn JobCancellationOverride>;
 
 /// A host operation following the `moonbitlang/async` native Job contract.
 ///
@@ -89,6 +103,14 @@ impl Job {
     pub(crate) fn cancellation_resource(&self) -> Option<crate::resource::ResourceRef> {
         match &self.payload {
             JobPayload::Process(job) => job.cancellation_resource(),
+            _ => None,
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn cancellation_override(&self) -> Option<JobCancellation> {
+        match &self.payload {
+            JobPayload::Signal(job) => Some(job.cancellation_override()),
             _ => None,
         }
     }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -29,6 +29,8 @@ use crate::resource::ResourceRef;
 use std::os::unix::thread::JoinHandleExt;
 
 use super::Job;
+#[cfg(unix)]
+use super::JobCancellation;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WorkerCompletionId(i32);
@@ -93,8 +95,15 @@ pub(crate) enum WorkerCancellationTarget {
 #[derive(Debug)]
 struct HostWorkerState {
     job: Option<HostWorkerJob>,
+    // Rust moves the active Job out of this state. Retain only its optional
+    // native-shaped cancellation hook, and distinguish it from a queued Job
+    // whose hook must replace this one before that Job can start.
+    #[cfg(unix)]
+    cancel_override: Option<JobCancellation>,
     #[cfg(windows)]
     running_cancel: RunningCancellation,
+    #[cfg(unix)]
+    running: bool,
     waiting: bool,
     terminating: bool,
 }
@@ -153,12 +162,18 @@ impl HostWorkerHandle {
     ) -> Self {
         #[cfg(unix)]
         init_worker_signal_handler();
+        #[cfg(unix)]
+        let init_cancel = init_job.job.cancellation_override();
 
         let shared = Arc::new(HostWorkerShared {
             state: Mutex::new(HostWorkerState {
                 job: Some(init_job),
+                #[cfg(unix)]
+                cancel_override: init_cancel,
                 #[cfg(windows)]
                 running_cancel: RunningCancellation::Idle,
+                #[cfg(unix)]
+                running: false,
                 waiting: false,
                 terminating: false,
             }),
@@ -181,6 +196,12 @@ impl HostWorkerHandle {
                         state = worker_shared.wakeup.wait(state).unwrap();
                     }
                     let job = (!state.terminating).then(|| state.job.take()).flatten();
+                    #[cfg(unix)]
+                    {
+                        state.running = job.is_some();
+                        state.cancel_override =
+                            job.as_ref().and_then(|job| job.job.cancellation_override());
+                    }
                     #[cfg(windows)]
                     {
                         state.running_cancel = match job.as_ref() {
@@ -197,6 +218,14 @@ impl HostWorkerHandle {
 
                 let terminating = {
                     let mut state = worker_shared.state.lock().unwrap();
+                    #[cfg(unix)]
+                    {
+                        state.running = false;
+                        state.cancel_override = state
+                            .job
+                            .as_ref()
+                            .and_then(|next_job| next_job.job.cancellation_override());
+                    }
                     #[cfg(windows)]
                     {
                         state.running_cancel = RunningCancellation::Idle;
@@ -238,13 +267,26 @@ impl HostWorkerHandle {
         }
         let previous_job = state.job.take();
         state.job = job;
+        #[cfg(unix)]
+        if !state.running {
+            state.cancel_override = state
+                .job
+                .as_ref()
+                .and_then(|job| job.job.cancellation_override());
+        }
         state.waiting = false;
         self.shared.wakeup.notify_one();
         previous_job
     }
 
     pub(crate) fn enter_idle(&self) -> Option<HostWorkerJob> {
-        self.shared.state.lock().unwrap().job.take()
+        let mut state = self.shared.state.lock().unwrap();
+        let job = state.job.take();
+        #[cfg(unix)]
+        if !state.running {
+            state.cancel_override = None;
+        }
+        job
     }
 
     #[cfg(windows)]
@@ -266,9 +308,15 @@ impl HostWorkerHandle {
     pub(crate) fn cancel(&self) -> AsyncHostResult<i32> {
         #[cfg(unix)]
         {
-            let state = self.shared.state.lock().unwrap();
-            if state.waiting {
-                return Ok(1);
+            let cancel = {
+                let state = self.shared.state.lock().unwrap();
+                if state.waiting {
+                    return Ok(1);
+                }
+                state.cancel_override.clone()
+            };
+            if let Some(cancel) = cancel {
+                return cancel.cancel();
             }
             let Some(thread) = &self.thread else {
                 return Err(crate::async_host::AsyncHostError::Badf);

--- a/crates/moonrun/src/async_sys/signal/mod.rs
+++ b/crates/moonrun/src/async_sys/signal/mod.rs
@@ -16,14 +16,16 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Raw process-global signal mechanisms ported from `moonbitlang/async`, split
-//! by host platform. Guest cancellation registration and delivery coordination
-//! belong to the Async Host.
+//! Platform signal values and Unix worker signal-mask management.
+//!
+//! Process signal capture belongs to the CLI. Guest signal registration and
+//! completion delivery belong to one Run.
 
 use crate::async_host::AsyncHostResult;
 #[cfg(windows)]
 use crate::async_sys::internal::event_loop::poll::CompletionPort;
 use crate::async_sys::ported_fns;
+use crate::run_signal::SignalReceiver;
 
 #[cfg(unix)]
 mod unix;
@@ -37,8 +39,8 @@ use windows as platform;
 
 #[cfg(unix)]
 pub(crate) use unix::{
-    SigwaitJob, init_thread_pool_signal_mask, restore_thread_pool_signal_mask,
-    set_worker_thread_signal_mask,
+    SigwaitJob, SigwaitTarget, init_thread_pool_signal_mask, make_sigwait_job,
+    restore_thread_pool_signal_mask, set_worker_thread_signal_mask,
 };
 
 ported_fns! {
@@ -47,10 +49,11 @@ ported_fns! {
         original = "moonbitlang_async_set_global_cancellation_signals"
     )]
     pub(crate) fn set_global_cancellation_signals(
+        receiver: &SignalReceiver,
         all_signals: &[i32],
         signals: &[i32],
     ) -> AsyncHostResult<()> {
-        platform::set_global_cancellation_signals(all_signals, signals)
+        platform::set_global_cancellation_signals(receiver, all_signals, signals)
     }
 
     #[ported(
@@ -59,10 +62,11 @@ ported_fns! {
     )]
     #[cfg(windows)]
     pub(crate) fn set_console_control_handler(
+        receiver: &SignalReceiver,
         add: bool,
         completion_target: Option<CompletionPort>,
     ) -> AsyncHostResult<i32> {
-        windows::set_console_control_handler(add, completion_target)
+        windows::set_console_control_handler(receiver, add, completion_target)
     }
 }
 

--- a/crates/moonrun/src/async_sys/signal/unix.rs
+++ b/crates/moonrun/src/async_sys/signal/unix.rs
@@ -16,100 +16,204 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::sync::Arc;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::sync::{Arc, Mutex, Weak};
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
-use crate::async_sys::ported_fns;
+use crate::async_sys::internal::event_loop::{
+    ThreadPoolCompletionNotifier,
+    thread_pool::{JobCancellation, JobCancellationOverride},
+};
+use crate::async_sys::internal::fd_util::stub as fd_util;
+use crate::run_signal::{SignalReceiver, SigwaitTargetGuard, signal_mask};
+
+#[derive(Clone, Debug)]
+pub(crate) struct SigwaitTarget {
+    signals: u32,
+    state: Arc<Mutex<SigwaitState>>,
+    wake: Arc<OwnedFd>,
+}
+
+impl SigwaitTarget {
+    pub(crate) fn send(&self, bit: u32) -> AsyncHostResult<bool> {
+        if self.signals & bit == 0 {
+            return Ok(false);
+        }
+
+        let mut state = self.state.lock().map_err(|_| AsyncHostError::Inval)?;
+        if state.cancelled {
+            return Ok(false);
+        }
+
+        // Standard signals coalesce while pending. Holding the state lock
+        // through the nonblocking write makes signal delivery and cancellation
+        // ordered: an accepted signal is always observed before cancellation.
+        if state.pending & bit != 0 {
+            return Ok(true);
+        }
+        state.pending |= bit;
+        match write_wakeup(&self.wake) {
+            Ok(true) => Ok(true),
+            Ok(false) => {
+                state.pending &= !bit;
+                Ok(false)
+            }
+            Err(error) => {
+                state.pending &= !bit;
+                Err(error)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct SigwaitState {
+    pending: u32,
+    cancelled: bool,
+}
 
 #[derive(Debug)]
+struct SigwaitCancellation {
+    state: Arc<Mutex<SigwaitState>>,
+    wake: Weak<OwnedFd>,
+}
+
+impl JobCancellationOverride for SigwaitCancellation {
+    fn cancel(&self) -> AsyncHostResult<i32> {
+        let mut state = self.state.lock().map_err(|_| AsyncHostError::Inval)?;
+        if state.cancelled {
+            return Ok(0);
+        }
+        state.cancelled = true;
+        if let Some(wake) = self.wake.upgrade()
+            && let Err(error) = write_wakeup(&wake)
+        {
+            state.cancelled = false;
+            return Err(error);
+        }
+        Ok(0)
+    }
+}
+
 pub(crate) struct SigwaitJob {
-    signals: Vec<i32>,
+    _target: SigwaitTargetGuard,
+    state: Arc<Mutex<SigwaitState>>,
+    cancellation: JobCancellation,
+    wake: OwnedFd,
     notifier: Arc<ThreadPoolCompletionNotifier>,
 }
 
+impl std::fmt::Debug for SigwaitJob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SigwaitJob").finish_non_exhaustive()
+    }
+}
+
 impl SigwaitJob {
-    pub(crate) fn new(signals: Vec<i32>, notifier: Arc<ThreadPoolCompletionNotifier>) -> Self {
-        Self { signals, notifier }
+    pub(crate) fn cancellation_override(&self) -> JobCancellation {
+        Arc::clone(&self.cancellation)
     }
 
     pub(crate) fn run(&mut self) -> AsyncHostResult<i64> {
-        run_sigwait_job(&self.signals, &self.notifier)
+        run_sigwait_job(self)
     }
 }
 
-ported_fns! {
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "sigwait_job_worker"
-    )]
-    fn run_sigwait_job(
-        signals: &[i32],
-        notifier: &ThreadPoolCompletionNotifier,
-    ) -> AsyncHostResult<i64> {
-        let mut set = empty_signal_set()?;
-        for signal in signals.iter().copied().filter(|signal| *signal > 0) {
-            check_signal_call(unsafe { libc::sigaddset(&mut set, signal) })?;
-        }
-        check_signal_call(unsafe { libc::sigaddset(&mut set, libc::SIGUSR2) })?;
+pub(crate) fn make_sigwait_job(
+    receiver: &SignalReceiver,
+    signals: &[i32],
+    notifier: Arc<ThreadPoolCompletionNotifier>,
+) -> AsyncHostResult<SigwaitJob> {
+    let [wake_recv, wake_send] = fd_util::pipe(false, true)?;
+    let wake_recv = unsafe { OwnedFd::from_raw_fd(wake_recv) };
+    let wake_send = unsafe { OwnedFd::from_raw_fd(wake_send) };
+    let state = Arc::new(Mutex::new(SigwaitState::default()));
+    let wake_send = Arc::new(wake_send);
+    let target = receiver
+        .attach_target(SigwaitTarget {
+            signals: signal_mask(signals),
+            state: Arc::clone(&state),
+            wake: Arc::clone(&wake_send),
+        })
+        .ok_or(AsyncHostError::Inval)?;
+    let cancellation = Arc::new(SigwaitCancellation {
+        state: Arc::clone(&state),
+        wake: Arc::downgrade(&wake_send),
+    });
+    Ok(SigwaitJob {
+        _target: target,
+        state,
+        cancellation,
+        wake: wake_recv,
+        notifier,
+    })
+}
 
-        // The Thread Pool interrupts blocking workers with SIGUSR2. This Job
-        // consumes that executor signal because sigwait would otherwise keep
-        // the worker parked after cancellation.
-        let mut all_signals = unsafe { std::mem::zeroed::<libc::sigset_t>() };
-        check_signal_call(unsafe { libc::sigfillset(&mut all_signals) })?;
-        let _mask_guard = SignalMaskGuard::replace(&all_signals)?;
-
-        loop {
-            let mut signal = 0;
-            let error = unsafe { libc::sigwait(&set, &mut signal) };
-            if error > 0 {
-                break Err(AsyncHostError::Native(error));
+// The process broker owns the real sigwait. This per-Run Job preserves the
+// guest's Job lifecycle while receiving forwarded signals through its pipe.
+// Its optional cancellation override wakes the same pipe, preserving native
+// Job cancellation semantics without relying on an interrupt arriving while
+// read(2) happens to be blocked.
+fn run_sigwait_job(job: &mut SigwaitJob) -> AsyncHostResult<i64> {
+    loop {
+        let mut signals = {
+            let mut state = job.state.lock().map_err(|_| AsyncHostError::Inval)?;
+            if state.pending == 0 && state.cancelled {
+                return Ok(0);
             }
-            if signal == libc::SIGUSR2 {
-                break Ok(0);
-            }
-
-            let completion_id = ((signal as u32) | (1u32 << 31)) as i32;
-            notifier.notify(completion_id)?;
+            std::mem::take(&mut state.pending)
+        };
+        while signals != 0 {
+            let signal = signals.trailing_zeros();
+            signals &= signals - 1;
+            let completion_id = (signal | (1_u32 << 31)) as i32;
+            job.notifier.notify(completion_id)?;
         }
+
+        let mut wake = [0_u8; 64];
+        let received =
+            unsafe { libc::read(job.wake.as_raw_fd(), wake.as_mut_ptr().cast(), wake.len()) };
+        if received > 0 {
+            continue;
+        }
+        if received == 0 {
+            return Ok(0);
+        }
+        return Err(AsyncHostError::Native(last_native_errno()));
     }
 }
 
-struct SignalMaskGuard {
-    old: libc::sigset_t,
-}
-
-impl SignalMaskGuard {
-    fn replace(set: &libc::sigset_t) -> AsyncHostResult<Self> {
-        let mut old = unsafe { std::mem::zeroed::<libc::sigset_t>() };
-        check_pthread_call(unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, set, &mut old) })?;
-        Ok(Self { old })
-    }
-}
-
-impl Drop for SignalMaskGuard {
-    fn drop(&mut self) {
-        unsafe {
-            libc::pthread_sigmask(libc::SIG_SETMASK, &self.old, std::ptr::null_mut());
+fn write_wakeup(wake: &OwnedFd) -> AsyncHostResult<bool> {
+    loop {
+        let byte = 0_u8;
+        let written = unsafe { libc::write(wake.as_raw_fd(), std::ptr::from_ref(&byte).cast(), 1) };
+        if written == 1 {
+            return Ok(true);
         }
+        if written == 0 {
+            return Err(AsyncHostError::Inval);
+        }
+        let errno = last_native_errno();
+        if errno == libc::EINTR {
+            continue;
+        }
+        if errno == libc::EAGAIN || errno == libc::EWOULDBLOCK {
+            return Ok(true);
+        }
+        if errno == libc::EPIPE || errno == libc::EBADF {
+            return Ok(false);
+        }
+        return Err(AsyncHostError::Native(errno));
     }
 }
 
 pub(super) fn set_global_cancellation_signals(
+    receiver: &SignalReceiver,
     all_signals: &[i32],
     signals: &[i32],
 ) -> AsyncHostResult<()> {
-    let mut set = current_signal_mask()?;
-    for signal in all_signals.iter().copied().filter(|signal| *signal >= 0) {
-        check_signal_call(unsafe { libc::sigdelset(&mut set, signal) })?;
-    }
-    for signal in signals.iter().copied().filter(|signal| *signal >= 0) {
-        check_signal_call(unsafe { libc::sigaddset(&mut set, signal) })?;
-    }
-    check_pthread_call(unsafe {
-        libc::pthread_sigmask(libc::SIG_SETMASK, &set, std::ptr::null_mut())
-    })
+    receiver.configure(all_signals, signals);
+    Ok(())
 }
 
 pub(crate) fn init_thread_pool_signal_mask() -> AsyncHostResult<libc::sigset_t> {
@@ -164,14 +268,6 @@ fn empty_signal_set() -> AsyncHostResult<libc::sigset_t> {
     Ok(set)
 }
 
-fn current_signal_mask() -> AsyncHostResult<libc::sigset_t> {
-    let mut set = unsafe { std::mem::zeroed::<libc::sigset_t>() };
-    check_pthread_call(unsafe {
-        libc::pthread_sigmask(libc::SIG_SETMASK, std::ptr::null(), &mut set)
-    })?;
-    Ok(set)
-}
-
 fn check_signal_call(result: i32) -> AsyncHostResult<()> {
     if result == 0 {
         Ok(())
@@ -204,22 +300,141 @@ fn last_native_errno() -> i32 {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::{SignalSendError, signal_channel};
+    use std::os::fd::RawFd;
+    use std::time::{Duration, Instant};
+
+    fn close(fd: RawFd) {
+        assert_eq!(unsafe { libc::close(fd) }, 0);
+    }
+
     #[test]
-    fn sigwait_job_references_native_worker_symbol() {
-        let async_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../third_party/moonbitlang_async");
-        for symbol in super::PORTED_SYMBOLS {
-            let source_path = async_root.join(symbol.source);
-            let contents = std::fs::read_to_string(&source_path)
-                .unwrap_or_else(|error| panic!("failed to read {:?}: {error}", source_path));
+    fn virtual_waiter_delivers_only_to_its_run_and_coalesces_signals() {
+        let (first_sender, first_receiver) = signal_channel();
+        let (second_sender, second_receiver) = signal_channel();
+        first_receiver.configure(&[libc::SIGINT, libc::SIGTERM], &[libc::SIGINT]);
+        second_receiver.configure(
+            &[libc::SIGINT, libc::SIGTERM],
+            &[libc::SIGINT, libc::SIGTERM],
+        );
+
+        let (first_notifier, first_fd) = ThreadPoolCompletionNotifier::new().unwrap();
+        let first_notifier = Arc::new(first_notifier);
+        let mut first_job = make_sigwait_job(
+            &first_receiver,
+            &[libc::SIGINT, libc::SIGTERM],
+            Arc::clone(&first_notifier),
+        )
+        .unwrap();
+        assert_eq!(
+            make_sigwait_job(
+                &first_receiver,
+                &[libc::SIGINT],
+                Arc::clone(&first_notifier),
+            )
+            .unwrap_err(),
+            AsyncHostError::Inval
+        );
+
+        let (second_notifier, second_fd) = ThreadPoolCompletionNotifier::new().unwrap();
+        let second_notifier = Arc::new(second_notifier);
+        let mut second_job = make_sigwait_job(
+            &second_receiver,
+            &[libc::SIGINT],
+            Arc::clone(&second_notifier),
+        )
+        .unwrap();
+
+        // Signals may become pending after the virtual waiter is installed but
+        // before its Worker begins running it.
+        assert_eq!(first_sender.send(libc::SIGINT), Ok(true));
+        assert_eq!(first_sender.send(libc::SIGINT), Ok(true));
+        assert_eq!(second_sender.send(libc::SIGTERM), Ok(false));
+        let first_thread = std::thread::spawn(move || first_job.run());
+        let second_thread = std::thread::spawn(move || second_job.run());
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let mut completions = [0; 8];
+        let received = loop {
+            let received = first_notifier.fetch(&mut completions).unwrap();
+            if received != 0 {
+                break received;
+            }
             assert!(
-                contents.contains(symbol.native_symbol),
-                "{:?} does not contain native worker symbol {} for {}::{}",
-                source_path,
-                symbol.native_symbol,
-                symbol.rust_module,
-                symbol.rust_symbol
+                Instant::now() < deadline,
+                "signal completion was not delivered"
             );
-        }
+            std::thread::yield_now();
+        };
+        assert_eq!(received, 4);
+        assert_eq!(
+            i32::from_ne_bytes(completions[..4].try_into().unwrap()),
+            ((libc::SIGINT as u32) | (1_u32 << 31)) as i32
+        );
+        assert_eq!(second_notifier.fetch(&mut [0; 4]).unwrap(), 0);
+
+        drop(first_receiver);
+        drop(second_receiver);
+        assert_eq!(first_thread.join().unwrap(), Ok(0));
+        assert_eq!(second_thread.join().unwrap(), Ok(0));
+
+        drop(first_notifier);
+        drop(second_notifier);
+        close(first_fd);
+        close(second_fd);
+
+        assert_eq!(
+            first_sender.send(libc::SIGINT),
+            Err(SignalSendError::Disconnected)
+        );
+    }
+
+    #[test]
+    fn virtual_waiter_releases_its_run_target_when_dropped() {
+        let (_sender, receiver) = signal_channel();
+        receiver.configure(&[libc::SIGINT], &[libc::SIGINT]);
+        let (notifier, notifier_fd) = ThreadPoolCompletionNotifier::new().unwrap();
+        let notifier = Arc::new(notifier);
+
+        let waiter = make_sigwait_job(&receiver, &[libc::SIGINT], Arc::clone(&notifier)).unwrap();
+        assert_eq!(
+            make_sigwait_job(&receiver, &[libc::SIGINT], Arc::clone(&notifier)).unwrap_err(),
+            AsyncHostError::Inval
+        );
+        drop(waiter);
+
+        let replacement = make_sigwait_job(&receiver, &[libc::SIGINT], Arc::clone(&notifier));
+        assert!(replacement.is_ok());
+
+        drop(replacement);
+        drop(notifier);
+        close(notifier_fd);
+    }
+
+    #[test]
+    fn virtual_waiter_preserves_signal_then_cancellation_before_it_runs() {
+        let (sender, receiver) = signal_channel();
+        receiver.configure(&[libc::SIGINT], &[libc::SIGINT]);
+        let (notifier, notifier_fd) = ThreadPoolCompletionNotifier::new().unwrap();
+        let notifier = Arc::new(notifier);
+        let mut waiter =
+            make_sigwait_job(&receiver, &[libc::SIGINT], Arc::clone(&notifier)).unwrap();
+
+        assert_eq!(sender.send(libc::SIGINT), Ok(true));
+        assert_eq!(waiter.cancellation_override().cancel(), Ok(0));
+        assert_eq!(sender.send(libc::SIGINT), Ok(false));
+        assert_eq!(waiter.run(), Ok(0));
+
+        let mut completion = [0; 4];
+        assert_eq!(notifier.fetch(&mut completion).unwrap(), 4);
+        assert_eq!(
+            i32::from_ne_bytes(completion),
+            ((libc::SIGINT as u32) | (1_u32 << 31)) as i32
+        );
+
+        drop(waiter);
+        drop(notifier);
+        close(notifier_fd);
     }
 }

--- a/crates/moonrun/src/async_sys/signal/windows.rs
+++ b/crates/moonrun/src/async_sys/signal/windows.rs
@@ -17,49 +17,30 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::async_sys::internal::event_loop::poll::{self, CompletionPort};
-
-static INTERESTED_CONSOLE_CTRL_EVENT: std::sync::atomic::AtomicI32 =
-    std::sync::atomic::AtomicI32::new(0);
-
-static CONSOLE_COMPLETION_TARGET: std::sync::Mutex<Option<CompletionPort>> =
-    std::sync::Mutex::new(None);
+use crate::async_sys::internal::event_loop::poll::CompletionPort;
+use crate::run_signal::SignalReceiver;
 
 pub(super) fn set_global_cancellation_signals(
-    _all_signals: &[i32],
+    receiver: &SignalReceiver,
+    all_signals: &[i32],
     signals: &[i32],
 ) -> AsyncHostResult<()> {
-    let mut mask = 0;
-    for signal in signals
-        .iter()
-        .copied()
-        .filter(|signal| (0..i32::BITS as i32).contains(signal))
-    {
-        mask |= 1_i32 << signal;
-    }
-    INTERESTED_CONSOLE_CTRL_EVENT.store(mask, std::sync::atomic::Ordering::Relaxed);
+    receiver.configure(all_signals, signals);
     Ok(())
 }
 
 pub(super) fn set_console_control_handler(
+    receiver: &SignalReceiver,
     add: bool,
     completion_target: Option<CompletionPort>,
 ) -> AsyncHostResult<i32> {
-    use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
-
+    // The CLI owns the one process-global Windows callback. The guest's
+    // set/unset operation instead selects whether that callback may forward
+    // to this Run's completion port.
     if add {
-        let completion_target = completion_target.ok_or(AsyncHostError::Badf)?;
-        *CONSOLE_COMPLETION_TARGET.lock().unwrap() = Some(completion_target);
-    }
-    if unsafe { SetConsoleCtrlHandler(Some(console_control_handler), i32::from(add)) } == 0 {
-        let error = last_native_error();
-        if add {
-            *CONSOLE_COMPLETION_TARGET.lock().unwrap() = None;
-        }
-        return Err(error);
-    }
-    if !add {
-        *CONSOLE_COMPLETION_TARGET.lock().unwrap() = None;
+        receiver.attach_target(completion_target.ok_or(AsyncHostError::Badf)?);
+    } else {
+        receiver.detach_target();
     }
     Ok(1)
 }
@@ -78,21 +59,4 @@ pub(super) fn signal_hup() -> i32 {
 
 pub(super) fn signal_break() -> i32 {
     windows_sys::Win32::System::Console::CTRL_BREAK_EVENT as i32
-}
-
-unsafe extern "system" fn console_control_handler(ctrl_type: u32) -> i32 {
-    let interested = INTERESTED_CONSOLE_CTRL_EVENT.load(std::sync::atomic::Ordering::Relaxed);
-    if ctrl_type < i32::BITS && (interested & (1_i32 << ctrl_type)) != 0 {
-        let target = CONSOLE_COMPLETION_TARGET.lock().unwrap().clone();
-        if let Some(completion_port) = target {
-            let _ =
-                poll::post_thread_pool_completion(&completion_port, (ctrl_type | (1 << 31)) as i32);
-            return 1;
-        }
-    }
-    0
-}
-
-fn last_native_error() -> AsyncHostError {
-    AsyncHostError::Native(unsafe { windows_sys::Win32::Foundation::GetLastError() as i32 })
 }

--- a/crates/moonrun/src/cli/mod.rs
+++ b/crates/moonrun/src/cli/mod.rs
@@ -16,9 +16,6 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-///|
-async fn main {
-  println("ready")
-  defer println("cleanup")
-  @async.sleep(60_000)
-}
+mod process_signals;
+
+pub(super) use process_signals::ProcessSignals;

--- a/crates/moonrun/src/cli/process_signals.rs
+++ b/crates/moonrun/src/cli/process_signals.rs
@@ -1,0 +1,245 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use moonrun::SignalSender;
+
+#[cfg(unix)]
+pub(crate) struct ProcessSignals;
+
+#[cfg(unix)]
+const MANAGED_SIGNALS: [i32; 3] = [libc::SIGINT, libc::SIGTERM, libc::SIGHUP];
+
+#[cfg(unix)]
+impl ProcessSignals {
+    pub(crate) fn install(sender: SignalSender) -> std::io::Result<Self> {
+        let signals = managed_signal_set()?;
+        let mut old_mask = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+        check_pthread_call(unsafe {
+            libc::pthread_sigmask(libc::SIG_BLOCK, &signals, &mut old_mask)
+        })?;
+        // macOS represents pthread_t as a raw pointer, which is not Send.
+        // Its value may still be passed to pthread_kill from another thread.
+        let installing_thread = unsafe { libc::pthread_self() } as usize;
+
+        let mut inherited_blocked_signals = 0_u32;
+        for signal in MANAGED_SIGNALS {
+            let blocked = unsafe { libc::sigismember(&old_mask, signal) };
+            if blocked < 0 {
+                let error = std::io::Error::last_os_error();
+                unsafe {
+                    libc::pthread_sigmask(libc::SIG_SETMASK, &old_mask, std::ptr::null_mut());
+                }
+                return Err(error);
+            }
+            if blocked != 0 {
+                inherited_blocked_signals |= 1_u32 << signal;
+            }
+        }
+
+        let thread = std::thread::Builder::new()
+            .name("moonrun-process-signals".to_owned())
+            .spawn(move || {
+                let mut signals = signals;
+                loop {
+                    let mut signal = 0;
+                    if unsafe { libc::sigwait(&signals, &mut signal) } != 0 {
+                        std::process::abort();
+                    }
+                    if sender.send(signal) != Ok(true) {
+                        if inherited_blocked_signals & (1_u32 << signal) != 0 {
+                            unsafe {
+                                // Return ownership to the inherited thread
+                                // mask. Stop consuming this signal before
+                                // re-queueing it on the thread whose mask we
+                                // inherited, so it remains pending there.
+                                if libc::sigdelset(&mut signals, signal) != 0
+                                    || libc::pthread_kill(
+                                        installing_thread as libc::pthread_t,
+                                        signal,
+                                    ) != 0
+                                {
+                                    libc::_exit(128 + signal);
+                                }
+                            }
+                        } else {
+                            apply_process_signal(signal);
+                        }
+                    }
+                }
+            });
+        if let Err(error) = thread {
+            unsafe {
+                libc::pthread_sigmask(libc::SIG_SETMASK, &old_mask, std::ptr::null_mut());
+            }
+            return Err(error);
+        }
+        Ok(Self)
+    }
+}
+
+#[cfg(unix)]
+fn managed_signal_set() -> std::io::Result<libc::sigset_t> {
+    let mut signals = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+    check_signal_call(unsafe { libc::sigemptyset(&mut signals) })?;
+    for signal in MANAGED_SIGNALS {
+        check_signal_call(unsafe { libc::sigaddset(&mut signals, signal) })?;
+    }
+    Ok(signals)
+}
+
+#[cfg(unix)]
+fn apply_process_signal(signal: i32) {
+    let mut signal_set = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+    unsafe {
+        if libc::sigemptyset(&mut signal_set) != 0
+            || libc::sigaddset(&mut signal_set, signal) != 0
+            || libc::pthread_sigmask(libc::SIG_UNBLOCK, &signal_set, std::ptr::null_mut()) != 0
+            || libc::raise(signal) != 0
+        {
+            libc::_exit(128 + signal);
+        }
+
+        // An ignored signal or a returning inherited handler leaves the
+        // broker alive. Re-block it before waiting again so future deliveries
+        // cannot escape to an arbitrary process thread.
+        if libc::pthread_sigmask(libc::SIG_BLOCK, &signal_set, std::ptr::null_mut()) != 0 {
+            libc::_exit(128 + signal);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn check_signal_call(result: i32) -> std::io::Result<()> {
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn check_pthread_call(result: i32) -> std::io::Result<()> {
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::from_raw_os_error(result))
+    }
+}
+
+#[cfg(windows)]
+pub(crate) struct ProcessSignals;
+
+#[cfg(windows)]
+static PROCESS_SIGNAL_TARGET: std::sync::Mutex<Option<SignalSender>> = std::sync::Mutex::new(None);
+
+#[cfg(windows)]
+impl ProcessSignals {
+    pub(crate) fn install(sender: SignalSender) -> std::io::Result<Self> {
+        use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
+
+        let mut target = PROCESS_SIGNAL_TARGET
+            .lock()
+            .map_err(|_| std::io::Error::other("moonrun process signal adapter is poisoned"))?;
+        if target.is_some() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "moonrun process signal adapter is already installed",
+            ));
+        }
+        *target = Some(sender);
+        if unsafe { SetConsoleCtrlHandler(Some(console_control_handler), 1) } == 0 {
+            *target = None;
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(Self)
+    }
+}
+
+#[cfg(windows)]
+unsafe extern "system" fn console_control_handler(control: u32) -> i32 {
+    let Ok(target) = PROCESS_SIGNAL_TARGET.lock() else {
+        return 0;
+    };
+    target
+        .as_ref()
+        .is_some_and(|sender| sender.send(control as i32) == Ok(true))
+        .into()
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::process::CommandExt;
+    use std::process::Command;
+    use std::time::Duration;
+
+    const BLOCKED_SIGNAL_CHILD: &str = "MOONRUN_TEST_BLOCKED_SIGNAL_CHILD";
+    const BLOCKED_SIGNAL_PRESERVED: &str = "blocked signal remained pending";
+    const TEST_NAME: &str =
+        "cli::process_signals::tests::inherited_blocked_signal_remains_pending_after_fallback";
+
+    #[test]
+    fn inherited_blocked_signal_remains_pending_after_fallback() {
+        if std::env::var_os(BLOCKED_SIGNAL_CHILD).is_some() {
+            let (sender, _receiver) = moonrun::signal_channel();
+            let _process_signals = ProcessSignals::install(sender).unwrap();
+            assert_eq!(unsafe { libc::kill(libc::getpid(), libc::SIGINT) }, 0);
+
+            // The broker thread is already running. Give the old implementation
+            // enough time to consume the signal and incorrectly deliver it.
+            std::thread::sleep(Duration::from_secs(1));
+
+            let mut pending = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+            assert_eq!(unsafe { libc::sigpending(&mut pending) }, 0);
+            assert_eq!(unsafe { libc::sigismember(&pending, libc::SIGINT) }, 1);
+            println!("{BLOCKED_SIGNAL_PRESERVED}");
+            return;
+        }
+
+        let mut child = Command::new(std::env::current_exe().unwrap());
+        child
+            .args(["--exact", TEST_NAME, "--nocapture"])
+            .env(BLOCKED_SIGNAL_CHILD, "1");
+        unsafe {
+            child.pre_exec(|| {
+                let mut blocked = std::mem::zeroed::<libc::sigset_t>();
+                if libc::sigemptyset(&mut blocked) != 0
+                    || libc::sigaddset(&mut blocked, libc::SIGINT) != 0
+                {
+                    return Err(std::io::Error::last_os_error());
+                }
+                let error = libc::pthread_sigmask(libc::SIG_BLOCK, &blocked, std::ptr::null_mut());
+                if error == 0 {
+                    Ok(())
+                } else {
+                    Err(std::io::Error::from_raw_os_error(error))
+                }
+            });
+        }
+
+        let output = child.output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success() && stdout.contains(BLOCKED_SIGNAL_PRESERVED),
+            "blocked-signal child failed with {:?}:\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            stdout,
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}

--- a/crates/moonrun/src/engine.rs
+++ b/crates/moonrun/src/engine.rs
@@ -16,6 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use crate::run_signal::{SignalReceiver, signal_channel};
 use crate::run_termination::RunTermination;
 use crate::runtime::{Runtime, Stdio, WorkingDirectory};
 use crate::{source_map, v8 as backend};
@@ -51,6 +52,8 @@ pub struct RunOptions {
     pub(crate) policy_source_dir: Option<PathBuf>,
     pub(crate) inherited_policy: Option<Vec<u8>>,
     pub(crate) working_directory: WorkingDirectory,
+    #[cfg(unix)]
+    pub(crate) preserved_child_signal_mask: Option<libc::sigset_t>,
 }
 
 #[derive(serde::Deserialize)]
@@ -122,6 +125,28 @@ impl RunOptions {
         self.working_directory = working_directory;
         self
     }
+
+    /// Preserve the calling thread's current signal mask for child processes.
+    ///
+    /// This is CLI plumbing: it snapshots the mask before the process signal
+    /// broker blocks its managed signals in every subsequently created thread.
+    #[cfg(unix)]
+    #[doc(hidden)]
+    pub fn preserve_current_signal_mask_for_children(mut self) -> anyhow::Result<Self> {
+        self.preserved_child_signal_mask = Some(current_signal_mask()?);
+        Ok(self)
+    }
+}
+
+#[cfg(unix)]
+fn current_signal_mask() -> anyhow::Result<libc::sigset_t> {
+    let mut signal_mask = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+    let error =
+        unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, std::ptr::null(), &mut signal_mask) };
+    if error != 0 {
+        return Err(std::io::Error::from_raw_os_error(error).into());
+    }
+    Ok(signal_mask)
 }
 
 /// The observable result of one MoonBit Wasm run.
@@ -256,12 +281,13 @@ impl fmt::Debug for Module {
 /// on the calling thread. It does not create threads or retain run lifecycle
 /// state; callers choose execution placement and manage lifecycle.
 ///
-/// The current implementation still uses process stdio and signal
-/// compatibility behavior. Environment and working-directory behavior are
-/// selected per run, but unrestricted environment access and the only current
-/// working-directory mode remain process-scoped. In particular, unrestricted
-/// guest environment mutations write through to the process and must not race
-/// other process-environment access.
+/// The current implementation still uses process stdio. Environment and
+/// working-directory behavior are selected per run, but unrestricted
+/// environment access and the only current working-directory mode remain
+/// process-scoped. Operating-system signal capture is left to the caller; a
+/// signal channel can direct cooperative delivery to one Run. In particular,
+/// unrestricted guest environment mutations write through to the process and
+/// must not race other process-environment access.
 #[derive(Clone, Debug)]
 pub struct Engine {
     backend: Arc<backend::Engine>,
@@ -316,11 +342,33 @@ impl Engine {
 
     /// Execute one run synchronously on the calling thread.
     pub fn run(&self, module: &Module, options: RunOptions) -> anyhow::Result<RunOutcome> {
+        self.run_with_signal_receiver(module, options, signal_channel().1)
+    }
+
+    /// Execute one run with a caller-provided signal receiver.
+    ///
+    /// Delivery is cooperative: the guest must first register interest and
+    /// start its async signal waiter. Signals are not retained before that
+    /// point and cannot yet forcibly interrupt guest execution.
+    pub fn run_with_signal_receiver(
+        &self,
+        module: &Module,
+        options: RunOptions,
+        signals: SignalReceiver,
+    ) -> anyhow::Result<RunOutcome> {
+        #[cfg(unix)]
+        let child_signal_mask = match options.preserved_child_signal_mask {
+            Some(signal_mask) => signal_mask,
+            None => current_signal_mask()?,
+        };
         let runtime = Runtime::new(
             options.policy_file.as_deref(),
             options.policy_source_dir.as_deref(),
             options.inherited_policy.as_deref(),
             options.working_directory.clone(),
+            signals,
+            #[cfg(unix)]
+            child_signal_mask,
         )?;
         let outcome = self.backend.run(
             module.name(),

--- a/crates/moonrun/src/lib.rs
+++ b/crates/moonrun/src/lib.rs
@@ -33,6 +33,7 @@ mod network;
 mod policy;
 mod process;
 mod resource;
+mod run_signal;
 mod run_termination;
 mod runtime;
 mod source_map;
@@ -43,4 +44,5 @@ mod wasi;
 mod wasm_diagnostic;
 
 pub use engine::{Engine, EngineConfig, Module, RunOptions, RunOutcome};
+pub use run_signal::{SignalReceiver, SignalSendError, SignalSender, signal_channel};
 pub use runtime::WorkingDirectory;

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -16,8 +16,11 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+mod cli;
+
 use clap::Parser;
-use moonrun::{Engine, EngineConfig, RunOptions, RunOutcome};
+use cli::ProcessSignals;
+use moonrun::{Engine, EngineConfig, RunOptions, RunOutcome, signal_channel};
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Parser)]
@@ -115,8 +118,18 @@ fn main() -> anyhow::Result<()> {
             None => options.with_policy_file(policy),
         };
     }
+    #[cfg(unix)]
+    {
+        options = options.preserve_current_signal_mask_for_children()?;
+    }
 
-    match Engine::new(engine_config).run_file(matches.path, options)? {
+    let (signal_sender, signal_receiver) = signal_channel();
+    let _process_signals = ProcessSignals::install(signal_sender)?;
+    let engine = Engine::new(engine_config);
+    let module = engine.load_file(matches.path)?;
+    let outcome = engine.run_with_signal_receiver(&module, options, signal_receiver);
+
+    match outcome? {
         RunOutcome::Completed => Ok(()),
         RunOutcome::Exited(code) => std::process::exit(code),
         RunOutcome::KilledBySignal(signal) => {

--- a/crates/moonrun/src/run_signal.rs
+++ b/crates/moonrun/src/run_signal.rs
@@ -1,0 +1,289 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
+
+#[cfg(windows)]
+use crate::async_sys::internal::event_loop::poll::{self, CompletionPort};
+#[cfg(unix)]
+use crate::async_sys::signal::SigwaitTarget;
+
+/// The sending half of one Run's signal channel.
+///
+/// Sending does not raise an operating-system signal. The caller chooses
+/// which Run receives the signal by choosing its sender.
+#[derive(Clone)]
+pub struct SignalSender {
+    shared: Arc<SignalState>,
+}
+
+/// The receiving half of one Run's signal channel.
+///
+/// Pass this value to [`crate::Engine::run_with_signal_receiver`]. A receiver
+/// belongs to exactly one Run and is intentionally not cloneable.
+pub struct SignalReceiver {
+    shared: Arc<SignalState>,
+}
+
+#[cfg(unix)]
+pub(crate) struct SigwaitTargetGuard {
+    shared: Arc<SignalState>,
+}
+
+/// An error returned when a signal cannot be delivered to a Run.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum SignalSendError {
+    #[error("invalid Run signal")]
+    InvalidSignal,
+    #[error("the Run signal receiver is disconnected")]
+    Disconnected,
+    #[error("failed to wake the Run event loop")]
+    DeliveryFailed,
+}
+
+/// Create a channel for directing signals to one Run.
+pub fn signal_channel() -> (SignalSender, SignalReceiver) {
+    let shared = Arc::new(SignalState {
+        inner: Mutex::new(SignalStateInner {
+            receiver_alive: true,
+            interested: 0,
+            #[cfg(unix)]
+            target: None,
+            #[cfg(windows)]
+            target: None,
+        }),
+    });
+    (
+        SignalSender {
+            shared: Arc::clone(&shared),
+        },
+        SignalReceiver { shared },
+    )
+}
+
+impl SignalSender {
+    /// Deliver a signal to this channel's Run.
+    ///
+    /// `Ok(true)` means the guest accepted the signal. `Ok(false)` means the
+    /// guest has not registered interest in it, so a process adapter may apply
+    /// its platform's default behavior instead.
+    pub fn send(&self, signal: i32) -> Result<bool, SignalSendError> {
+        if signal < 0 {
+            return Err(SignalSendError::InvalidSignal);
+        }
+        let bit = signal_bit(signal);
+
+        #[cfg(unix)]
+        {
+            let target = {
+                let state = self
+                    .shared
+                    .inner
+                    .lock()
+                    .map_err(|_| SignalSendError::Disconnected)?;
+                if !state.receiver_alive {
+                    return Err(SignalSendError::Disconnected);
+                }
+                if state.interested & bit == 0 {
+                    return Ok(false);
+                }
+                state.target.clone()
+            };
+            target.map_or(Ok(false), |target| {
+                target
+                    .send(bit)
+                    .map_err(|_| SignalSendError::DeliveryFailed)
+            })
+        }
+
+        #[cfg(windows)]
+        {
+            let event = encode_signal_event(signal);
+            let target = {
+                let state = self
+                    .shared
+                    .inner
+                    .lock()
+                    .map_err(|_| SignalSendError::Disconnected)?;
+                if !state.receiver_alive {
+                    return Err(SignalSendError::Disconnected);
+                }
+                if state.interested & bit == 0 {
+                    return Ok(false);
+                }
+                let Some(target) = state.target.clone() else {
+                    return Ok(false);
+                };
+                target
+            };
+            poll::post_thread_pool_completion(&target, event)
+                .map_err(|_| SignalSendError::DeliveryFailed)?;
+            Ok(true)
+        }
+    }
+}
+
+impl fmt::Debug for SignalSender {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SignalSender").finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for SignalReceiver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SignalReceiver").finish_non_exhaustive()
+    }
+}
+
+impl SignalReceiver {
+    pub(crate) fn configure(&self, all_signals: &[i32], signals: &[i32]) {
+        self.shared.inner.lock().unwrap().interested =
+            signal_mask(signals) & signal_mask(all_signals);
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn attach_target(&self, target: SigwaitTarget) -> Option<SigwaitTargetGuard> {
+        let Ok(mut state) = self.shared.inner.lock() else {
+            return None;
+        };
+        if !state.receiver_alive || state.target.is_some() {
+            return None;
+        }
+        state.target = Some(target);
+        Some(SigwaitTargetGuard {
+            shared: Arc::clone(&self.shared),
+        })
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn attach_target(&self, target: CompletionPort) {
+        self.shared.inner.lock().unwrap().target = Some(target);
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn detach_target(&self) {
+        self.shared.inner.lock().unwrap().target = None;
+    }
+}
+
+#[cfg(unix)]
+impl Drop for SigwaitTargetGuard {
+    fn drop(&mut self) {
+        self.shared.inner.lock().unwrap().target = None;
+    }
+}
+
+impl Drop for SignalReceiver {
+    fn drop(&mut self) {
+        let mut state = self.shared.inner.lock().unwrap();
+        state.receiver_alive = false;
+        state.target = None;
+    }
+}
+
+struct SignalState {
+    inner: Mutex<SignalStateInner>,
+}
+
+struct SignalStateInner {
+    receiver_alive: bool,
+    interested: u32,
+    #[cfg(unix)]
+    target: Option<SigwaitTarget>,
+    #[cfg(windows)]
+    target: Option<CompletionPort>,
+}
+
+#[cfg(windows)]
+fn encode_signal_event(signal: i32) -> i32 {
+    ((signal as u32) | (1_u32 << 31)) as i32
+}
+
+fn signal_bit(signal: i32) -> u32 {
+    u32::try_from(signal)
+        .ok()
+        .and_then(|signal| 1_u32.checked_shl(signal))
+        .unwrap_or(0)
+}
+
+pub(crate) fn signal_mask(signals: &[i32]) -> u32 {
+    signals
+        .iter()
+        .copied()
+        .fold(0, |mask, signal| mask | signal_bit(signal))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_negative_signals() {
+        let (sender, _receiver) = signal_channel();
+        assert_eq!(sender.send(-1), Err(SignalSendError::InvalidSignal));
+    }
+
+    #[test]
+    fn sender_disconnects_with_receiver() {
+        let (sender, receiver) = signal_channel();
+        drop(receiver);
+        assert_eq!(sender.send(2), Err(SignalSendError::Disconnected));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_signals_are_delivered_only_to_the_selected_run() {
+        use windows_sys::Win32::System::Console::CTRL_BREAK_EVENT;
+
+        let signal = CTRL_BREAK_EVENT as i32;
+        let (first_sender, first_receiver) = signal_channel();
+        let (second_sender, second_receiver) = signal_channel();
+        first_receiver.configure(&[signal], &[signal]);
+        second_receiver.configure(&[signal], &[signal]);
+
+        let mut first_poll = poll::poll_create().unwrap();
+        let mut second_poll = poll::poll_create().unwrap();
+        first_receiver.attach_target(CompletionPort::from_poll(&first_poll));
+        second_receiver.attach_target(CompletionPort::from_poll(&second_poll));
+
+        assert_eq!(first_sender.send(signal), Ok(true));
+        assert_eq!(poll::poll_wait(&mut first_poll, 0).unwrap(), 1);
+        assert_eq!(poll::poll_wait(&mut second_poll, 0).unwrap(), 0);
+        let event = poll::event_list_get(&first_poll, 0).unwrap();
+        assert_eq!(
+            poll::event_get_bytes_transferred(event),
+            encode_signal_event(signal) as u32
+        );
+
+        assert_eq!(second_sender.send(signal), Ok(true));
+        assert_eq!(poll::poll_wait(&mut second_poll, 0).unwrap(), 1);
+        assert_eq!(poll::poll_wait(&mut first_poll, 0).unwrap(), 0);
+        let event = poll::event_list_get(&second_poll, 0).unwrap();
+        assert_eq!(
+            poll::event_get_bytes_transferred(event),
+            encode_signal_event(signal) as u32
+        );
+
+        drop(first_receiver);
+        drop(second_receiver);
+        poll::poll_destroy(first_poll);
+        poll::poll_destroy(second_poll);
+    }
+}

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -37,6 +37,7 @@ use crate::filesystem::HostFs;
 use crate::network::HostNetwork;
 use crate::policy::{self, Policy};
 use crate::process::HostProcess;
+use crate::run_signal::SignalReceiver;
 use crate::sqlite::SqliteHost;
 
 pub(crate) use environment::Env;
@@ -124,6 +125,8 @@ impl Runtime {
         policy_source_dir: Option<&Path>,
         inherited_policy: Option<&[u8]>,
         working_directory: WorkingDirectory,
+        signals: SignalReceiver,
+        #[cfg(unix)] child_signal_mask: libc::sigset_t,
     ) -> anyhow::Result<Self> {
         let (mut policy, env_provisioning) = match (inherited_policy, policy_file) {
             (Some(contents), _) => {
@@ -171,6 +174,9 @@ impl Runtime {
             network,
             process,
             Rc::clone(&keys),
+            signals,
+            #[cfg(unix)]
+            child_signal_mask,
         );
         let sqlite = SqliteHost::new(Arc::clone(&filesystem), keys);
         Ok(Self {

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -725,7 +725,7 @@ fn test_moonrun_async_main_preserves_signal_termination() {
         .expect("capture stderr")
         .read_to_string(&mut stderr)
         .expect("read stderr");
-    assert_eq!(remaining_stdout, "");
+    assert_eq!(remaining_stdout, "cleanup\n");
     assert_eq!(stderr, "");
     #[cfg(unix)]
     assert_eq!(status.signal(), Some(libc::SIGINT));


### PR DESCRIPTION
## Why

Moonrun's signal integration currently connects process-global OS handlers directly to one Run's completion target. That ownership is unsafe for library callers that execute multiple modules in the same process: one Run can replace or tear down another Run's signal target, which is the source of the flaky Windows multi-Run failure.

## What changed

- Add a per-Run signal channel and an explicit `Engine::run_with_signal_receiver` entry point.
- Keep process-global OS signal registration in the CLI adapter instead of the reusable engine.
- On Unix, use one process broker backed by real `sigwait`, then forward signals to each Run's virtual sigwait Job through its existing completion path.
- On Windows, keep the guest-visible console-handler set/unset lifecycle while forwarding console events only to the active Run's IOCP target.
- Preserve the inherited child signal mask and the native fallback behavior when a Run does not accept a signal.

## Why this is correct

The process adapter owns process-wide state, while each Run owns only its signal interest and completion target. This prevents one Run from overwriting another Run's target and lets library callers choose their own dispatch policy.

Unix signal delivery retains standard-signal coalescing. Its virtual sigwait Job uses the native Job model's optional cancellation override so cancellation is durable even if requested before the blocking read begins. It still reports the same successful completion as the native sigwait Job. Ordinary Unix Jobs continue to use the default `pthread_kill(SIGUSR2)` cancellation path.

The change adds no dependency and keeps the existing single-Run CLI behavior. The new boundary is limited to signal ownership: scheduling and termination remain owned by each Run.
