### PR TITLE
fix(mooncake): decouple MVS traversal from logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,16 +1664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "junction"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52f6e1bf39a7894f618c9d378904a11dbd7e10fe3ec20d1173600e79b1408d8"
-dependencies = [
- "scopeguard",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,7 +1925,6 @@ dependencies = [
  "home",
  "ignore",
  "indexmap",
- "junction",
  "libc",
  "log",
  "moon-test-util",
@@ -1998,7 +1987,6 @@ dependencies = [
  "ctrlc",
  "dialoguer",
  "dunce",
- "expect-test",
  "handlebars",
  "http",
  "hyper",
@@ -2915,12 +2903,6 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.106",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,27 +920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "env_filter"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,7 +2080,6 @@ dependencies = [
  "serde_json_lenient",
  "sha2",
  "tempfile",
- "test-log",
  "thiserror 1.0.63",
  "tracing",
  "walkdir",
@@ -3311,28 +3289,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "test-log"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
-dependencies = [
- "env_logger",
- "test-log-macros",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "test-log-macros"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ http = "1.1.0"
 bytes = "1.6"
 dialoguer = { version = "0.11.0", default-features = false }
 self-replace = "1.3.7"
-junction = "1"
 tempfile = "3.10.1"
 line-index = "0.1.1"
 libsqlite3-sys = { version = "0.38.2", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,6 @@ text-size = "1.1.1"
 unicode-width = "0.1.13"
 log = "0.4.20"
 thiserror = "1.0"
-test-log = "0.2"
 ariadne = { version = "0.5.1", features = ["auto-color"] }
 clap_complete = { version = "4.5.4" }
 clap-markdown = "0.1.4"

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -82,9 +82,6 @@ features = [
     "Win32_System_Threading",
 ]
 
-[target."cfg(windows)".dependencies]
-junction.workspace = true
-
 [dev-dependencies]
 regex.workspace = true
 snapbox = { workspace = true, features = ["regex"] }

--- a/crates/moonbuild/Cargo.toml
+++ b/crates/moonbuild/Cargo.toml
@@ -56,7 +56,6 @@ handlebars.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }
 
 [dev-dependencies]
-expect-test.workspace = true
 tempfile.workspace = true
 
 [target."cfg(windows)".dependencies]

--- a/crates/mooncake/Cargo.toml
+++ b/crates/mooncake/Cargo.toml
@@ -49,4 +49,3 @@ dunce.workspace = true
 [dev-dependencies]
 expect-test.workspace = true
 petgraph.workspace = true
-test-log.workspace = true

--- a/crates/mooncake/src/resolver/mvs.rs
+++ b/crates/mooncake/src/resolver/mvs.rs
@@ -237,6 +237,11 @@ fn workspace_version_override_warning(
     ))
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(root_count = res.input_module_ids().len())
+)]
 fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog) -> bool {
     let workspace_roots = res
         .input_module_ids()
@@ -262,9 +267,9 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog)
 
     // Collect all version constraints for each dependency.
     let mut working_list = vec![];
-    let mut visited = HashSet::new();
-
-    log::debug!("Begin MVS solving");
+    // Roots are scheduled below, so mark them visited before traversal to prevent
+    // dependency edges back to a root from scheduling it a second time.
+    let mut visited = root_sources.clone();
 
     working_list.extend(res.input_module_ids().iter().map(|&id| {
         (
@@ -272,16 +277,15 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog)
             Arc::clone(res.module_info(id)),
         )
     }));
-    if log::log_enabled!(log::Level::Debug) {
+    if tracing::enabled!(tracing::Level::DEBUG) {
         for &id in res.input_module_ids() {
-            log::debug!("MVS root item: {}", res.module_source(id));
-            visited.insert(res.module_source(id).clone());
+            tracing::debug!(module = %res.module_source(id), "registered root module");
         }
     }
 
     // Do a DFS in the graph
     while let Some((source, module)) = working_list.pop() {
-        log::debug!("-- Solving for {}", source);
+        tracing::debug!(module = %source, "visiting module dependencies");
         let bin_deps = root_sources.contains(&source).then(|| {
             module
                 .bin_deps
@@ -316,20 +320,19 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog)
     }
 
     if env.any_errors() {
-        log::warn!("Errors in MVS dependency solving, bailing out.");
         return false;
     }
 
-    log::debug!("Selecting minimal version for each set of compatible versions");
+    tracing::debug!("selecting minimal version for each compatibility set");
 
     // Select the minimal version of each compatible version set.
     let mut settled_versions = HashMap::<ModuleName, BTreeSet<ModuleSourceOrdWrapper>>::new();
     for (name, versions) in gathered_versions {
-        log::debug!("-- Module {}", name);
+        let _span = tracing::debug_span!("select_module_version", module = %name).entered();
 
         let mut versions = versions.into_iter().map(|x| x.0);
         let mut curr = versions.next().unwrap();
-        log::debug!("---- seen {}", curr);
+        tracing::debug!(version = %curr, "considering version");
         for v in versions {
             if same_mvs_compatibility_set(curr.version(), v.version()) {
                 // v >= curr, as implied by btreeset
@@ -337,7 +340,7 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog)
                 warn_about_skipped_local_or_git_dep(&curr, user_log);
                 curr = v;
             } else {
-                log::debug!("---- selected {}", curr);
+                tracing::debug!(version = %curr, "selected version");
                 settled_versions
                     .entry(name.clone())
                     .or_default()
@@ -345,25 +348,28 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog)
                 // This starts a new incompatible set.
                 curr = v;
             }
-            log::debug!("---- seen {}", curr);
+            tracing::debug!(version = %curr, "considering version");
         }
         // There's one last version left to be inserted
-        log::debug!("---- selected {}", curr);
+        tracing::debug!(version = %curr, "selected version");
         settled_versions
             .entry(name)
             .or_default()
             .insert(curr.into());
     }
 
-    log::debug!("Building result dependency graph");
+    tracing::debug!("building resolved dependency graph");
 
     // And finally, build the dependency graph
-    log::debug!("-- Reusing root modules");
     let mut working_list = res
         .input_module_ids()
         .iter()
         .map(|&id| {
-            log::debug!("---- {} -> {:?}", res.module_source(id), id);
+            tracing::debug!(
+                module = %res.module_source(id),
+                module_id = ?id,
+                "reusing root module"
+            );
             (
                 Arc::clone(res.module_info(id)),
                 res.module_source(id).clone(),
@@ -376,7 +382,6 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog)
         .map(|&id| (res.module_source(id).clone(), id))
         .collect::<HashMap<_, _>>();
 
-    log::debug!("-- Inserting dependencies");
     while let Some((module, module_source)) = working_list.pop() {
         let pkg = module_source;
 
@@ -430,12 +435,17 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog)
             } else {
                 let dep_module = env.get(resolved).unwrap();
                 let id = res.add_module(resolved.clone(), Arc::clone(&dep_module));
-                log::debug!("---- {} -> {:?}", resolved, id);
+                tracing::debug!(module = %resolved, module_id = ?id, "inserted resolved module");
                 visited.insert(resolved.clone(), id);
                 working_list.push((dep_module, resolved.clone()));
                 id
             };
-            log::debug!("---- {}.deps[{}] = {}", pkg, dep_name, resolved);
+            tracing::debug!(
+                dependant = %pkg,
+                dependency = %dep_name,
+                resolved = %resolved,
+                "inserted dependency edge"
+            );
 
             // Add dependency
             res.add_dependency(
@@ -450,11 +460,8 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog)
     }
 
     if env.any_errors() {
-        log::warn!("Errors while building resolved dependency graph, bailing out.");
         return false;
     }
-
-    log::debug!("Finished MVS solving");
 
     true
 }
@@ -471,10 +478,10 @@ fn resolve_pkg(
         if let Some(warning) = workspace_version_override_warning(req, dependant, source) {
             user_log.warn(warning);
         }
-        log::debug!(
-            "---- Dependency {} resolved to workspace module {}",
-            pkg_name,
-            source
+        tracing::debug!(
+            dependency = %pkg_name,
+            resolved = %source,
+            "resolved dependency to workspace module"
         );
         return Ok((source.clone(), Arc::clone(module)));
     }
@@ -549,11 +556,11 @@ fn resolve_pkg(
     // to resolving from a registry.
     let (version, module) =
         select_min_version_satisfying_in_env(env, pkg_name, dependant.name(), req, user_log)?;
-    log::debug!(
-        "---- Dependency {}, required {:?}, selected {}",
-        pkg_name,
-        req,
-        version
+    tracing::debug!(
+        dependency = %pkg_name,
+        required = ?req,
+        selected = %version,
+        "resolved registry dependency"
     );
     let ms = ModuleSource::new_full(pkg_name.clone(), version, ModuleSourceKind::Registry);
     Ok((ms, module))
@@ -565,7 +572,6 @@ mod test {
     use moonutil::resolution::ModuleId;
     use moonutil::resolution::{DependencyEdge, ResolvedModule, ResolvedRootModules};
     use petgraph::dot::{Config, Dot};
-    use test_log::test;
 
     use super::*;
     use crate::registry::Registry;
@@ -1149,6 +1155,38 @@ mod test {
 
         assert_depends_on_source(&result, &app_src, &shared_src);
         assert_no_depends_on_source(&result, &app_src, &"dep/shared@0.2.0".parse().unwrap());
+    }
+
+    #[test]
+    fn test_workspace_roots_are_not_reprocessed() {
+        let registry = MockRegistry::new();
+        let mut env = ResolverEnv::new(&registry);
+        let mut resolver = MvsSolver;
+        let app = Arc::new(create_mock_module(
+            "workspace/app",
+            "0.1.0",
+            [("workspace/lib", "0.2.0")],
+        ));
+        let lib = Arc::new(create_mock_module(
+            "workspace/lib",
+            "0.1.0",
+            [("workspace/app", "0.2.0")],
+        ));
+        let roots = create_mock_workspace_roots([
+            ("/workspace/app", Arc::clone(&app)),
+            ("/workspace/lib", Arc::clone(&lib)),
+        ]);
+        let mut result_env = ResolvedEnv::from_root_modules(roots);
+        let (user_log, capture) = UserLog::captured(log::LevelFilter::Warn);
+
+        let status = resolver.resolve(&mut env, &mut result_env, &user_log);
+
+        assert!(status, "Resolve failed");
+        assert_eq!(
+            capture.take().len(),
+            2,
+            "each incompatible workspace dependency should warn exactly once",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

The MVS resolver initialized its root visited set only when debug logging was enabled. As a result, logging configuration could change traversal behavior and cause cyclic workspace roots to be processed more than once.

The previous dependency cleanup also left three unused test or platform dependencies behind: test-log in mooncake, junction in moon, and expect-test in legacy moonbuild.

## What changed

- Initialize MVS root visitation state unconditionally.
- Move internal MVS diagnostics from log to structured tracing events and spans.
- Keep user-facing resolution warnings in UserLog and remove redundant internal bailout warnings.
- Add a regression test covering cyclic workspace roots and duplicate warnings.
- Remove test-log and its transitive logging packages.
- Remove the unused junction dependency from moon.
- Remove the unused expect-test dev-dependency from legacy moonbuild.

## Correctness and scope

Every MVS root is placed on the work list before traversal, so seeding visited from the same root set preserves the traversal invariant and prevents back-edges from scheduling roots twice. The dependency removals have no remaining source references and are kept in a separate cleanup commit within this PR.

The log dependency remains available to mooncake because other modules and the current UserLog API still use it; a crate-wide migration remains separate.