### PR TITLE
support import all (`*` alias) in mbtx/moon.pkg

### DIFF
--- a/crates/moon/tests/test_cases/moon_test_single_file.in/import_all_alias.mbtx
+++ b/crates/moon/tests/test_cases/moon_test_single_file.in/import_all_alias.mbtx
@@ -1,0 +1,7 @@
+import {
+  "moonbitlang/x@0.4.38/stack" *,
+}
+
+fn main {
+  println("hello")
+}

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -469,10 +469,7 @@ fn test_single_file_mbtx_dry_run_preserves_import_all_alias() {
         .find(|line| line.contains("-pkg moon/test/single "))
         .expect("dry-run should contain the synthetic package build");
 
-    assert!(
-        command.contains("-i .mooncakes/moonbitlang/x/stack/stack.mi:*"),
-        "command: {command}"
-    );
+    assert!(command.contains("stack/stack.mi:*"), "command: {command}");
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -461,6 +461,21 @@ fn test_single_file_mbtx_builds_original_source() {
 }
 
 #[test]
+fn test_single_file_mbtx_dry_run_preserves_import_all_alias() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let stdout = get_stdout(&dir, ["run", "import_all_alias.mbtx", "--dry-run"]);
+    let command = stdout
+        .lines()
+        .find(|line| line.contains("-pkg moon/test/single "))
+        .expect("dry-run should contain the synthetic package build");
+
+    assert!(
+        command.contains("-i .mooncakes/moonbitlang/x/stack/stack.mi:*"),
+        "command: {command}"
+    );
+}
+
+#[test]
 fn test_single_file_check_rejects_patch_file() {
     let dir = TestDir::new("moon_test_single_file.in");
 

--- a/crates/moonbuild-rupes-recta/src/mbtx.rs
+++ b/crates/moonbuild-rupes-recta/src/mbtx.rs
@@ -274,6 +274,27 @@ mod tests {
     }
 
     #[test]
+    fn parse_mbtx_imports_supports_import_all_alias() {
+        let input = r#"import {
+  "moonbitlang/x@0.4.38/stack" *,
+}
+
+        fn main {}
+"#;
+        let imports = parse_imports_from_source(input).expect("import should decode");
+        assert_eq!(imports.imports.len(), 1);
+        assert_eq!(imports.imports[0].get_path(), "moonbitlang/x/stack");
+        assert!(imports.deps.contains_key("moonbitlang/x"));
+        assert!(matches!(
+            &imports.imports[0],
+            Import::Alias {
+                alias: Some(alias),
+                ..
+            } if alias == "*"
+        ));
+    }
+
+    #[test]
     fn extract_mbtx_import_source_returns_none_without_import() {
         let input = "fn main { println(\"ok\") }\n";
         assert_eq!(extract_mbtx_import_source(input), None);

--- a/crates/moonutil/src/moon_pkg/lexer.rs
+++ b/crates/moonutil/src/moon_pkg/lexer.rs
@@ -58,6 +58,8 @@ pub enum Token {
     RPAREN(Loc),
     #[token(";", with_span)]
     SEMI(Loc),
+    #[token("*", with_span)]
+    STAR(Loc),
     #[token("true", with_span)]
     TRUE(Loc),
     #[token("false", with_span)]
@@ -180,6 +182,7 @@ pub enum TokenKind {
     LPAREN,
     RPAREN,
     SEMI,
+    STAR,
     TRUE,
     FALSE,
     FOR,
@@ -205,6 +208,7 @@ impl Token {
             | Token::LPAREN(r)
             | Token::RPAREN(r)
             | Token::SEMI(r)
+            | Token::STAR(r)
             | Token::TRUE(r)
             | Token::FALSE(r)
             | Token::FOR(r)
@@ -229,6 +233,7 @@ impl Token {
             Token::LPAREN(_) => TokenKind::LPAREN,
             Token::RPAREN(_) => TokenKind::RPAREN,
             Token::SEMI(_) => TokenKind::SEMI,
+            Token::STAR(_) => TokenKind::STAR,
             Token::TRUE(_) => TokenKind::TRUE,
             Token::FALSE(_) => TokenKind::FALSE,
             Token::FOR(_) => TokenKind::FOR,
@@ -256,6 +261,7 @@ impl Display for Token {
             Token::LPAREN(_) => write!(f, "("),
             Token::RPAREN(_) => write!(f, ")"),
             Token::SEMI(_) => write!(f, ";"),
+            Token::STAR(_) => write!(f, "*"),
             Token::TRUE(_) => write!(f, "true"),
             Token::FALSE(_) => write!(f, "false"),
             Token::FOR(_) => write!(f, "for"),
@@ -737,6 +743,12 @@ fn tokenize_package_name_with_dash() {
         &tokens[3],
         Token::PACKAGENAME((_, alias)) if alias == "pkg-A"
     ));
+}
+
+#[test]
+fn tokenize_import_all_alias() {
+    let tokens = tokenize(r#"import { "path/to/pkg" * }"#).unwrap();
+    assert!(matches!(&tokens[3], Token::STAR(_)));
 }
 
 #[test]

--- a/crates/moonutil/src/moon_pkg/parser.rs
+++ b/crates/moonutil/src/moon_pkg/parser.rs
@@ -284,6 +284,10 @@ impl Parser {
                         s.skip();
                         Some(alias)
                     }
+                    Token::STAR(_) => {
+                        s.skip();
+                        Some("*".to_string())
+                    }
                     _ => None,
                 };
                 Ok(match alias {
@@ -496,6 +500,30 @@ import {
             {
                 "path": "path/to/pkg",
                 "alias": "pkg-A"
+            }
+        ])
+    );
+}
+
+#[test]
+fn parse_import_all_alias() {
+    let source = r#"
+import {
+  "path/to/pkg" *,
+}
+    "#;
+
+    let tokens = tokenize(source).unwrap();
+    let ast = Parser::parse(tokens).unwrap();
+
+    assert_eq!(ast.entries.len(), 1);
+    assert_eq!(ast.entries[0].0, "import");
+    assert_eq!(
+        ast.entries[0].1,
+        json!([
+            {
+                "path": "path/to/pkg",
+                "alias": "*"
             }
         ])
     );


### PR DESCRIPTION
We plan to add a new feature to `.mbtx`: the user can write `@pkg/full/path *` to implicitly import all definitions from the package for convenience. This feature is mainly implemented in `moonc`, for `moon` the work is basically accept `*` in the syntax and pass it as-is to `moonc`.

`moon.pkg` parser also support this syntax, but `moonc` will reject use of import-all in normal build currently.

Verified locally on latest compiler with `*` support, the complete `moon run xxx.mbtx` pipeline works with import all.