### PR TITLE
chore(deps): remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,6 @@ name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "argh"
@@ -851,7 +848,6 @@ dependencies = [
  "console 0.15.8",
  "shell-words",
  "thiserror 1.0.63",
- "zeroize",
 ]
 
 [[package]]
@@ -922,15 +918,6 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "env_filter"
@@ -1963,7 +1950,6 @@ dependencies = [
  "colored",
  "ctrlc",
  "derive_builder",
- "dialoguer",
  "dunce",
  "escargot",
  "expect-test",
@@ -1984,7 +1970,6 @@ dependencies = [
  "petgraph",
  "rand 0.8.6",
  "regex",
- "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -2027,10 +2012,8 @@ dependencies = [
  "anstream",
  "anstyle",
  "anyhow",
- "arcstr",
  "ariadne",
  "base64",
- "chrono",
  "clap",
  "colored",
  "ctrlc",
@@ -2038,7 +2021,6 @@ dependencies = [
  "dunce",
  "expect-test",
  "handlebars",
- "home",
  "http",
  "hyper",
  "hyper-staticfile",
@@ -2047,28 +2029,18 @@ dependencies = [
  "json-structural-diff",
  "line-index",
  "log",
- "mooncake",
  "moonutil",
  "n2",
- "petgraph",
- "rand 0.8.6",
- "regex",
  "reqwest",
  "self-replace",
- "semver",
  "serde",
  "serde_json",
  "serde_json_lenient",
- "shlex",
  "similar",
  "tempfile",
  "text-size",
- "thiserror 1.0.63",
  "tokio",
  "toml",
- "walkdir",
- "which 6.0.2",
- "zip",
 ]
 
 [[package]]
@@ -2086,7 +2058,6 @@ dependencies = [
 name = "moonbuild-rupes-recta"
 version = "0.1.0"
 dependencies = [
- "aho-corasick",
  "anyhow",
  "arcstr",
  "dunce",
@@ -2116,8 +2087,6 @@ dependencies = [
  "arcstr",
  "bytes",
  "clap",
- "colored",
- "dialoguer",
  "dunce",
  "expect-test",
  "form_urlencoded",
@@ -2767,7 +2736,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2780,8 +2748,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2794,14 +2760,12 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -3927,19 +3891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4623,7 +4574,6 @@ dependencies = [
  "clap",
  "dunce",
  "serde",
- "serde_json",
  "toml",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,12 @@ edition = "2024"
 
 [workspace.dependencies]
 n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "79d275ef051cf0d4864ae3b4f4947e3f3f035899" }
-arcstr = { version = "1.2", features = ["serde"] }
+arcstr = "1.2"
 moonbuild = { path = "./crates/moonbuild", version = "*" }
 moonbuild-rupes-recta = { path = "./crates/moonbuild-rupes-recta", version = "*" }
 moonbuild-debug = { path = "./crates/moonbuild-debug", version = "*" }
 mooncake = { path = "./crates/mooncake", version = "*" }
+moon-test-util = { path = "./crates/moon-test-util", version = "*" }
 moonutil = { path = "./crates/moonutil", version = "*" }
 anyhow = { version = "1.0.86" }
 anstream = "0.6.21"
@@ -48,17 +49,14 @@ dunce = "1.0.4"
 escargot = "0.5.15"
 expect-test = "1.5.0"
 find-msvc-tools = "0.1.9"
+form_urlencoded = "1.2.1"
 snapbox = "0.6.23"
-futures = { version = "0.3.29", features = ["std"], default-features = false }
 indexmap = { version = "2.2.6", features = ["serde"] }
 reqwest = { version = "0.12.28", default-features = false, features = [
-    "multipart",
     "blocking",
     "json",
-    "stream",
     "rustls-tls",
     "rustls-tls-native-roots",
-    "charset",
     "http2",
     "system-proxy",
 ] }
@@ -81,6 +79,7 @@ tokio = { version = "1.34.0", features = [
 ] }
 walkdir = "2.5.0"
 which = "6.0.1"
+windows-sys = "0.59.0"
 zip = { version = "0.6.6", features = ["deflate"], default-features = false }
 home = "0.5.0"
 semver = { version = "1.0.22", features = ["serde"] }
@@ -95,10 +94,9 @@ hyper-util = { version = "0.1.20", features = ["http1", "server", "tokio"] }
 hyper-staticfile = "0.10.0"
 http = "1.1.0"
 bytes = "1.6"
-dialoguer = { version = "0.11.0", features = [
-    "password",
-], default-features = false }
+dialoguer = { version = "0.11.0", default-features = false }
 self-replace = "1.3.7"
+junction = "1"
 tempfile = "3.10.1"
 line-index = "0.1.1"
 libsqlite3-sys = { version = "0.38.2", features = ["bundled"] }
@@ -109,6 +107,7 @@ thiserror = "1.0"
 test-log = "0.2"
 ariadne = { version = "0.5.1", features = ["auto-color"] }
 clap_complete = { version = "4.5.4" }
+clap-markdown = "0.1.4"
 schemars = "0.8"
 nucleo-matcher = "0.3.1"
 regex = { version = "1.11.0", default-features = false, features = ["std"] }
@@ -121,6 +120,20 @@ slotmap = "1.0.7"
 toml = "0.9.5"
 ignore = "0.4.23"
 similar = { version = "2.7.0", features = ["inline"] }
+notify = "6.1.1"
+json-structural-diff = { version = "0.1.0", features = ["colorize"] }
+handlebars = { version = "6.3.2", default-features = false }
+logos = "0.15.1"
+globset = "0.4"
+vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
+v8 = "0.106.0"
+wasmtime = { version = "48.0.1", default-features = false, features = [
+    "anyhow",
+    "runtime",
+    "cranelift",
+    "gc-copying",
+] }
+wat = "1.255.0"
 
 libc = "0.2.177"
 

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -42,7 +42,6 @@ colored.workspace = true
 serde.workspace = true
 serde_json_lenient.workspace = true
 serde_json.workspace = true
-dialoguer.workspace = true
 dunce.workspace = true
 ctrlc.workspace = true
 home.workspace = true
@@ -50,7 +49,7 @@ which.workspace = true
 chrono.workspace = true
 log.workspace = true
 walkdir.workspace = true
-notify = "6.1.1"
+notify.workspace = true
 tokio = { workspace = true, features = ["rt", "signal"] }
 tokio-util.workspace = true
 clap_complete.workspace = true
@@ -63,8 +62,6 @@ shlex.workspace = true
 derive_builder.workspace = true
 sha2.workspace = true
 blake3.workspace = true
-similar.workspace = true
-reqwest.workspace = true
 
 ignore.workspace = true
 
@@ -76,6 +73,7 @@ tracing-chrome.workspace = true
 libc.workspace = true
 
 [target."cfg(windows)".dependencies.windows-sys]
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Security",
@@ -83,23 +81,20 @@ features = [
     "Win32_System_JobObjects",
     "Win32_System_Threading",
 ]
-version = "0.59.0"
 
 [target."cfg(windows)".dependencies]
-junction = "1"
+junction.workspace = true
 
 [dev-dependencies]
-tempfile = "3.6.0"
 regex.workspace = true
 snapbox = { workspace = true, features = ["regex"] }
 expect-test.workspace = true
 escargot.workspace = true
-clap-markdown = "0.1.4"
+clap-markdown.workspace = true
 similar.workspace = true
-colored.workspace = true
 libc.workspace = true
 moonbuild-debug.workspace = true
-moon-test-util = { path = "../moon-test-util" }
+moon-test-util.workspace = true
 zip.workspace = true
 
 

--- a/crates/moonbuild-rupes-recta/Cargo.toml
+++ b/crates/moonbuild-rupes-recta/Cargo.toml
@@ -45,6 +45,5 @@ tracing.workspace = true
 regex.workspace = true
 dunce.workspace = true
 
-aho-corasick = "1.1.3"
 serde = { workspace = true, features = ["rc"] }
 sha2.workspace = true

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -1885,11 +1885,7 @@ fn cat_opt(x: Option<String>, y: Option<&str>) -> Option<String> {
     }
 }
 
-static PREBUILD_AUTOMATA: LazyLock<aho_corasick::AhoCorasick> = LazyLock::new(|| {
-    aho_corasick::AhoCorasickBuilder::new()
-        .build([MOONCAKE_BIN, MOD_DIR, PKG_DIR, "$input", "$output"])
-        .expect("Failed to build automata")
-});
+const PREBUILD_PLACEHOLDERS: [&str; 5] = [MOONCAKE_BIN, MOD_DIR, PKG_DIR, "$input", "$output"];
 
 /// Substitute prebuild command placeholders and resolve a relative shell argv0.
 ///
@@ -1928,17 +1924,27 @@ fn resolve_prebuild_command(
 
     let mut resolved = String::new();
 
-    // Perform replacements
+    // Perform replacements in one pass while preserving unrecognized `$` sequences.
     let mut last_end = 0usize;
-    for magic in PREBUILD_AUTOMATA.find_iter(command) {
+    while let Some(next_dollar) = command[last_end..].find('$') {
+        let start = last_end + next_dollar;
+        let Some((pattern_id, pattern)) = PREBUILD_PLACEHOLDERS
+            .iter()
+            .enumerate()
+            .find(|(_, pattern)| command[start..].starts_with(**pattern))
+        else {
+            resolved.push_str(&command[last_end..=start]);
+            last_end = start + 1;
+            continue;
+        };
+
         // Commit previous segment
-        if magic.start() > last_end {
-            resolved.push_str(&command[last_end..magic.start()]);
+        if start > last_end {
+            resolved.push_str(&command[last_end..start]);
         }
 
         // Insert replacement
-        // See the IDs in CHECK_AUTOMATA
-        match magic.pattern().as_usize() {
+        match pattern_id {
             // $mooncake_bin => <project target dir>/__moonbin__
             0 => {
                 write!(resolved, "{}", mooncake_bin_dir.display()).expect("write can't fail");
@@ -1968,9 +1974,9 @@ fn resolve_prebuild_command(
                     write!(resolved, "{f}").expect("write can't fail");
                 }
             }
-            _ => unreachable!("Unexpected pattern id from CHECK_AUTOMATA"),
+            _ => unreachable!("Unexpected prebuild placeholder index"),
         }
-        last_end = magic.end();
+        last_end = start + pattern.len();
     }
 
     if last_end < command.len() {
@@ -2164,6 +2170,23 @@ mod tests {
         assert_eq!(
             command,
             "generate --inputs ./src/lib/input.txt ./src/assets/second.txt --outputs ./src/lib/generated.mbt ./src/lib/generated_2.mbt"
+        );
+    }
+
+    #[test]
+    fn resolve_prebuild_command_replaces_all_placeholders_and_preserves_unknown_ones() {
+        let command = resolve_prebuild_command(
+            "tool $mooncake_bin $mod_dir $pkg_dir $input $output $unknown",
+            Path::new("module"),
+            Path::new("bin"),
+            Path::new("package"),
+            &["input-a".to_owned(), "input-b".to_owned()],
+            &["output".to_owned()],
+        );
+
+        assert_eq!(
+            command,
+            "tool bin module package input-a input-b output $unknown"
         );
     }
 

--- a/crates/moonbuild/Cargo.toml
+++ b/crates/moonbuild/Cargo.toml
@@ -27,9 +27,7 @@ rust-version.workspace = true
 [dependencies]
 anstream.workspace = true
 anstyle.workspace = true
-arcstr.workspace = true
 moonutil.workspace = true
-mooncake.workspace = true
 n2.workspace = true
 clap.workspace = true
 serde.workspace = true
@@ -38,16 +36,10 @@ anyhow.workspace = true
 colored.workspace = true
 dunce.workspace = true
 indexmap.workspace = true
-petgraph.workspace = true
-walkdir.workspace = true
-tempfile.workspace = true
 ctrlc.workspace = true
 similar.workspace = true
 line-index.workspace = true
-which.workspace = true
-home.workspace = true
 tokio.workspace = true
-self-replace.workspace = true
 text-size.workspace = true
 log.workspace = true
 hyper.workspace = true
@@ -56,19 +48,17 @@ hyper-staticfile.workspace = true
 http.workspace = true
 dialoguer.workspace = true
 reqwest.workspace = true
-semver.workspace = true
-chrono.workspace = true
-zip.workspace = true
-thiserror.workspace = true
-rand.workspace = true
-json-structural-diff = { version = "0.1.0", features = ["colorize"] }
+json-structural-diff.workspace = true
 base64.workspace = true
-shlex.workspace = true
 serde_json.workspace = true
-regex.workspace = true
 ariadne.workspace = true
-handlebars = { version = "6.3.2", default-features = false }
+handlebars.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }
 
 [dev-dependencies]
 expect-test.workspace = true
+tempfile.workspace = true
+
+[target."cfg(windows)".dependencies]
+self-replace.workspace = true
+tempfile.workspace = true

--- a/crates/mooncake/Cargo.toml
+++ b/crates/mooncake/Cargo.toml
@@ -32,7 +32,6 @@ serde_json.workspace = true
 serde_json_lenient.workspace = true
 anyhow.workspace = true
 zip.workspace = true
-colored.workspace = true
 reqwest.workspace = true
 bytes.workspace = true
 semver.workspace = true
@@ -42,13 +41,12 @@ log.workspace = true
 tracing.workspace = true
 walkdir.workspace = true
 tempfile.workspace = true
-dialoguer.workspace = true
-form_urlencoded = "1.2.1"
+form_urlencoded.workspace = true
 indexmap.workspace = true
-petgraph.workspace = true
 thiserror.workspace = true
 dunce.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true
+petgraph.workspace = true
 test-log.workspace = true

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -40,14 +40,9 @@ libsqlite3-sys.workspace = true
 slotmap.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }
 moonutil.workspace = true
-rand = "0.8.5"
-v8 = { version = "0.106.0", optional = true }
-wasmtime = { version = "48.0.1", default-features = false, optional = true, features = [
-    "anyhow",
-    "runtime",
-    "cranelift",
-    "gc-copying",
-] }
+rand.workspace = true
+v8 = { workspace = true, optional = true }
+wasmtime = { workspace = true, optional = true }
 
 [target."cfg(not(windows))".dependencies]
 openssl.workspace = true
@@ -57,7 +52,7 @@ openssl-probe.workspace = true
 libc.workspace = true
 
 [target."cfg(windows)".dependencies.windows-sys]
-version = "0.59.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Globalization",
@@ -83,15 +78,15 @@ features = [
 ]
 
 [build-dependencies]
-vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
+vergen.workspace = true
 chrono.workspace = true
 
 [dev-dependencies]
 escargot.workspace = true
-moon-test-util = { path = "../moon-test-util" }
+moon-test-util.workspace = true
 snapbox.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "time"] }
-wat = "1.255.0"
+wat.workspace = true
 
 [[bin]]
 name = "moonrun"

--- a/crates/moonutil/Cargo.toml
+++ b/crates/moonutil/Cargo.toml
@@ -51,13 +51,13 @@ derive_builder.workspace = true
 serde_yaml.workspace = true
 slotmap.workspace = true
 shlex.workspace = true
-logos = "0.15.1"
-globset = "0.4"
+logos.workspace = true
+globset.workspace = true
 tempfile.workspace = true
 
 [target."cfg(windows)".dependencies]
 find-msvc-tools.workspace = true
-windows-sys = { version = "0.59.0", features = ["Win32_Foundation"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation"] }
 
 [target."cfg(unix)".dependencies]
 libc.workspace = true
@@ -66,5 +66,5 @@ libc.workspace = true
 expect-test.workspace = true
 
 [build-dependencies]
-vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
+vergen.workspace = true
 chrono.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -25,10 +25,9 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.79"
-clap = { version = "4.4.12", features = ["derive", "env"] }
+anyhow.workspace = true
+clap.workspace = true
 dunce.workspace = true
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde.workspace = true
 toml.workspace = true
 walkdir.workspace = true


### PR DESCRIPTION
## Why
Several workspace members retained dependencies after code moved or was removed, and dependency versions were split between the root and member manifests. Rupes Recta also used aho-corasick for only five fixed prebuild placeholders.

## What
- remove unused and duplicate dependency declarations
- scope test-only and Windows-only dependencies appropriately
- centralize workspace dependency versions in the root manifest
- narrow unused arcstr, dialoguer, and reqwest features
- replace the fixed placeholder matcher with a single-pass standard-library scanner

## Why this is correct
The remaining direct dependencies are backed by source call sites, and every root workspace dependency is referenced by at least one member. The replacement scanner preserves all five supported placeholders and unknown dollar-prefixed text, with focused regression coverage.

## Scope
This is one dependency-cleanup commit. It does not include the dependency/license table or broader migrations between overlapping libraries.