### PR TITLE
fix(moon.pkg): accept large integer literals

### DIFF
--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -43,6 +43,9 @@ fn test_moon_pkg() {
               cwd: .
         "#]],
     );
+
+    let output = get_stdout(&dir, ["build", "--target", "wasm", "--dry-run"]);
+    assert!(output.contains("-heap-start-address 2214592512"));
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/moon_pkg.in/main/moon.pkg
+++ b/crates/moon/tests/test_cases/moon_pkg.in/main/moon.pkg
@@ -3,8 +3,12 @@ import {
 }
 
 options(
-  "is-main": true 
+  "is-main": true,
+  link: {
+    "wasm": {
+      "heap-start-address": 2214592512,
+    },
+  },
 )
-
 
 

--- a/crates/moonutil/src/moon_pkg/lexer.rs
+++ b/crates/moonutil/src/moon_pkg/lexer.rs
@@ -68,8 +68,8 @@ pub enum Token {
     FOR(Loc),
     #[regex(r#""([^"\\]|\\.)*""#, with_string)]
     STRING((Loc, String)),
-    #[regex(r"-?[0-9]+", with_int)]
-    INT((Loc, i32)),
+    #[regex(r"-?[0-9]+", with_lexeme)]
+    INT((Loc, String)),
     #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*", with_lexeme)]
     LIDENT((Loc, String)),
     #[token("as", with_span)]
@@ -112,13 +112,6 @@ fn with_lexeme<'a>(lex: &mut Lexer<'a, Token>) -> (Loc, String) {
     let loc = get_loc(lex);
     let lexme = s.to_string();
     (loc, lexme)
-}
-
-fn with_int<'a>(lex: &mut Lexer<'a, Token>) -> (Loc, i32) {
-    let s = lex.slice();
-    let loc = get_loc(lex);
-    let i = s.parse::<i32>().unwrap(); // Safe because regex ensures valid integer
-    (loc, i)
 }
 
 fn with_string<'a>(lex: &mut Lexer<'a, Token>) -> Result<(Loc, String), ()> {
@@ -916,4 +909,13 @@ fn test_escape_sequences() {
         )
     "#]]
     .assert_debug_eq(&tokens);
+}
+
+#[test]
+fn tokenize_preserves_integer_lexemes() {
+    let tokens = tokenize("18446744073709551616").unwrap();
+    assert!(matches!(
+        &tokens[0],
+        Token::INT((_, value)) if value == "18446744073709551616"
+    ));
 }

--- a/crates/moonutil/src/moon_pkg/parser.rs
+++ b/crates/moonutil/src/moon_pkg/parser.rs
@@ -22,7 +22,7 @@ use crate::moon_pkg::{lexer, syntax::Dsl};
 
 use super::lexer::{Token, TokenKind};
 use anyhow::anyhow;
-use serde_json_lenient::{Map, Value, json};
+use serde_json_lenient::{Map, Number, Value, json};
 use std::{cell::Cell, fmt, ops::Range};
 
 /// Parser for MoonPkg DSL
@@ -36,6 +36,7 @@ pub struct Parser {
 #[derive(Debug)]
 pub enum ParseError {
     UnexpectedToken(Token),
+    IntegerOutOfRange { literal: String, loc: lexer::Loc },
     LexingError(Range<usize>),
 }
 
@@ -48,6 +49,13 @@ impl fmt::Display for ParseError {
                     f,
                     "unexpected token {} at line {}, column {}",
                     token, loc.start.line, loc.start.column
+                )
+            }
+            ParseError::IntegerOutOfRange { literal, loc } => {
+                write!(
+                    f,
+                    "integer literal `{literal}` is out of range at line {}, column {}",
+                    loc.start.line, loc.start.column
                 )
             }
             ParseError::LexingError(range) => {
@@ -181,6 +189,24 @@ impl Parser {
         Ok(Value::Object(Map::from_iter(elems)))
     }
 
+    fn parse_integer(&self) -> Result<Value, ParseError> {
+        let Token::INT((loc, literal)) = self.peek() else {
+            return Err(ParseError::UnexpectedToken(self.peek().clone()));
+        };
+        // TODO: Replace this JSON-number bridge with a DSL integer node once
+        // package conversion no longer deserializes DSL values through `MoonPkgJSON`.
+        let number = literal
+            .parse::<i64>()
+            .map(Number::from)
+            .or_else(|_| literal.parse::<u64>().map(Number::from))
+            .map_err(|_| ParseError::IntegerOutOfRange {
+                literal: literal.clone(),
+                loc: loc.clone(),
+            })?;
+        self.skip();
+        Ok(Value::Number(number))
+    }
+
     fn parse_expr(&self) -> Result<Value, ParseError> {
         match self.peek() {
             Token::LBRACKET(_) => self.parse_array(),
@@ -197,10 +223,7 @@ impl Parser {
                 self.skip();
                 Ok(json!(s))
             }
-            Token::INT((_, i)) => {
-                self.skip();
-                Ok(json!(i))
-            }
+            Token::INT(_) => self.parse_integer(),
             other => Err(ParseError::UnexpectedToken(other.clone())),
         }
     }
@@ -353,10 +376,13 @@ impl Parser {
     }
 }
 
-/// Parse MoonPkg DSL input string into serde_json_lenient::Value
+/// Parse MoonPkg DSL input into its current JSON-shaped compatibility model.
+///
+/// Package conversion reuses the typed `MoonPkgJSON` deserializer until the DSL
+/// has its own typed AST, so expressions are lowered to JSON values here.
 pub fn parse(input: &str) -> anyhow::Result<Dsl> {
     let tokens = lexer::tokenize(input)?;
-    Parser::parse(tokens).map_err(|e| anyhow!("Parsing error: {:?}", e))
+    Parser::parse(tokens).map_err(|e| anyhow!("Parsing error: {e}"))
 }
 
 #[test]
@@ -561,4 +587,14 @@ import "wbtest" {
         }
     "#]]
     .assert_debug_eq(&ast);
+}
+
+#[test]
+fn parse_reports_integer_overflow() {
+    let literal = format!("1{}", "0".repeat(400));
+    let error = parse(&format!("options(value: {literal})")).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        format!("Parsing error: integer literal `{literal}` is out of range at line 1, column 16")
+    );
 }

--- a/crates/moonutil/src/package.rs
+++ b/crates/moonutil/src/package.rs
@@ -1081,6 +1081,45 @@ fn convert_test_pkg_json(
 }
 
 #[test]
+fn convert_pkg_dsl_supports_u32_values() {
+    let json = crate::moon_pkg::parse(
+        r#"
+options(
+  link: { "wasm": { "heap-start-address": 2214592512 } },
+)
+"#,
+    )
+    .unwrap();
+    let (pkg, _) = convert_test_pkg_dsl(json, false).unwrap();
+
+    assert_eq!(
+        pkg.link.unwrap().wasm.unwrap().heap_start_address,
+        Some(2_214_592_512)
+    );
+}
+
+#[test]
+fn convert_pkg_dsl_supports_leading_zero_integers() {
+    let json = crate::moon_pkg::parse(r#"options("max-concurrent-tests": 08)"#).unwrap();
+    let (pkg, _) = convert_test_pkg_dsl(json, false).unwrap();
+
+    assert_eq!(pkg.max_concurrent_tests, Some(8));
+}
+
+#[test]
+fn convert_pkg_dsl_rejects_values_above_u32() {
+    let json = crate::moon_pkg::parse(
+        r#"
+options(
+  link: { "wasm": { "heap-start-address": 4294967297 } },
+)
+"#,
+    )
+    .unwrap();
+    assert!(convert_test_pkg_dsl(json, false).is_err());
+}
+
+#[test]
 fn convert_pkg_dsl_supports_supported_targets_shorthand() {
     let json = crate::moon_pkg::parse(r#"supported_targets = "js""#).unwrap();
     let (pkg, decl_kind) = convert_test_pkg_dsl(json, true).unwrap();


### PR DESCRIPTION
## Why

`moon.pkg` converted integer tokens to `i32` in the lexer and unwrapped parsing, so valid `u32` configuration values such as a Wasm `heap-start-address` above 2 GiB crashed Moon after the JSON-to-DSL migration.

## What changed

- Keep integer tokens as raw lexemes and interpret them only while lowering the DSL into its current JSON-shaped compatibility model.
- Return a located parse error when a numeric literal cannot be represented.
- Cover the reported large heap address through package conversion and Wasm command generation, while retaining rejection of values outside the field-specific `u32` range.

## Why this is correct

Lexing now recognizes syntax without assigning field semantics. The typed package model remains responsible for field constraints, so `2214592512` reaches the Wasm linker while values above `u32::MAX` are rejected.

## Scope

The change is limited to integer handling in `moon.pkg` and its regression coverage. It does not alter `BoolOrLink` deserialization or unrelated configuration behavior.

Fixes #2158