### PR TITLE
fix: restrict unstable prebuild to native backends

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -600,14 +600,17 @@ pub(crate) fn plan_resolved_build_from_intent(
     let target_dir = preconfig.target_dir.clone();
     info!("User intent calculated: {:?}", intent.intents);
 
-    let prebuild_config = if preconfig.action == RunMode::Check {
-        info!("Skipping prebuild configuration for check run mode");
-        None
-    } else {
-        info!("Running prebuild configuration");
-        let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
-        Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
-    };
+    // Module-level configuration discovers native toolchains and flags; other
+    // backends do not need to execute these scripts.
+    let prebuild_config =
+        if preconfig.action == RunMode::Check || !planning_context.target_backend.is_native() {
+            info!("Skipping prebuild configuration for check or non-native backend");
+            None
+        } else {
+            info!("Running prebuild configuration");
+            let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
+            Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
+        };
 
     info!("Expanding user intents to requested artifacts");
     let requested_artifacts =
@@ -698,14 +701,17 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
     let target_dir = preconfig.target_dir.clone();
     info!("Standalone user intent calculated: {:?}", intent.intents);
 
-    let prebuild_config = if preconfig.action == RunMode::Check {
-        info!("Skipping prebuild configuration for check run mode");
-        None
-    } else {
-        info!("Running prebuild configuration");
-        let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
-        Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
-    };
+    // Module-level configuration discovers native toolchains and flags; other
+    // backends do not need to execute these scripts.
+    let prebuild_config =
+        if preconfig.action == RunMode::Check || !planning_context.target_backend.is_native() {
+            info!("Skipping prebuild configuration for check or non-native backend");
+            None
+        } else {
+            info!("Running prebuild configuration");
+            let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
+            Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
+        };
 
     let requested_artifacts =
         intent.requested_artifacts(&resolve_output, user_log, planning_context.target_backend);

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -1,6 +1,6 @@
 use std::cell::OnceCell;
 
-use crate::{TestDir, assert_success, get_err_stderr, get_stdout_with_envs};
+use crate::{TestDir, assert_success, get_err_stderr, get_stdout_with_envs, moon_cmd};
 
 // Notice the two `this-is-added-by-config-script`
 #[test]
@@ -61,13 +61,74 @@ fn test_prebuild_config_common(dir: TestDir) {
 fn test_prebuild_config_not_run_in_check() {
     let dir = TestDir::new("prebuild_config_script/check_skip_on_check");
 
-    let build_err = get_err_stderr(&dir, ["build", "--dry-run"]);
+    let build_err = get_err_stderr(&dir, ["build", "--target", "native", "--dry-run"]);
     assert!(
         build_err.contains("prebuild script `fail.js`"),
         "expected build to execute prebuild script and fail, got:\n{build_err}"
     );
 
-    assert_success(&dir, ["check"]);
+    for target in ["native", "llvm"] {
+        assert_success(&dir, ["check", "--target", target]);
+    }
+}
+
+#[test]
+fn test_unstable_prebuild_config_only_runs_for_native_backends() {
+    for target in ["wasm", "wasm-gc", "js"] {
+        let dir = TestDir::new("prebuild_config_script/check_skip_on_check");
+        moon_cmd(&dir)
+            .args(["build", "--target", target, "--release"])
+            .assert()
+            .success();
+        moon_cmd(&dir)
+            .args(["build", "--target", target, "--release", "--dry-run"])
+            .assert()
+            .success();
+    }
+
+    for target in ["native", "llvm"] {
+        let dir = TestDir::new("prebuild_config_script/check_skip_on_check");
+        moon_cmd(&dir)
+            .args(["build", "--target", target, "--release", "--dry-run"])
+            .assert()
+            .failure()
+            .stderr_eq(snapbox::str![[r#"
+...
+[..]Failed to run prebuild script for module username/check_skip_on_check
+...
+"#]]);
+    }
+}
+
+#[test]
+fn test_unstable_prebuild_config_uses_preferred_backend() {
+    for target in ["wasm", "wasm-gc", "js", "native", "llvm"] {
+        let dir = TestDir::new("prebuild_config_script/check_skip_on_check");
+        let manifest_path = dir.join("moon.mod.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        manifest["preferred-target"] = target.into();
+        std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+
+        let result = moon_cmd(&dir)
+            .args(["build", "--release", "--dry-run"])
+            .assert();
+        if matches!(target, "native" | "llvm") {
+            result.failure().stderr_eq(snapbox::str![[r#"
+...
+[..]Failed to run prebuild script for module username/check_skip_on_check
+...
+"#]]);
+        } else {
+            result.success();
+        }
+
+        // An explicit backend overrides the module's preferred backend.
+        moon_cmd(&dir)
+            .args(["build", "--target", "wasm", "--release", "--dry-run"])
+            .assert()
+            .success();
+    }
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -68,7 +68,9 @@ fn test_prebuild_config_not_run_in_check() {
     );
 
     for target in ["native", "llvm"] {
-        assert_success(&dir, ["check", "--target", target]);
+        // Prebuild eligibility is decided during planning; LLVM standard-library
+        // artifacts are not available on every platform running this test.
+        assert_success(&dir, ["check", "--target", target, "--dry-run"]);
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/prebuild.rs
+++ b/crates/moonbuild-rupes-recta/src/prebuild.rs
@@ -18,9 +18,10 @@
 
 //! Prebuild config (module-level) and logic.
 //!
-//! Currently, prebuild config runs unconditionally and before everything else,
-//! but ultimately we might want to merge it into the main build graph. This is
-//! a temporary solution.
+//! The command layer runs prebuild config for native and LLVM builds, except
+//! check, before build planning. Eligible scripts always rerun; ultimately we
+//! might want to merge them into the main build graph. This is a temporary
+//! solution.
 
 use std::collections::HashMap;
 

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -9,8 +9,27 @@ Prebuild tasks let a package generate source files (typically `.mbt`) from other
   though its child build presents the distributed module as an input module.
   Published packages must contain their generated outputs.
 - Package-level prebuild tasks are separate from the experimental module-level
-  prebuild configuration script. The latter may still run for a bin-dep to
-  produce build configuration such as native link flags.
+  prebuild configuration script. The latter may still run for a native or LLVM
+  bin-dep build to produce build configuration such as native link flags.
+
+## Module-Level Prebuild Configuration
+
+`--moonbit-unstable-prebuild` in `moon.mod.json` supplies dynamic native build
+configuration, such as toolchain selection and compiler or linker flags. It runs
+only for the Native and LLVM target backends. Wasm, WasmGC, and JS builds skip
+it, including `moon build --target wasm --release` and dry runs. This applies
+to both project and standalone-file builds, using the resolved target backend.
+
+`moon check` skips this configuration for the checked project on every backend.
+Dependency installation can still invoke a separate native or LLVM build whose
+configuration script runs. Native and LLVM dry runs also run these scripts,
+because their output is needed to construct build commands.
+
+Unlike package-level `pre-build` / `dev_build` code generation, whose outputs
+should be generated before distribution, this configuration depends on the
+consumer's build environment. `MOON_IGNORE_PREBUILD` continues to control
+package-level generation; it does not suppress native or LLVM module-level
+configuration scripts.
 
 ## Package Configuration
 


### PR DESCRIPTION
Module-level `--moonbit-unstable-prebuild` currently executes even for `moon build --target wasm --release`, allowing published modules to run configuration scripts during registry Wasm builds.

Package-level `pre-build` / `dev_build` handles code generation whose outputs should be included before distribution. The unstable module-level hook instead supplies dynamic native toolchain and compiler/linker configuration in the consumer's build environment. Restrict it to native and LLVM using the resolved backend in both project and standalone build planning. Wasm, WasmGC, and JS skip the hook; native and LLVM retain it, including dry runs and bin-dependency child builds. The existing skip during `moon check` remains intact.

Regression coverage exercises release builds, dry runs, all five backends, preferred-backend selection, and explicit overrides. The behavior reference documents the distinction and remaining native child-build behavior. This is a focused backend restriction; consolidating the duplicated prebuild orchestration is deferred, and no general no-user-scripts guarantee is introduced.

Related to #2141.
