### PR TITLE
fix: isolate standalone file build directories

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -619,8 +619,7 @@ fn run_check_for_single_file_rr(
         );
     }
 
-    let filename = single_file_path.file_name().and_then(|name| name.to_str());
-    run_planned_checks(cli, cmd, dirs, planned_runs, true, filename, output, json)
+    run_planned_checks(cli, cmd, dirs, planned_runs, true, output, json)
         .map(|ok| if ok { 0 } else { 1 })
 }
 
@@ -787,7 +786,6 @@ fn run_check_normal_rr_from_resolved(
         dirs,
         planned_runs,
         cmd.package_path.is_none() && cmd.path.is_empty(),
-        None,
         output,
         json,
     )?;
@@ -803,14 +801,12 @@ fn run_check_normal_rr_from_resolved(
 /// end.
 ///
 /// The caller must hold the target-directory lock for a non-dry-run check.
-#[allow(clippy::too_many_arguments)]
 fn run_planned_checks(
     cli: &UniversalFlags,
     cmd: &CheckSubcommand,
     dirs: &PackageDirs,
     planned_runs: Vec<(rr_build::BuildMeta, rr_build::BuildInput)>,
     publish_metadata: bool,
-    metadata_filename: Option<&str>,
     output: &CommandOutput,
     json: Option<&mut CheckJsonAccumulator>,
 ) -> anyhow::Result<bool> {
@@ -851,7 +847,7 @@ fn run_planned_checks(
         // Generate all_pkgs.json for indirect dependency resolution
         rr_build::generate_all_pkgs_json(build_meta)?;
         if publish_metadata {
-            rr_build::generate_metadata(source_dir, build_meta, build_input, metadata_filename)?;
+            rr_build::generate_metadata(source_dir, build_meta, build_input)?;
         }
     }
     if publish_metadata {
@@ -862,7 +858,7 @@ fn run_planned_checks(
             .last()
             .expect("non-empty planned runs were checked above")
             .0;
-        rr_build::generate_metadata_selector(selected, metadata_filename)?;
+        rr_build::generate_metadata_selector(selected)?;
         rr_build::generate_metadata_index(planned_runs.iter().map(|(build_meta, _)| build_meta))?;
     }
 

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -193,7 +193,7 @@ pub(crate) fn run_doc_rr(
     // before executing the build
     rr_build::generate_all_pkgs_json(&build_meta)?;
     // Generate metadata for `moondoc`
-    rr_build::generate_metadata(source_dir, &build_meta, &build_graph, None)?;
+    rr_build::generate_metadata(source_dir, &build_meta, &build_graph)?;
 
     // Execute the build
     let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -833,22 +833,14 @@ pub fn plan_fmt(
 ///
 /// To ensure the correct paths are generated, `build_meta` should come from the
 /// same configuration used in [`plan_build`].
-///
-/// If the caller is from a single-file build, `single_file_filename` should
-/// be set to the filename (with extension) of the single file being built.
 #[instrument(level = Level::DEBUG, skip_all)]
 pub fn generate_metadata(
     source_dir: &Path,
     build_meta: &BuildMeta,
     build_input: &BuildInput,
-    single_file_filename: Option<&str>,
 ) -> anyhow::Result<()> {
     let layout = build_meta.artifact_paths.target_layout();
-    let scoped_metadata_file = if let Some(filename) = single_file_filename {
-        layout.standalone_packages_json_path(build_meta.target_backend(), filename)
-    } else {
-        layout.packages_json_path(build_meta.target_backend())
-    };
+    let scoped_metadata_file = layout.packages_json_path(build_meta.target_backend());
 
     let check_commands = collect_check_commands_by_output(build_input);
     let metadata = moonbuild_rupes_recta::metadata::gen_metadata_json(
@@ -864,10 +856,7 @@ pub fn generate_metadata(
 }
 
 /// Generate the universal `packages.json` selector for one scoped document.
-pub fn generate_metadata_selector(
-    build_meta: &BuildMeta,
-    single_file_filename: Option<&str>,
-) -> anyhow::Result<()> {
+pub fn generate_metadata_selector(build_meta: &BuildMeta) -> anyhow::Result<()> {
     let selector = moonutil::manifest::PackagesSelectorJSON {
         backend: build_meta.target_backend().to_string(),
         opt_level: build_meta.opt_level.as_str().to_string(),
@@ -875,11 +864,7 @@ pub fn generate_metadata_selector(
     let selector = serde_json::to_string_pretty(&selector)
         .context("Failed to serialize universal packages metadata")?;
     let layout = build_meta.artifact_paths.target_layout();
-    let metadata_file = if let Some(filename) = single_file_filename {
-        layout.standalone_packages_selector_path(filename)
-    } else {
-        layout.packages_selector_path()
-    };
+    let metadata_file = layout.packages_selector_path();
     write_metadata_if_changed(&metadata_file, &selector)
 }
 

--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -53,32 +53,37 @@ impl AsRef<Path> for TestDir {
 }
 
 fn packages_selector_path(dir: impl AsRef<Path>) -> PathBuf {
-    dir.as_ref().join("_build/packages.json")
+    target_packages_selector_path(dir.as_ref().join("_build"))
 }
 
 fn packages_index_path(dir: impl AsRef<Path>) -> PathBuf {
-    dir.as_ref().join("_build/index.json")
+    target_packages_index_path(dir.as_ref().join("_build"))
 }
 
 fn scoped_packages_json_path(dir: impl AsRef<Path>, backend: &str, profile: &str) -> PathBuf {
-    dir.as_ref()
-        .join(format!("_build/{backend}/{profile}/check/packages.json"))
+    target_scoped_packages_json_path(dir.as_ref().join("_build"), backend, profile)
 }
 
-fn standalone_packages_selector_path(dir: impl AsRef<Path>, source_filename: &str) -> PathBuf {
-    dir.as_ref()
-        .join(format!("_build/{source_filename}.packages.json"))
+fn target_packages_selector_path(target_dir: impl AsRef<Path>) -> PathBuf {
+    target_dir.as_ref().join("packages.json")
 }
 
-fn standalone_scoped_packages_json_path(
-    dir: impl AsRef<Path>,
+fn target_packages_index_path(target_dir: impl AsRef<Path>) -> PathBuf {
+    target_dir.as_ref().join("index.json")
+}
+
+fn target_scoped_packages_json_path(
+    target_dir: impl AsRef<Path>,
     backend: &str,
     profile: &str,
-    source_filename: &str,
 ) -> PathBuf {
-    dir.as_ref().join(format!(
-        "_build/{backend}/{profile}/check/{source_filename}.packages.json"
-    ))
+    target_dir
+        .as_ref()
+        .join(format!("{backend}/{profile}/check/packages.json"))
+}
+
+fn standalone_target_dir(dir: impl AsRef<Path>, source_filename: &str) -> PathBuf {
+    dir.as_ref().join("_build").join(source_filename)
 }
 
 pub fn moon_cmd(dir: &impl AsRef<Path>) -> snapbox::cmd::Command {

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -89,7 +89,7 @@ fn test_moon_help() {
               -C <DIR>
                       Change to DIR before doing anything else (must appear before the subcommand). Relative paths in other options and arguments are interpreted relative to DIR. Example: `moon -C a run .` runs the same as invoking `moon run .` from within `a`
                   --target-dir <TARGET_DIR>
-                      The target directory. Defaults to `<project-root>/_build`
+                      The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build/<file-name>` for a standalone file
               -q, --quiet
                       Suppress output
               -v, --verbose
@@ -176,10 +176,10 @@ native
         .stderr_eq("");
 
     assert!(
-        dir.join("_build/wasm/debug/build/single/single.wasm")
+        dir.join("_build/moonx_args.mbtx/wasm/debug/build/single/single.wasm")
             .is_file()
     );
-    assert!(!dir.join("_build/wasm-gc").exists());
+    assert!(!dir.join("_build/moonx_args.mbtx/wasm-gc").exists());
 }
 
 #[test]
@@ -1632,7 +1632,7 @@ fn test_moon_explain_without_flags_shows_guidance() {
               -h, --help                       Print help
 
             Common Options:
-                  --target-dir <TARGET_DIR>  The target directory. Defaults to `<project-root>/_build`
+                  --target-dir <TARGET_DIR>  The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build/<file-name>` for a standalone file
               -q, --quiet                    Suppress output
               -v, --verbose                  Increase verbosity
                   --trace                    Trace the execution of the program
@@ -1986,7 +1986,7 @@ fn test_moon_run_command_string_defaults_to_wasm() {
 
     assert!(stdout.contains("-target wasm"), "stdout: {stdout}");
     assert!(
-        stdout.contains("./_build/wasm/debug/build/single/single.core"),
+        stdout.contains("./_build/command.mbtx/wasm/debug/build/single/single.core"),
         "stdout: {stdout}"
     );
     assert!(!stdout.contains("-target wasm-gc"), "stdout: {stdout}");
@@ -2013,10 +2013,15 @@ fn test_moon_run_command_string_explicit_target_overrides_wasm_default() {
 
     assert!(stdout.contains("-target wasm-gc"), "stdout: {stdout}");
     assert!(
-        stdout.contains("'$MOONRUN_OVERRIDE' ./_build/wasm-gc/debug/build/single/single.wasm --"),
+        stdout.contains(
+            "'$MOONRUN_OVERRIDE' ./_build/command.mbtx/wasm-gc/debug/build/single/single.wasm --"
+        ),
         "stdout: {stdout}"
     );
-    assert!(!stdout.contains("./_build/wasm/debug/"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("./_build/command.mbtx/wasm/debug/"),
+        "stdout: {stdout}"
+    );
     assert!(!stdout.contains("-target native"), "stdout: {stdout}");
 }
 
@@ -2038,7 +2043,7 @@ fn test_moon_run_command_string_short_alias_c_defaults_to_wasm() {
 
     assert!(stdout.contains("-target wasm"), "stdout: {stdout}");
     assert!(
-        stdout.contains("./_build/wasm/debug/build/single/single.core"),
+        stdout.contains("./_build/command.mbtx/wasm/debug/build/single/single.core"),
         "stdout: {stdout}"
     );
     assert!(!stdout.contains("-target wasm-gc"), "stdout: {stdout}");

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -34,16 +34,16 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::Native),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/native/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target native -O0 -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/native/debug/build/single/single.core -main moon/test/single -o ./_build/native/debug/build/single/single.c -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native -O0
-            cc -o ./_build/native/debug/build/runtime-utf.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/utf.c'
-            cc -o ./_build/native/debug/build/runtime-sync_io.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/sync_io.c'
-            cc -o ./_build/native/debug/build/runtime-runtime.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/runtime.c'
-            cc -o ./_build/native/debug/build/runtime-env.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/env.c'
-            cc -o ./_build/native/debug/build/runtime-backtrace.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/backtrace.c'
-            [ARCHIVER] [CREATE_ARGS] ./_build/native/debug/build/libruntime[FINGER_PRINT].a ./_build/native/debug/build/runtime-backtrace.o ./_build/native/debug/build/runtime-env.o ./_build/native/debug/build/runtime-runtime.o ./_build/native/debug/build/runtime-sync_io.o ./_build/native/debug/build/runtime-utf.o
-            cc -o ./_build/native/debug/build/single/single.exe '-I$MOON_HOME/include' -fwrapv -fno-strict-aliasing -Og '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/libmoonbitrun.o' ./_build/native/debug/build/single/single.c ./_build/native/debug/build/libruntime[FINGER_PRINT].a -lm '$MOON_HOME/lib/libbacktrace.a'
-            ./_build/native/debug/build/single/single.exe
+            moonc build-package ./single.mbt -o ./_build/single.mbt/native/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target native -O0 -workspace-path . -all-pkgs ./_build/single.mbt/native/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/single.mbt/native/debug/build/single/single.core -main moon/test/single -o ./_build/single.mbt/native/debug/build/single/single.c -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native -O0
+            cc -o ./_build/single.mbt/native/debug/build/runtime-utf.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/utf.c'
+            cc -o ./_build/single.mbt/native/debug/build/runtime-sync_io.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/sync_io.c'
+            cc -o ./_build/single.mbt/native/debug/build/runtime-runtime.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/runtime.c'
+            cc -o ./_build/single.mbt/native/debug/build/runtime-env.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/env.c'
+            cc -o ./_build/single.mbt/native/debug/build/runtime-backtrace.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/backtrace.c'
+            [ARCHIVER] [CREATE_ARGS] ./_build/single.mbt/native/debug/build/libruntime[FINGER_PRINT].a ./_build/single.mbt/native/debug/build/runtime-backtrace.o ./_build/single.mbt/native/debug/build/runtime-env.o ./_build/single.mbt/native/debug/build/runtime-runtime.o ./_build/single.mbt/native/debug/build/runtime-sync_io.o ./_build/single.mbt/native/debug/build/runtime-utf.o
+            cc -o ./_build/single.mbt/native/debug/build/single/single.exe '-I$MOON_HOME/include' -fwrapv -fno-strict-aliasing -Og '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/libmoonbitrun.o' ./_build/single.mbt/native/debug/build/single/single.c ./_build/single.mbt/native/debug/build/libruntime[FINGER_PRINT].a -lm '$MOON_HOME/lib/libbacktrace.a'
+            ./_build/single.mbt/native/debug/build/single/single.exe
         "#]],
     );
 
@@ -64,16 +64,16 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::Native),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/native/release/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target native -workspace-path . -all-pkgs ./_build/native/release/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/native/release/build/single/single.core -main moon/test/single -o ./_build/native/release/build/single/single.c -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native
-            cc -o ./_build/native/release/build/runtime-utf.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/utf.c'
-            cc -o ./_build/native/release/build/runtime-sync_io.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/sync_io.c'
-            cc -o ./_build/native/release/build/runtime-runtime.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/runtime.c'
-            cc -o ./_build/native/release/build/runtime-env.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/env.c'
-            cc -o ./_build/native/release/build/runtime-backtrace.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/backtrace.c'
-            [ARCHIVER] [CREATE_ARGS] ./_build/native/release/build/libruntime[FINGER_PRINT].a ./_build/native/release/build/runtime-backtrace.o ./_build/native/release/build/runtime-env.o ./_build/native/release/build/runtime-runtime.o ./_build/native/release/build/runtime-sync_io.o ./_build/native/release/build/runtime-utf.o '$MOON_HOME/lib/moonbit_simdutf.o' '$MOON_HOME/lib/simdutf.o'
-            cc -o ./_build/native/release/build/single/single.exe '-I$MOON_HOME/include' -fwrapv -fno-strict-aliasing -O2 '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/libmoonbitrun.o' ./_build/native/release/build/single/single.c ./_build/native/release/build/libruntime[FINGER_PRINT].a -lm '$MOON_HOME/lib/libbacktrace.a'
-            ./_build/native/release/build/single/single.exe
+            moonc build-package ./single.mbt -o ./_build/single.mbt/native/release/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target native -workspace-path . -all-pkgs ./_build/single.mbt/native/release/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/single.mbt/native/release/build/single/single.core -main moon/test/single -o ./_build/single.mbt/native/release/build/single/single.c -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native
+            cc -o ./_build/single.mbt/native/release/build/runtime-utf.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/utf.c'
+            cc -o ./_build/single.mbt/native/release/build/runtime-sync_io.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/sync_io.c'
+            cc -o ./_build/single.mbt/native/release/build/runtime-runtime.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/runtime.c'
+            cc -o ./_build/single.mbt/native/release/build/runtime-env.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/env.c'
+            cc -o ./_build/single.mbt/native/release/build/runtime-backtrace.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/backtrace.c'
+            [ARCHIVER] [CREATE_ARGS] ./_build/single.mbt/native/release/build/libruntime[FINGER_PRINT].a ./_build/single.mbt/native/release/build/runtime-backtrace.o ./_build/single.mbt/native/release/build/runtime-env.o ./_build/single.mbt/native/release/build/runtime-runtime.o ./_build/single.mbt/native/release/build/runtime-sync_io.o ./_build/single.mbt/native/release/build/runtime-utf.o '$MOON_HOME/lib/moonbit_simdutf.o' '$MOON_HOME/lib/simdutf.o'
+            cc -o ./_build/single.mbt/native/release/build/single/single.exe '-I$MOON_HOME/include' -fwrapv -fno-strict-aliasing -O2 '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/libmoonbitrun.o' ./_build/single.mbt/native/release/build/single/single.c ./_build/single.mbt/native/release/build/libruntime[FINGER_PRINT].a -lm '$MOON_HOME/lib/libbacktrace.a'
+            ./_build/single.mbt/native/release/build/single/single.exe
         "#]],
     );
 
@@ -91,9 +91,9 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::Js),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/js/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/js/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/js/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/js/release/bundle/core.core' ./_build/js/debug/build/single/single.core -main moon/test/single -o ./_build/js/debug/build/single/single.js -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target js -g -O0 -source-map
-            node --enable-source-maps ./_build/js/debug/build/single/single.js
+            moonc build-package ./single.mbt -o ./_build/single.mbt/js/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/single.mbt/js/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/js/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/js/release/bundle/core.core' ./_build/single.mbt/js/debug/build/single/single.core -main moon/test/single -o ./_build/single.mbt/js/debug/build/single/single.js -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target js -g -O0 -source-map
+            node --enable-source-maps ./_build/single.mbt/js/debug/build/single/single.js
         "#]],
     );
 
@@ -104,9 +104,9 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::WasmGC),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/wasm-gc/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/wasm-gc/debug/build/single/single.core -main moon/test/single -o ./_build/wasm-gc/debug/build/single/single.wasm -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
-            '$MOONRUN_OVERRIDE' ./_build/wasm-gc/debug/build/single/single.wasm --
+            moonc build-package ./single.mbt -o ./_build/single.mbt/wasm-gc/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/single.mbt/wasm-gc/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/single.mbt/wasm-gc/debug/build/single/single.core -main moon/test/single -o ./_build/single.mbt/wasm-gc/debug/build/single/single.wasm -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
+            '$MOONRUN_OVERRIDE' ./_build/single.mbt/wasm-gc/debug/build/single/single.wasm --
         "#]],
     );
 
@@ -117,9 +117,9 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::Js),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/js/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/js/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/js/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/js/release/bundle/core.core' ./_build/js/debug/build/single/single.core -main moon/test/single -o ./_build/js/debug/build/single/single.js -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target js -g -O0 -source-map
-            node --enable-source-maps ./_build/js/debug/build/single/single.js
+            moonc build-package ./single.mbt -o ./_build/single.mbt/js/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/single.mbt/js/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/js/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/js/release/bundle/core.core' ./_build/single.mbt/js/debug/build/single/single.core -main moon/test/single -o ./_build/single.mbt/js/debug/build/single/single.js -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target js -g -O0 -source-map
+            node --enable-source-maps ./_build/single.mbt/js/debug/build/single/single.js
         "#]],
     );
 
@@ -130,11 +130,11 @@ fn test_moon_run_single_file_dry_run() {
     check(
         &output,
         expect![[r#"
-            {"artifacts_path":["$ROOT/a/b/_build/js/debug/build/single/single.js"]}
+            {"artifacts_path":["$ROOT/a/b/_build/single.mbt/js/debug/build/single/single.js"]}
         "#]],
     );
     assert!(
-        dir.join("a/b/_build/js/debug/build/single/single.js")
+        dir.join("a/b/_build/single.mbt/js/debug/build/single/single.js")
             .exists()
     );
 }
@@ -622,9 +622,9 @@ fn test_single_file_commands_work_with_workspace_disabled() {
         "#]],
     );
     assert!(!packages_selector_path(dir).exists());
-    let packages_selector = standalone_packages_selector_path(dir, "hello.mbt");
-    let scoped_pkg_json =
-        standalone_scoped_packages_json_path(dir, "wasm-gc", "debug", "hello.mbt");
+    let target_dir = standalone_target_dir(dir, "hello.mbt");
+    let packages_selector = target_packages_selector_path(&target_dir);
+    let scoped_pkg_json = target_scoped_packages_json_path(&target_dir, "wasm-gc", "debug");
     let packages_selector: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(packages_selector).unwrap()).unwrap();
     assert_eq!(
@@ -638,8 +638,10 @@ fn test_single_file_commands_work_with_workspace_disabled() {
         serde_json::from_str(&std::fs::read_to_string(scoped_pkg_json).unwrap()).unwrap();
     assert_eq!(scoped_pkg_json["backend"], serde_json::json!("wasm-gc"));
     assert_eq!(scoped_pkg_json["opt_level"], serde_json::json!("debug"));
-    let packages_index: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(packages_index_path(dir)).unwrap()).unwrap();
+    let packages_index: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(target_packages_index_path(&target_dir)).unwrap(),
+    )
+    .unwrap();
     assert_eq!(packages_index, serde_json::json!(["wasm-gc"]));
 
     check(
@@ -665,6 +667,36 @@ fn test_single_file_commands_work_with_workspace_disabled() {
 }
 
 #[test]
+fn test_single_files_use_isolated_target_directories() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let source = r#"fn main {
+  println("hello")
+}
+"#;
+    std::fs::write(dir.join("main.mbt"), source).unwrap();
+    std::fs::write(dir.join("main.mbtx"), source).unwrap();
+
+    for filename in ["main.mbt", "main.mbtx"] {
+        moon_cmd(&dir)
+            .env(MOON_WORK_ENV, "off")
+            .args(["check", filename, "--target", "wasm-gc"])
+            .assert()
+            .success();
+
+        let target_dir = standalone_target_dir(dir, filename);
+        assert!(target_dir.join(".moon_db").is_file());
+        assert!(target_packages_selector_path(&target_dir).is_file());
+    }
+
+    assert!(!dir.join("_build/.moon_db").exists());
+    assert_ne!(
+        standalone_target_dir(dir, "main.mbt"),
+        standalone_target_dir(dir, "main.mbtx")
+    );
+}
+
+#[test]
 fn test_single_file_check_accepts_multiple_targets() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path();
@@ -684,13 +716,16 @@ fn test_single_file_check_accepts_multiple_targets() {
         .assert()
         .success();
 
-    assert!(standalone_scoped_packages_json_path(dir, "wasm-gc", "debug", "hello.mbt").exists());
-    assert!(standalone_scoped_packages_json_path(dir, "js", "debug", "hello.mbt").exists());
-    let packages_index: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(packages_index_path(dir)).unwrap()).unwrap();
+    let target_dir = standalone_target_dir(dir, "hello.mbt");
+    assert!(target_scoped_packages_json_path(&target_dir, "wasm-gc", "debug").exists());
+    assert!(target_scoped_packages_json_path(&target_dir, "js", "debug").exists());
+    let packages_index: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(target_packages_index_path(&target_dir)).unwrap(),
+    )
+    .unwrap();
     assert_eq!(packages_index, serde_json::json!(["wasm-gc", "js"]));
     let selector: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(standalone_packages_selector_path(dir, "hello.mbt")).unwrap(),
+        &std::fs::read_to_string(target_packages_selector_path(&target_dir)).unwrap(),
     )
     .unwrap();
     assert_eq!(selector["backend"], "js");

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -243,7 +243,10 @@ fn test_single_file_mbtx_build() {
         "stdout: {stdout}"
     );
     assert!(stdout.contains("moonc link-core"), "stdout: {stdout}");
-    assert!(stdout.contains("_build/wasm/"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("_build/moonx_args.mbtx/wasm/"),
+        "stdout: {stdout}"
+    );
     assert!(!stdout.contains("moonrun"), "stdout: {stdout}");
 }
 
@@ -253,10 +256,13 @@ fn test_single_file_mbtx_build_accepts_multiple_targets() {
     let _ = get_stdout(&dir, ["build", "moonx_args.mbtx", "--target", "wasm,js"]);
 
     assert!(
-        dir.join("_build/wasm/debug/build/single/single.wasm")
+        dir.join("_build/moonx_args.mbtx/wasm/debug/build/single/single.wasm")
             .is_file()
     );
-    assert!(dir.join("_build/js/debug/build/single/single.js").is_file());
+    assert!(
+        dir.join("_build/moonx_args.mbtx/js/debug/build/single/single.js")
+            .is_file()
+    );
 }
 
 #[test]
@@ -297,8 +303,8 @@ fn test_project_mbtx_check_uses_standalone_input() {
         .assert()
         .success();
 
-    let metadata =
-        standalone_scoped_packages_json_path(dir.join("A"), "wasm", "debug", "script.mbtx");
+    let target_dir = standalone_target_dir(dir.join("A"), "script.mbtx");
+    let metadata = target_scoped_packages_json_path(target_dir, "wasm", "debug");
     assert!(
         metadata.is_file(),
         "standalone check should publish file-scoped package metadata"
@@ -403,9 +409,9 @@ fn test_single_file_mbtx_reuses_dependency_graph_after_script_change() {
     let stdout = get_stdout(&dir, args);
     assert!(stdout.contains("hello"));
 
-    let build_dir = dir.join("_build/wasm/debug/build");
+    let build_dir = dir.join("_build/import_ok.mbtx/wasm/debug/build");
     let dependency_core = build_dir.join(".mooncakes/moonbitlang/x/stack/stack.core");
-    let n2_db = dir.join("_build/.moon_db");
+    let n2_db = dir.join("_build/import_ok.mbtx/.moon_db");
     assert!(dependency_core.is_file());
     assert!(n2_db.is_file());
 

--- a/crates/moon/tests/test_cases/value_tracing/mod.rs
+++ b/crates/moon/tests/test_cases/value_tracing/mod.rs
@@ -180,9 +180,9 @@ fn test_tracing_value_for_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::WasmGC),
         expect![[r#"
-            moonc build-package ./main.mbt -o ./_build/wasm-gc/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target wasm-gc -g -O0 -source-map -enable-value-tracing -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/wasm-gc/debug/build/single/single.core -main moon/test/single -o ./_build/wasm-gc/debug/build/single/single.wasm -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
-            '$MOONRUN_OVERRIDE' ./_build/wasm-gc/debug/build/single/single.wasm --
+            moonc build-package ./main.mbt -o ./_build/main.mbt/wasm-gc/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target wasm-gc -g -O0 -source-map -enable-value-tracing -workspace-path . -all-pkgs ./_build/main.mbt/wasm-gc/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/main.mbt/wasm-gc/debug/build/single/single.core -main moon/test/single -o ./_build/main.mbt/wasm-gc/debug/build/single/single.wasm -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
+            '$MOONRUN_OVERRIDE' ./_build/main.mbt/wasm-gc/debug/build/single/single.wasm --
         "#]],
     );
 }

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -149,7 +149,8 @@ impl TargetLayoutMode {
 /// Target folder layout for generated artifacts.
 #[derive(Clone, Debug)]
 pub struct TargetLayout {
-    /// The base target directory, usually `<project-root>/_build`.
+    /// The base target directory, usually `<project-root>/_build` or
+    /// `<source-dir>/_build/<file-name>` for a standalone file.
     target_base_dir: PathBuf,
     mode: TargetLayoutMode,
     /// The optimization level, debug or release.
@@ -597,7 +598,7 @@ impl TargetLayout {
 
     /// Returns the universal `packages.json` selector path.
     pub fn packages_selector_path(&self) -> PathBuf {
-        packages_metadata_path(self.target_base_dir.clone(), None)
+        self.target_base_dir.join(PACKAGES_JSON)
     }
 
     /// Returns the backend inventory path shared by package metadata consumers.
@@ -605,25 +606,9 @@ impl TargetLayout {
         self.target_base_dir.join(PACKAGES_INDEX_JSON)
     }
 
-    /// Returns the universal metadata selector path for a standalone source
-    /// file.
-    pub fn standalone_packages_selector_path(&self, source_filename: &str) -> PathBuf {
-        packages_metadata_path(self.target_base_dir.clone(), Some(source_filename))
-    }
-
     /// Returns the backend/profile/run-mode-scoped `packages.json` path.
     pub fn packages_json_path(&self, backend: TargetBackend) -> PathBuf {
-        packages_metadata_path(self.run_mode_dir(backend), None)
-    }
-
-    /// Returns the backend/profile/run-mode-scoped metadata path for a
-    /// standalone source file.
-    pub fn standalone_packages_json_path(
-        &self,
-        backend: TargetBackend,
-        source_filename: &str,
-    ) -> PathBuf {
-        packages_metadata_path(self.run_mode_dir(backend), Some(source_filename))
+        self.run_mode_dir(backend).join(PACKAGES_JSON)
     }
 
     /// Returns the n2 database shared by executions in this target directory.
@@ -634,14 +619,6 @@ impl TargetLayout {
     pub fn n2_db_path(&self) -> PathBuf {
         self.target_base_dir.join(".moon_db")
     }
-}
-
-fn packages_metadata_path(mut dir: PathBuf, source_filename: Option<&str>) -> PathBuf {
-    match source_filename {
-        Some(source_filename) => dir.push(format!("{source_filename}.{PACKAGES_JSON}")),
-        None => dir.push(PACKAGES_JSON),
-    }
-    dir
 }
 
 #[derive(Clone, Debug)]
@@ -1736,16 +1713,8 @@ mod tests {
             PathBuf::from("_build/index.json")
         );
         assert_eq!(
-            layout.standalone_packages_selector_path("main.mbt"),
-            PathBuf::from("_build/main.mbt.packages.json")
-        );
-        assert_eq!(
             layout.packages_json_path(TargetBackend::WasmGC),
             PathBuf::from("_build/wasm-gc/debug/check/packages.json")
-        );
-        assert_eq!(
-            layout.standalone_packages_json_path(TargetBackend::WasmGC, "main.mbt"),
-            PathBuf::from("_build/wasm-gc/debug/check/main.mbt.packages.json")
         );
     }
 

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -76,7 +76,8 @@ pub struct SourceTargetDirs {
     #[arg(short = 'C', value_name = "DIR")]
     pub cwd: Option<PathBuf>,
 
-    /// The target directory. Defaults to `<project-root>/_build`.
+    /// The target directory. Defaults to `<project-root>/_build`, or
+    /// `<source-dir>/_build/<file-name>` for a standalone file.
     #[clap(long, global = true)]
     pub target_dir: Option<PathBuf>,
 }
@@ -150,7 +151,19 @@ impl SourceTargetDirs {
             .context("file path must have a parent directory")
             .map(Path::to_path_buf)
             .map_err(PackageDirsError::from)?;
+        // Keep the complete filename so supported source extensions with the
+        // same stem cannot share build state.
+        let file_name = file_path
+            .file_name()
+            .context("file path must have a file name")
+            .map_err(PackageDirsError::from)?;
         let package_dirs = self.source_root_package_dirs(source_dir)?;
+        let target_dir = prepare_target_dir(package_dirs.target_dir.join(file_name))?;
+        let package_dirs = PackageDirs {
+            mooncake_bin_dir: target_dir.join(MOON_BIN_DIR),
+            target_dir,
+            ..package_dirs
+        };
         Ok(SingleFilePackageDirs {
             file_path,
             package_dirs,
@@ -191,6 +204,10 @@ fn resolve_target_dir(
     let target_dir = configured_target_dir
         .map(Path::to_path_buf)
         .unwrap_or_else(|| project_root.join(BUILD_DIR));
+    prepare_target_dir(target_dir)
+}
+
+fn prepare_target_dir(target_dir: PathBuf) -> Result<PathBuf, PackageDirsError> {
     if !target_dir.exists() {
         std::fs::create_dir_all(&target_dir)
             .context("failed to create target directory")
@@ -812,6 +829,62 @@ mod tests {
         assert_eq!(
             dirs.mooncake_bin_dir,
             canonical(project.path().join("tmp-target")).join(MOON_BIN_DIR)
+        );
+    }
+
+    #[test]
+    fn single_file_package_dirs_scope_target_to_complete_filename() {
+        let project = tempfile::tempdir().expect("create test project");
+        write_file(&project.path().join("first.mbt"), "fn main {}\n");
+        write_file(&project.path().join("second.mbtx"), "fn main {}\n");
+        let source_target_dirs = SourceTargetDirs {
+            cwd: None,
+            target_dir: None,
+        };
+
+        let first = source_target_dirs
+            .single_file_package_dirs(project.path().join("first.mbt"))
+            .unwrap();
+        let second = source_target_dirs
+            .single_file_package_dirs(project.path().join("second.mbtx"))
+            .unwrap();
+
+        assert_eq!(
+            first.package_dirs.target_dir,
+            canonical(project.path().join("_build/first.mbt"))
+        );
+        assert_eq!(
+            second.package_dirs.target_dir,
+            canonical(project.path().join("_build/second.mbtx"))
+        );
+        assert_ne!(
+            first.package_dirs.target_dir,
+            second.package_dirs.target_dir
+        );
+    }
+
+    #[test]
+    fn single_file_package_dirs_scope_configured_target_to_filename() {
+        let project = tempfile::tempdir().expect("create test project");
+        write_file(
+            &project.path().join("main.mbt.md"),
+            "```mbt\nfn main {}\n```\n",
+        );
+
+        let dirs = SourceTargetDirs {
+            cwd: None,
+            target_dir: Some(project.path().join("target")),
+        }
+        .single_file_package_dirs(project.path().join("main.mbt.md"))
+        .unwrap();
+
+        assert_eq!(
+            dirs.package_dirs.target_dir,
+            canonical(project.path().join("target/main.mbt.md"))
+        );
+        assert_eq!(
+            dirs.package_dirs.mooncake_bin_dir,
+            dirs.package_dirs.target_dir.join(MOON_BIN_DIR)
         );
     }
 

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -57,6 +57,10 @@ pub enum PackageDirsError {
     WorkspaceDisabledNotInModule(PathBuf),
     #[error("pinned workspace `{workspace}` from MOON_WORK does not apply to module `{module}`")]
     PinnedWorkspaceDoesNotApply { workspace: PathBuf, module: PathBuf },
+    #[error(
+        "target directory `{0}` exists and is not a directory; choose a different `--target-dir`"
+    )]
+    TargetDirNotDirectory(PathBuf),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -208,7 +212,11 @@ fn resolve_target_dir(
 }
 
 fn prepare_target_dir(target_dir: PathBuf) -> Result<PathBuf, PackageDirsError> {
-    if !target_dir.exists() {
+    if target_dir.exists() {
+        if !target_dir.is_dir() {
+            return Err(PackageDirsError::TargetDirNotDirectory(target_dir));
+        }
+    } else {
         std::fs::create_dir_all(&target_dir)
             .context("failed to create target directory")
             .map_err(PackageDirsError::from)?;
@@ -886,6 +894,25 @@ mod tests {
             dirs.package_dirs.mooncake_bin_dir,
             dirs.package_dirs.target_dir.join(MOON_BIN_DIR)
         );
+    }
+
+    #[test]
+    fn single_file_package_dirs_reject_target_aliasing_source_file() {
+        let project = tempfile::tempdir().expect("create test project");
+        let source_file = project.path().join("main.mbtx");
+        write_file(&source_file, "fn main {}\n");
+
+        let result = SourceTargetDirs {
+            cwd: None,
+            target_dir: Some(project.path().to_path_buf()),
+        }
+        .single_file_package_dirs(&source_file);
+
+        assert!(matches!(
+            result,
+            Err(PackageDirsError::TargetDirNotDirectory(path))
+                if path == canonical(source_file)
+        ));
     }
 
     #[test]

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -192,6 +192,13 @@ forward instead of letting later phases infer it again. In particular:
 - package and module directories come from discovery results, not from later
   path guessing.
 
+Standalone-file commands scope this target directory by the input's complete
+filename, including its extension. The default is
+`<source-dir>/_build/<filename>`; an explicit `--target-dir <dir>` produces
+`<dir>/<filename>`. This keeps the synthetic package artifacts, metadata,
+dependency binaries, lock, and n2 database for different files from
+overlapping.
+
 Source directory, `.mooncakes` directory, target directory, and optional project
 manifest path are user/config facts from project discovery. The synced
 dependency result is derived data: it contains the resolved module
@@ -646,13 +653,13 @@ and conditional metadata for all package files. This first migration step only
 relocates that document behind the selector; backend/profile projection and
 removal of redundant legacy fields are deferred to a follow-up change.
 
-Standalone-file checks similarly publish their selector and scoped document,
-and replace the shared backend index:
+Standalone-file checks publish the same relative metadata layout within their
+filename-scoped target directory:
 
 ```text
-_build/<filename>.packages.json
-_build/index.json
-_build/<backend>/<profile>/check/<filename>.packages.json
+_build/<filename>/packages.json
+_build/<filename>/index.json
+_build/<filename>/<backend>/<profile>/check/packages.json
 ```
 
 Project checks without a package or path selector publish metadata; focused

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -195,9 +195,12 @@ forward instead of letting later phases infer it again. In particular:
 Standalone-file commands scope this target directory by the input's complete
 filename, including its extension. The default is
 `<source-dir>/_build/<filename>`; an explicit `--target-dir <dir>` produces
-`<dir>/<filename>`. This keeps the synthetic package artifacts, metadata,
-dependency binaries, lock, and n2 database for different files from
-overlapping.
+`<dir>/<filename>`. The source-local default separates files in different
+source directories, while the complete filename separates differently named
+files within one target root. Callers that reuse an explicit target root for
+files with the same complete filename also reuse their synthetic package
+artifacts, metadata, dependency binaries, lock, and n2 database; they must
+choose distinct target roots when that isolation is required.
 
 Source directory, `.mooncakes` directory, target directory, and optional project
 manifest path are user/config facts from project discovery. The synced

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -37,6 +37,10 @@ extension discovered in ordinary packages.
 standalone representation, even when the file is located under an ordinary
 package root. Each command accepts one standalone `.mbtx` path and supports
 single- and multi-backend target selection; watch mode remains project-only.
+All standalone-file commands use `<source-dir>/_build/<filename>` as their
+default target directory, including the complete extension in `<filename>`, so
+different inputs do not share synthetic package artifacts or incremental build
+state. With `--target-dir <dir>`, the target directory is `<dir>/<filename>`.
 
 ### Build targets
 

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -39,8 +39,11 @@ package root. Each command accepts one standalone `.mbtx` path and supports
 single- and multi-backend target selection; watch mode remains project-only.
 All standalone-file commands use `<source-dir>/_build/<filename>` as their
 default target directory, including the complete extension in `<filename>`, so
-different inputs do not share synthetic package artifacts or incremental build
-state. With `--target-dir <dir>`, the target directory is `<dir>/<filename>`.
+differently named inputs in one source directory do not share synthetic package
+artifacts or incremental build state. With `--target-dir <dir>`, the target
+directory is `<dir>/<filename>`; the option relocates the target root without
+adding source-path identity, so callers are responsible for using distinct
+target roots for equal filenames from different source directories.
 
 ### Build targets
 


### PR DESCRIPTION
## Why

Standalone-file builds currently share one target base, so artifacts and incremental state from different inputs can overlap.

## What changed

- Scope standalone targets to _build/<complete filename>/, or <target-dir>/<complete filename> when configured.
- Derive metadata, n2 state, locks, dependency binaries, and artifacts from that target directory.
- Remove redundant standalone metadata path variants and update behavioral references and coverage.

## Why this is correct

PackageDirs remains the authoritative directory source. Selecting the filename-scoped target once means every downstream path uses the same isolated base without passing filenames through unrelated APIs. Complete filenames preserve isolation between inputs such as main.mbt and main.mbtx.

## Scope

The change is limited to standalone-file directory selection and paths derived from it; project builds retain their existing target layout.