### PR TITLE
refactor(rr): own native mode selection in backend planning

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -46,9 +46,7 @@ use moonbuild_rupes_recta::{
     execution_plan::{ActionId, ExecutionPlan},
     fmt::{FmtConfig, FmtResolveOutput},
     intent::UserIntent,
-    model::{
-        BackendConfig, DirectNativeMode, NativeBackendMode, NativeTarget, PackageId, TargetKind,
-    },
+    model::{BackendConfig, ENV_MOONBIT_NEW_NATIVE, NativeTarget, PackageId, TargetKind},
     prebuild::{PrebuildEnvironment, run_prebuild_config},
     target_layout::{ArtifactPathResolver, GENERATED_TEST_DRIVER_PREFIX, TargetLayout},
 };
@@ -338,8 +336,6 @@ impl CompilePreConfig {
         final_target_backend: TargetBackend,
         is_core: bool,
         resolve_output: &ResolveOutput,
-        requested_artifacts: &[ArtifactKey],
-        _user_log: &UserLog,
     ) -> anyhow::Result<CompileConfig> {
         info!("Determining compilation configuration");
 
@@ -371,10 +367,17 @@ impl CompilePreConfig {
                 use_wat: self.output_wat,
             },
             TargetBackend::Js => BackendConfig::Js,
-            TargetBackend::Native => BackendConfig::Native {
-                mode: self.detect_mode(resolve_output, requested_artifacts),
-                allocator: compiler_flags::NativeAllocator::from_env()?,
-            },
+            TargetBackend::Native => {
+                let new_native_env = std::env::var(ENV_MOONBIT_NEW_NATIVE).ok();
+                BackendConfig::Native {
+                    direct_object_candidate: NativeTarget::from_host_with_new_native_env(
+                        std::env::consts::ARCH,
+                        std::env::consts::OS,
+                        new_native_env.as_deref(),
+                    ),
+                    allocator: compiler_flags::NativeAllocator::from_env()?,
+                }
+            }
             TargetBackend::LLVM => BackendConfig::Llvm {
                 allocator: compiler_flags::NativeAllocator::from_env()?,
             },
@@ -409,54 +412,6 @@ impl CompilePreConfig {
             warn_list: self.warn_list,
             info_no_alias: self.info_no_alias,
         })
-    }
-
-    /// Detect the native payload and executable realization for this invocation.
-    fn detect_mode(
-        &self,
-        resolve_output: &ResolveOutput,
-        requested_artifacts: &[ArtifactKey],
-    ) -> NativeBackendMode {
-        // TODO: Native payload form is selected once per invocation. Before
-        // selecting it per executable, key the shared runtime and package C-stub
-        // products by their native toolchain and realization. Otherwise mixed
-        // payload forms can require incompatible shared artifacts, especially
-        // for the strict MSVC direct object target.
-        let native_configs = requested_artifacts
-            .iter()
-            .filter_map(|artifact| {
-                let ArtifactKey::Executable { package, .. } = artifact else {
-                    return None;
-                };
-                let package = resolve_output.pkg_dirs.get_package(*package);
-                let native = package
-                    .raw
-                    .link
-                    .as_ref()
-                    .and_then(|link| link.native.as_ref())?;
-                Some((package, native))
-            })
-            .collect::<Vec<_>>();
-
-        let native_target = if self.opt_level == BuildProfile::Debug {
-            NativeTarget::from_env_for_host()
-        } else {
-            None
-        };
-        info!("New native target: {:?}", native_target);
-        if let Some(native_target) = native_target {
-            if native_configs
-                .iter()
-                .any(|(_, native)| native.cc_flags.is_some())
-            {
-                info!("Disabling direct object native output: C/C++ compiler flags are set");
-                return NativeBackendMode::GeneratedC;
-            }
-
-            return NativeBackendMode::DirectObject(DirectNativeMode::Target(native_target));
-        }
-
-        NativeBackendMode::GeneratedC
     }
 }
 
@@ -628,8 +583,6 @@ pub(crate) fn plan_resolved_build_from_intent(
         planning_context.target_backend,
         planning_context.is_core,
         &resolve_output,
-        &requested_artifacts,
-        user_log,
     )?;
     info!("Begin lowering to build graph");
     let compile_output = moonbuild_rupes_recta::compile(
@@ -728,8 +681,6 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
         planning_context.target_backend,
         planning_context.is_core,
         &resolve_output,
-        &requested_artifacts,
-        user_log,
     )?;
     let compile_output = moonbuild_rupes_recta::compile_standalone(
         &cx,

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 use std::process::Command;
 
 use moonbuild::entry::TestArgs;
-use moonbuild_rupes_recta::model::{BackendConfig, NativeBackendMode};
+use moonbuild_rupes_recta::model::BackendConfig;
 
 /// The runtime mode used to execute one built artifact.
 #[derive(Clone, Copy)]
@@ -37,11 +37,7 @@ impl From<&BackendConfig> for ExecutionMode {
         match backend {
             BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } => Self::MoonRun,
             BackendConfig::Js => Self::Node,
-            BackendConfig::Native {
-                mode: NativeBackendMode::GeneratedC | NativeBackendMode::DirectObject(_),
-                ..
-            }
-            | BackendConfig::Llvm { .. } => Self::Native,
+            BackendConfig::Native { .. } | BackendConfig::Llvm { .. } => Self::Native,
         }
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
@@ -59,20 +59,9 @@ mod tests {
 
     #[test]
     fn c_direct_object_realizes_linker_executable() {
-        let backend = BackendConfig::Native {
-            mode: NativeBackendMode::DirectObject(DirectNativeMode::Target(
-                crate::model::NativeTarget::Aarch64AppleDarwin,
-            )),
-            allocator: NativeAllocator::Default,
-        };
-
-        let BackendConfig::Native {
-            mode: ref native_mode,
-            ..
-        } = backend
-        else {
-            panic!("native backend should select C lowering")
-        };
+        let native_mode = NativeBackendMode::DirectObject(DirectNativeMode::Target(
+            crate::model::NativeTarget::Aarch64AppleDarwin,
+        ));
         assert_eq!(
             native_mode.executable_realization(),
             CExecutableRealization::LinkDirectObject

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -96,7 +96,7 @@ impl ActionArtifacts {
             ctx.action(provider_action),
             ctx.packages,
             ctx.modules,
-            ctx.opt.artifact_path_options(),
+            ctx.opt.artifact_path_options(ctx.plan.backend_plan()),
         );
         RealizedArtifact { artifact, paths }
     }
@@ -260,113 +260,7 @@ impl<'a> LoweringContext<'a> {
                 };
             }
         };
-        match node {
-            BuildPlanNode::Check(target) => BuildAction::Check {
-                target,
-                info: self
-                    .plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for Check nodes"),
-            },
-            BuildPlanNode::EmitProof(target) => BuildAction::EmitProof {
-                target,
-                info: self
-                    .plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for EmitProof nodes"),
-            },
-            BuildPlanNode::Prove(target) => BuildAction::Prove {
-                target,
-                info: self
-                    .plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for Prove nodes"),
-            },
-            BuildPlanNode::BuildCore(target) => BuildAction::BuildCore {
-                target,
-                info: self
-                    .plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for BuildCore nodes"),
-            },
-            BuildPlanNode::BuildCStub(package, index) => BuildAction::BuildCStub {
-                package,
-                index,
-                info: self
-                    .plan
-                    .get_c_stubs_info(package)
-                    .expect("C stub info should be present for BuildCStub nodes"),
-            },
-            BuildPlanNode::ArchiveOrLinkCStubs(package) => BuildAction::ArchiveOrLinkCStubs {
-                package,
-                info: self
-                    .plan
-                    .get_c_stubs_info(package)
-                    .expect("C stubs info should be present for BuildCStubs nodes"),
-            },
-            BuildPlanNode::LinkCore(target) => BuildAction::LinkCore {
-                target,
-                info: self
-                    .plan
-                    .get_link_core_info(&target)
-                    .expect("Link core info should be present for LinkCore nodes"),
-                make_executable_info: self.plan.get_make_executable_info(&target),
-            },
-            BuildPlanNode::MakeExecutable(target) => BuildAction::MakeExecutable {
-                target,
-                info: self
-                    .plan
-                    .get_make_executable_info(&target)
-                    .expect("MakeExecutable nodes should contain native linking info"),
-            },
-            BuildPlanNode::GenerateDsym(target) => BuildAction::GenerateDsym {
-                target,
-                dsymutil: self
-                    .plan
-                    .get_dsymutil()
-                    .expect("dsymutil should be present for GenerateDsym nodes"),
-            },
-            BuildPlanNode::GenerateTestInfo(target) => BuildAction::GenerateTestInfo {
-                target,
-                info: self
-                    .plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for GenerateTestInfo nodes"),
-            },
-            BuildPlanNode::GenerateNodeTestPackageConfig(package) => {
-                BuildAction::GenerateNodeTestPackageConfig { package }
-            }
-            BuildPlanNode::GenerateMbti(target) => BuildAction::GenerateMbti { target },
-            BuildPlanNode::BuildVirtual(package) => BuildAction::BuildVirtual {
-                package,
-                input: self
-                    .plan
-                    .virtual_contract_input(package)
-                    .expect("virtual contract input should be selected during build planning"),
-            },
-            BuildPlanNode::Bundle(module) => BuildAction::Bundle {
-                module,
-                targets: &self
-                    .plan
-                    .bundle_info(module)
-                    .expect("Bundle info should be present when lowering bundle node")
-                    .bundle_targets,
-            },
-            BuildPlanNode::BuildRuntimeObject(index) => BuildAction::BuildRuntimeObject {
-                index,
-                info: self
-                    .plan
-                    .get_runtime_info()
-                    .expect("Runtime info should be present for runtime object nodes"),
-            },
-            BuildPlanNode::BuildRuntimeLib => BuildAction::BuildRuntimeLib {
-                info: self
-                    .plan
-                    .get_runtime_info()
-                    .expect("Runtime info should be present for BuildRuntimeLib nodes"),
-            },
-            BuildPlanNode::BuildDocs(module) => BuildAction::BuildDocs { module },
-        }
+        self.plan.backend_plan().action(node)
     }
 
     fn human_desc(&self, action_key: &BuildPlanActionKey, action: BuildAction<'_>) -> String {
@@ -544,8 +438,8 @@ impl<'a> LoweringContext<'a> {
             BuildAction::MakeExecutable { .. }
                 if matches!(
                     &self.opt.backend,
-                    BackendConfig::Native { mode, .. }
-                        if mode.executable_realization()
+                    BackendConfig::Native { .. }
+                        if self.plan.backend_plan().native_mode().executable_realization()
                             == CExecutableRealization::CompileAndLinkGeneratedC
                 )
         );
@@ -623,12 +517,19 @@ impl<'a> LoweringContext<'a> {
                     && package_link_flags.is_none_or(<[_]>::is_empty)
             }
             BuildAction::MakeExecutable { info, .. } => match &self.opt.backend {
-                BackendConfig::Native { mode, .. } => match mode.executable_realization() {
-                    CExecutableRealization::CompileAndLinkGeneratedC => {
-                        info.c_flags.is_empty() && info.link_flags.is_empty()
+                BackendConfig::Native { .. } => {
+                    match self
+                        .plan
+                        .backend_plan()
+                        .native_mode()
+                        .executable_realization()
+                    {
+                        CExecutableRealization::CompileAndLinkGeneratedC => {
+                            info.c_flags.is_empty() && info.link_flags.is_empty()
+                        }
+                        CExecutableRealization::LinkDirectObject => info.link_flags.is_empty(),
                     }
-                    CExecutableRealization::LinkDirectObject => info.link_flags.is_empty(),
-                },
+                }
                 BackendConfig::Llvm { .. } => info.c_flags.is_empty() && info.link_flags.is_empty(),
                 BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
                     unreachable!("non-native plans do not contain MakeExecutable actions")
@@ -657,7 +558,9 @@ impl<'a> LoweringContext<'a> {
                     .dsym_bundle_of_build_target(
                         self.packages,
                         &target,
-                        self.opt.artifact_path_options().executable,
+                        self.opt
+                            .artifact_path_options(self.plan.backend_plan())
+                            .executable,
                     ),
             ],
             BuildAction::RunPrebuild { info } => info.resolved_outputs.clone(),

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -723,7 +723,7 @@ impl<'a> LoweringContext<'a> {
             package_sources: &package_sources,
             stdlib_core_source: None,
             target_backend: self.opt.target_backend(),
-            native_target: self.opt.backend.direct_native_target(),
+            native_target: self.plan.backend_plan().direct_native_target(),
             flags: self.set_flags(),
             test_mode: target.kind.is_test(),
             wasm_config: self.get_wasm_config(target, package),
@@ -1020,14 +1020,21 @@ impl<'a> LoweringContext<'a> {
             BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
                 unreachable!("non-native plans do not contain MakeExecutable actions")
             }
-            BackendConfig::Native { mode, .. } => match mode.executable_realization() {
-                CExecutableRealization::LinkDirectObject => {
-                    self.lower_link_new_native_exe(artifacts, target, info)
+            BackendConfig::Native { .. } => {
+                match self
+                    .plan
+                    .backend_plan()
+                    .native_mode()
+                    .executable_realization()
+                {
+                    CExecutableRealization::LinkDirectObject => {
+                        self.lower_link_new_native_exe(artifacts, target, info)
+                    }
+                    CExecutableRealization::CompileAndLinkGeneratedC => {
+                        self.lower_build_exe_regular(artifacts, target, info)
+                    }
                 }
-                CExecutableRealization::CompileAndLinkGeneratedC => {
-                    self.lower_build_exe_regular(artifacts, target, info)
-                }
-            },
+            }
             BackendConfig::Llvm { .. } => self.lower_build_exe_regular(artifacts, target, info),
         }
     }

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -34,7 +34,7 @@ use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    build_plan::{BuildPlan, BuildPlanActionKey},
+    build_plan::{BackendPlan, BuildPlan, BuildPlanActionKey},
     execution_plan::{ActionId, ExecutionPlan, ExecutionPlanBuilder},
     model::{BackendConfig, BuildPlanNode, OperatingSystem, PackageId},
     target_layout::{
@@ -66,6 +66,8 @@ use context::LoweringContext;
 /// The build pipeline passes this object explicitly so lower phases do not
 /// rediscover environment facts in place. Individual facts remain lazy because
 /// non-native backends do not need native OS/toolchain details.
+// TODO: Remove these lazy environment reads once command orchestration supplies
+// the selected OS and compiler paths explicitly.
 #[derive(Default)]
 pub struct LoweringEnvironment {
     os: OnceLock<OperatingSystem>,
@@ -133,7 +135,7 @@ impl BuildOptions {
         self.lowering_environment.compiler_paths()
     }
 
-    pub fn artifact_path_options(&self) -> ArtifactPathOptions {
+    fn artifact_path_options(&self, backend_plan: &BackendPlan) -> ArtifactPathOptions {
         let os = match &self.backend {
             BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
                 OperatingSystem::None
@@ -150,9 +152,9 @@ impl BuildOptions {
                 LinkedCoreArtifact::WasmGC { use_wat: *use_wat },
             ),
             BackendConfig::Js => (ExecutableArtifact::Js, LinkedCoreArtifact::Js),
-            BackendConfig::Native { mode, .. } => (
+            BackendConfig::Native { .. } => (
                 ExecutableArtifact::NativeExecutable,
-                if mode.direct_target().is_some() {
+                if backend_plan.direct_native_target().is_some() {
                     LinkedCoreArtifact::NativeObject { os }
                 } else {
                     LinkedCoreArtifact::NativeC
@@ -424,7 +426,10 @@ mod tests {
             };
 
             assert!(options.lowering_environment.os.get().is_none());
-            assert_eq!(options.artifact_path_options().os, OperatingSystem::None);
+            assert_eq!(
+                options.artifact_path_options(&BackendPlan::default()).os,
+                OperatingSystem::None
+            );
             assert!(options.lowering_environment.os.get().is_none());
         }
     }
@@ -1048,10 +1053,12 @@ mod tests {
         let native_mode = NativeBackendMode::DirectObject(DirectNativeMode::Target(
             NativeTarget::X86_64PcWindowsMsvc,
         ));
+        plan.test_backend_plan_mut()
+            .test_set_native_mode(Some(native_mode));
         let options = BuildOptions {
             artifact_paths: artifact_paths.clone(),
             backend: BackendConfig::Native {
-                mode: native_mode,
+                direct_object_candidate: Some(NativeTarget::X86_64PcWindowsMsvc),
                 allocator: NativeAllocator::Default,
             },
             opt_level: OptLevel::Debug,
@@ -1290,12 +1297,17 @@ mod tests {
                 allocator: NativeAllocator::Default,
             },
             BackendConfig::Native {
-                mode: NativeBackendMode::DirectObject(DirectNativeMode::Target(
-                    NativeTarget::Aarch64AppleDarwin,
-                )),
+                direct_object_candidate: Some(NativeTarget::Aarch64AppleDarwin),
                 allocator: NativeAllocator::Default,
             },
         ] {
+            plan.test_backend_plan_mut().test_set_native_mode(
+                matches!(backend, BackendConfig::Native { .. }).then_some(
+                    NativeBackendMode::DirectObject(DirectNativeMode::Target(
+                        NativeTarget::Aarch64AppleDarwin,
+                    )),
+                ),
+            );
             let lowering_environment = LoweringEnvironment::default();
             lowering_environment
                 .os
@@ -1332,12 +1344,16 @@ mod tests {
             let executable = artifact_paths.target_layout().executable_of_build_target(
                 &resolve_output.pkg_dirs,
                 &target,
-                options.artifact_path_options().executable,
+                options
+                    .artifact_path_options(plan.backend_plan())
+                    .executable,
             );
             let dsym_bundle = artifact_paths.target_layout().dsym_bundle_of_build_target(
                 &resolve_output.pkg_dirs,
                 &target,
-                options.artifact_path_options().executable,
+                options
+                    .artifact_path_options(plan.backend_plan())
+                    .executable,
             );
 
             let link_args = lowered

--- a/crates/moonbuild-rupes-recta/src/build_plan/action.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/action.rs
@@ -21,10 +21,10 @@ use std::path::Path;
 use moonutil::resolution::ModuleId;
 
 use super::{
-    BuildCStubsInfo, BuildRuntimeInfo, BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo,
-    PrebuildInfo,
+    BackendPlan, BuildCStubsInfo, BuildRuntimeInfo, BuildTargetInfo, LinkCoreInfo,
+    MakeExecutableInfo, PrebuildInfo,
 };
-use crate::model::{BuildTarget, PackageId};
+use crate::model::{BuildPlanNode, BuildTarget, PackageId};
 
 /// A semantic Build Plan action hydrated with the metadata needed by lowering.
 ///
@@ -111,4 +111,118 @@ pub(crate) enum BuildAction<'a> {
         input: &'a Path,
         output: &'a Path,
     },
+}
+
+impl BackendPlan {
+    /// Hydrate a backend action from its owning plan's metadata.
+    pub(crate) fn action(&self, node: BuildPlanNode) -> BuildAction<'_> {
+        match node {
+            BuildPlanNode::Check(target) => BuildAction::Check {
+                target,
+                info: self
+                    .build_target_infos
+                    .get(&target)
+                    .expect("Build target info should be present for Check nodes"),
+            },
+            BuildPlanNode::EmitProof(target) => BuildAction::EmitProof {
+                target,
+                info: self
+                    .build_target_infos
+                    .get(&target)
+                    .expect("Build target info should be present for EmitProof nodes"),
+            },
+            BuildPlanNode::Prove(target) => BuildAction::Prove {
+                target,
+                info: self
+                    .build_target_infos
+                    .get(&target)
+                    .expect("Build target info should be present for Prove nodes"),
+            },
+            BuildPlanNode::BuildCore(target) => BuildAction::BuildCore {
+                target,
+                info: self
+                    .build_target_infos
+                    .get(&target)
+                    .expect("Build target info should be present for BuildCore nodes"),
+            },
+            BuildPlanNode::BuildCStub(package, index) => BuildAction::BuildCStub {
+                package,
+                index,
+                info: self
+                    .c_stubs_info
+                    .get(&package)
+                    .expect("C stub info should be present for BuildCStub nodes"),
+            },
+            BuildPlanNode::ArchiveOrLinkCStubs(package) => BuildAction::ArchiveOrLinkCStubs {
+                package,
+                info: self
+                    .c_stubs_info
+                    .get(&package)
+                    .expect("C stubs info should be present for BuildCStubs nodes"),
+            },
+            BuildPlanNode::LinkCore(target) => BuildAction::LinkCore {
+                target,
+                info: self
+                    .link_core_info
+                    .get(&target)
+                    .expect("Link core info should be present for LinkCore nodes"),
+                make_executable_info: self.make_executable_info.get(&target),
+            },
+            BuildPlanNode::MakeExecutable(target) => BuildAction::MakeExecutable {
+                target,
+                info: self
+                    .make_executable_info
+                    .get(&target)
+                    .expect("MakeExecutable nodes should contain native linking info"),
+            },
+            BuildPlanNode::GenerateDsym(target) => BuildAction::GenerateDsym {
+                target,
+                dsymutil: self
+                    .dsymutil
+                    .as_deref()
+                    .expect("dsymutil should be present for GenerateDsym nodes"),
+            },
+            BuildPlanNode::GenerateTestInfo(target) => BuildAction::GenerateTestInfo {
+                target,
+                info: self
+                    .build_target_infos
+                    .get(&target)
+                    .expect("Build target info should be present for GenerateTestInfo nodes"),
+            },
+            BuildPlanNode::GenerateNodeTestPackageConfig(package) => {
+                BuildAction::GenerateNodeTestPackageConfig { package }
+            }
+            BuildPlanNode::GenerateMbti(target) => BuildAction::GenerateMbti { target },
+            BuildPlanNode::BuildVirtual(package) => BuildAction::BuildVirtual {
+                package,
+                input: self
+                    .virtual_contract_inputs
+                    .get(&package)
+                    .map(|path| path.as_path())
+                    .expect("virtual contract input should be selected during build planning"),
+            },
+            BuildPlanNode::Bundle(module) => BuildAction::Bundle {
+                module,
+                targets: &self
+                    .bundle_info
+                    .get(&module)
+                    .expect("Bundle info should be present when lowering bundle node")
+                    .bundle_targets,
+            },
+            BuildPlanNode::BuildRuntimeObject(index) => BuildAction::BuildRuntimeObject {
+                index,
+                info: self
+                    .runtime_info
+                    .as_ref()
+                    .expect("Runtime info should be present for runtime object nodes"),
+            },
+            BuildPlanNode::BuildRuntimeLib => BuildAction::BuildRuntimeLib {
+                info: self
+                    .runtime_info
+                    .as_ref()
+                    .expect("Runtime info should be present for BuildRuntimeLib nodes"),
+            },
+            BuildPlanNode::BuildDocs(module) => BuildAction::BuildDocs { module },
+        }
+    }
 }

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -85,11 +85,11 @@ fn should_generate_direct_native_dsym(
 
 impl<'a> BuildPlanConstructor<'a> {
     fn new_native_linker_context(&self, err: anyhow::Error) -> anyhow::Error {
-        if self.build_env.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
+        if self.res.backend.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
             err.context(
                 "Windows MSVC direct object native target requires an MSVC compiler/linker driver such as cl.exe or clang-cl.exe",
             )
-        } else if self.build_env.direct_native_target().is_some() {
+        } else if self.res.backend.direct_native_target().is_some() {
             err.context(
                 "new native backend requires a C compiler/linker driver; install clang/cc or set MOON_CC",
             )
@@ -112,8 +112,10 @@ impl<'a> BuildPlanConstructor<'a> {
     }
 
     fn effective_native_toolchain(&mut self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
+        // TODO: Consume explicit toolchain candidates and environment overrides
+        // once native toolchain discovery moves to command orchestration.
         debug_assert!(self.build_env.target_backend().is_native());
-        if self.build_env.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
+        if self.res.backend.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
             self.warn_incompatible_windows_msvc_env_override();
             return compiler_flags::windows_msvc_native_toolchain(package_cc);
         }
@@ -1138,20 +1140,16 @@ impl<'a> BuildPlanConstructor<'a> {
             BackendConfig::Llvm { .. } => {
                 should_generate_llvm_dsym(self.build_env.debug_symbols, self.build_env.os)
             }
-            BackendConfig::Native {
-                mode: NativeBackendMode::DirectObject(mode),
-                ..
-            } => should_generate_direct_native_dsym(
-                mode,
-                self.build_env.debug_symbols
-                    || (self.build_env.action == RunMode::Run
-                        && self.build_env.opt_level == OptLevel::Debug),
-                &effective_native_toolchain,
-            ),
-            BackendConfig::Native {
-                mode: NativeBackendMode::GeneratedC,
-                ..
-            } => false,
+            BackendConfig::Native { .. } => match self.res.backend.native_mode() {
+                NativeBackendMode::DirectObject(mode) => should_generate_direct_native_dsym(
+                    mode,
+                    self.build_env.debug_symbols
+                        || (self.build_env.action == RunMode::Run
+                            && self.build_env.opt_level == OptLevel::Debug),
+                    &effective_native_toolchain,
+                ),
+                NativeBackendMode::GeneratedC => false,
+            },
             BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
                 unreachable!("non-native executable planning returns before toolchain planning")
             }

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -226,9 +226,14 @@ impl<'a> BuildPlanConstructor<'a> {
                 );
             }
             BuildPlanNode::BuildCore(target) => {
-                let emits_mi = self.res.get_build_target_info(&target).is_some_and(|info| {
-                    info.check_mi_against.is_none() && !info.no_mi() && !target.kind.is_test()
-                });
+                let emits_mi = self
+                    .res
+                    .backend
+                    .build_target_infos
+                    .get(&target)
+                    .is_some_and(|info| {
+                        info.check_mi_against.is_none() && !info.no_mi() && !target.kind.is_test()
+                    });
                 if emits_mi {
                     self.res.artifacts.provide(
                         node,

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -67,7 +67,10 @@ use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    model::{BackendConfig, BuildPlanNode, BuildTarget, NativeTarget, OperatingSystem, PackageId},
+    model::{
+        BackendConfig, BuildPlanNode, BuildTarget, NativeBackendMode, NativeTarget,
+        OperatingSystem, PackageId,
+    },
     pkg_name::PackageFQNWithSource,
     prebuild::PrebuildOutput,
 };
@@ -108,7 +111,11 @@ impl From<BuildPlanNode> for BuildPlanActionKey {
 /// planned action. Keeping both here makes that invariant local to backend
 /// planning.
 #[derive(Default)]
-struct BackendPlan {
+pub(crate) struct BackendPlan {
+    /// Derived once from the requested artifacts before expanding actions.
+    /// Present only for Native; all Native planning and lowering read this value.
+    native_mode: Option<NativeBackendMode>,
+
     /// Planned backend actions, in stable insertion order.
     actions: IndexSet<BuildPlanNode>,
 
@@ -144,6 +151,18 @@ struct BackendPlan {
 }
 
 impl BackendPlan {
+    pub(crate) fn native_mode(&self) -> &NativeBackendMode {
+        self.native_mode
+            .as_ref()
+            .expect("Native planning must select a payload form")
+    }
+
+    pub(crate) fn direct_native_target(&self) -> Option<NativeTarget> {
+        self.native_mode
+            .as_ref()
+            .and_then(NativeBackendMode::direct_target)
+    }
+
     fn actions(&self) -> impl Iterator<Item = BuildPlanNode> + '_ {
         self.actions.iter().copied()
     }
@@ -182,6 +201,11 @@ pub struct BuildPlan {
 }
 
 impl BuildPlan {
+    /// Borrow the backend-owned actions and metadata for backend lowering.
+    pub(crate) fn backend_plan(&self) -> &BackendPlan {
+        &self.backend
+    }
+
     /// Get the semantic actions that **the given action depends on**.
     pub(crate) fn dependency_actions(
         &self,
@@ -231,53 +255,11 @@ impl BuildPlan {
         self.requested_artifacts.iter()
     }
 
-    /// Get build target information for the given target.
-    pub fn get_build_target_info(&self, target: &BuildTarget) -> Option<&BuildTargetInfo> {
-        self.backend.build_target_infos.get(target)
-    }
-
-    /// Get link core information for the given target.
-    pub fn get_link_core_info(&self, target: &BuildTarget) -> Option<&LinkCoreInfo> {
-        self.backend.link_core_info.get(target)
-    }
-
-    /// Get C stubs information for the given target.
-    pub fn get_c_stubs_info(&self, target: PackageId) -> Option<&BuildCStubsInfo> {
-        self.backend.c_stubs_info.get(&target)
-    }
-
-    /// Get make executable information for the given target.
-    pub fn get_make_executable_info(&self, target: &BuildTarget) -> Option<&MakeExecutableInfo> {
-        self.backend.make_executable_info.get(target)
-    }
-
-    /// Get the resolved dsymutil executable.
-    pub fn get_dsymutil(&self) -> Option<&Path> {
-        self.backend.dsymutil.as_deref()
-    }
-
-    /// Get runtime library build information.
-    pub fn get_runtime_info(&self) -> Option<&BuildRuntimeInfo> {
-        self.backend.runtime_info.as_ref()
-    }
-
     pub(crate) fn package_prebuild_action(
         &self,
         key: &PackagePrebuildKey,
     ) -> Option<&PackagePrebuildAction> {
         self.package_prebuild.action(key)
-    }
-
-    pub(crate) fn virtual_contract_input(&self, package: PackageId) -> Option<&Path> {
-        self.backend
-            .virtual_contract_inputs
-            .get(&package)
-            .map(PathBuf::as_path)
-    }
-
-    /// Get bundle information for the given module.
-    pub fn bundle_info(&self, module_id: ModuleId) -> Option<&BuildBundleInfo> {
-        self.backend.bundle_info.get(&module_id)
     }
 
     pub(crate) fn all_actions(&self) -> impl Iterator<Item = BuildPlanActionKey> + '_ {
@@ -297,7 +279,18 @@ impl BuildPlan {
 }
 
 #[cfg(test)]
+impl BackendPlan {
+    pub(crate) fn test_set_native_mode(&mut self, mode: Option<NativeBackendMode>) {
+        self.native_mode = mode;
+    }
+}
+
+#[cfg(test)]
 impl BuildPlan {
+    pub(crate) fn test_backend_plan_mut(&mut self) -> &mut BackendPlan {
+        &mut self.backend
+    }
+
     pub(crate) fn test_add_node(&mut self, node: BuildPlanNode) {
         self.backend.insert(node);
     }
@@ -644,10 +637,6 @@ impl BuildEnvironment {
     pub(crate) fn target_backend(&self) -> TargetBackend {
         self.backend.target_backend()
     }
-
-    pub(crate) fn direct_native_target(&self) -> Option<NativeTarget> {
-        self.backend.direct_native_target()
-    }
 }
 
 /// How package-level prebuild participates in this plan.
@@ -759,6 +748,43 @@ pub enum BuildPlanConstructError {
     },
 }
 
+/// Select one Native payload form for all requested artifacts in a plan.
+/// Host capability is supplied by the caller; package policy belongs to RR.
+pub(super) fn resolve_native_backend_mode(
+    resolved: &ResolveOutput,
+    requested_artifacts: &[ArtifactKey],
+    opt_level: OptLevel,
+    native_target: Option<crate::model::NativeTarget>,
+) -> crate::model::NativeBackendMode {
+    use crate::model::{DirectNativeMode, NativeBackendMode};
+
+    // TODO: Before selecting payload form per executable, key shared runtime
+    // and C-stub artifacts by toolchain and realization. A plan currently
+    // requires one mode so its executables can safely share those artifacts.
+    let Some(native_target) = native_target.filter(|_| opt_level == OptLevel::Debug) else {
+        return NativeBackendMode::GeneratedC;
+    };
+    let needs_c_compiler = requested_artifacts.iter().any(|artifact| {
+        let ArtifactKey::Executable { package, .. } = artifact else {
+            return false;
+        };
+        resolved
+            .pkg_dirs
+            .get_package(*package)
+            .raw
+            .link
+            .as_ref()
+            .and_then(|link| link.native.as_ref())
+            .is_some_and(|native| native.cc_flags.is_some())
+    });
+    if needs_c_compiler {
+        tracing::info!("Disabling direct object native output: C/C++ compiler flags are set");
+        NativeBackendMode::GeneratedC
+    } else {
+        NativeBackendMode::DirectObject(DirectNativeMode::Target(native_target))
+    }
+}
+
 /// Construct a Build Plan that produces the requested artifacts.
 #[instrument(skip_all)]
 pub fn build_plan(
@@ -785,7 +811,29 @@ pub fn build_plan(
         prebuild_config,
         user_log,
     );
-    constructor.build(input)?;
+    let input = input.collect::<Vec<_>>();
+    if let BackendConfig::Native {
+        direct_object_candidate,
+        ..
+    } = &build_env.backend
+    {
+        constructor.res.backend.native_mode = Some(resolve_native_backend_mode(
+            resolved,
+            &input,
+            build_env.opt_level,
+            *direct_object_candidate,
+        ));
+    }
+    // Preserve the caller-requested executable scope for Native selection,
+    // then drop test artifacts excluded by the standard-library special cases.
+    constructor.build(input.into_iter().filter(|artifact| {
+        artifact.package_target().is_none_or(|target| {
+            !target.kind.is_test()
+                || !crate::special_cases::should_skip_tests(
+                    &resolved.pkg_dirs.get_package(target.package).fqn,
+                )
+        })
+    }))?;
     let result = constructor.finish();
 
     info!(

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -19,7 +19,7 @@
 use log::{debug, info};
 use moonutil::{build_options::RunMode, cond_expr::OptLevel, user_log::UserLog};
 use std::path::{Path, PathBuf};
-use tracing::{Level, instrument};
+use tracing::instrument;
 
 use crate::{
     build_lower::{self, LoweringEnvironment, WarningCondition},
@@ -28,7 +28,6 @@ use crate::{
     model::{BackendConfig, OperatingSystem},
     prebuild::PrebuildOutput,
     resolve::ResolveOutput,
-    special_cases::should_skip_tests,
     target_layout::ArtifactPathResolver,
 };
 
@@ -112,18 +111,12 @@ pub fn compile(
         requested_artifacts.len()
     );
 
-    let requested_artifacts = requested_artifacts
-        .iter()
-        .filter(|artifact| filter_special_case_requested_artifact(artifact, resolve_output))
-        .cloned()
-        .collect::<Vec<_>>();
-
     let build_env = build_environment(cx);
     let plan = build_plan::build_plan(
         resolve_output,
         mooncake_bin_dir,
         &build_env,
-        requested_artifacts.into_iter(),
+        requested_artifacts.iter().cloned(),
         input_directive,
         prebuild_config,
         user_log,
@@ -148,17 +141,12 @@ pub fn compile_standalone(
     user_log: &UserLog,
 ) -> Result<StandaloneCompileOutput, CompileGraphError> {
     info!("Building one logical plan for standalone dependency and script work");
-    let requested_artifacts = requested_artifacts
-        .iter()
-        .filter(|artifact| filter_special_case_requested_artifact(artifact, resolve_output))
-        .cloned()
-        .collect::<Vec<_>>();
     let build_env = build_environment(cx);
     let plan = build_plan::build_plan(
         resolve_output,
         mooncake_bin_dir,
         &build_env,
-        requested_artifacts.into_iter(),
+        requested_artifacts.iter().cloned(),
         input_directive,
         prebuild_config,
         user_log,
@@ -239,24 +227,6 @@ fn lowering_options(cx: &CompileConfig) -> build_lower::BuildOptions {
         info_no_alias: cx.info_no_alias,
         stdlib_path: cx.stdlib_path.clone(),
         lowering_environment: cx.lowering_environment.clone(),
-    }
-}
-
-/// A filter to remove requested test artifacts that are invalid. Returns
-/// `true` if the artifact should be retained.
-///
-/// See [`crate::special_cases`] for more information.
-#[instrument(level = Level::DEBUG, skip_all)]
-fn filter_special_case_requested_artifact(
-    artifact: &ArtifactKey,
-    resolve_output: &ResolveOutput,
-) -> bool {
-    match artifact.package_target() {
-        Some(tgt) if tgt.kind.is_test() => {
-            let pkg_name = &resolve_output.pkg_dirs.get_package(tgt.package).fqn;
-            !should_skip_tests(pkg_name)
-        }
-        _ => true,
     }
 }
 
@@ -371,6 +341,146 @@ mod tests {
             c_stub_header_files: Vec::new(),
             virtual_mbti_files: Vec::new(),
             is_stdlib: false,
+        }
+    }
+
+    #[test]
+    fn native_payload_selection_uses_only_requested_executables() {
+        use crate::{
+            build_plan::{BuildEnvironment, build_plan, resolve_native_backend_mode},
+            model::{NativeTarget, OperatingSystem},
+        };
+
+        let module_source = ModuleSource::local_path(
+            "test/single"
+                .parse::<ModuleName>()
+                .expect("test module should parse"),
+            PathBuf::from("."),
+            DEFAULT_VERSION.clone(),
+        );
+        let (modules, module) = ResolvedEnv::only_one_module(module_source.clone(), moon_mod());
+        let mut packages = DiscoverResult::default();
+        packages.test_register_module(module, moon_mod());
+        let plain = packages.test_add_package(
+            module,
+            PackagePath::new("plain").expect("plain package path should parse"),
+            package(module, &module_source, "plain", false, true),
+        );
+        let mut with_flags = package(module, &module_source, "with_flags", false, true);
+        with_flags.raw.link = Some(moonutil::package::Link {
+            wasm: None,
+            wasm_gc: None,
+            js: None,
+            native: Some(moonutil::package::NativeLinkConfig {
+                exports: None,
+                cc: None,
+                cc_flags: Some("-fno-inline".into()),
+                cc_link_flags: None,
+                stub_cc: None,
+                stub_cc_flags: None,
+                stub_cc_link_flags: None,
+                stub_lib_deps: None,
+            }),
+        });
+        let with_flags = packages.test_add_package(
+            module,
+            PackagePath::new("with_flags").expect("flagged package path should parse"),
+            with_flags,
+        );
+        let resolved = ResolveOutput {
+            module_rel: modules,
+            module_dirs: DirSyncResult::default(),
+            pkg_dirs: packages,
+            pkg_rel: DepRelationship::default(),
+        };
+        // Empty plans exercise capability forwarding without resolving host tools.
+        // Include foreign targets and None so a planner-side host read cannot pass.
+        for candidate in [
+            None,
+            Some(NativeTarget::Aarch64AppleDarwin),
+            Some(NativeTarget::X86_64UnknownLinuxGnu),
+            Some(NativeTarget::X86_64PcWindowsMsvc),
+        ] {
+            for opt_level in [OptLevel::Debug, OptLevel::Release] {
+                let build_env = BuildEnvironment {
+                    backend: BackendConfig::Native {
+                        direct_object_candidate: candidate,
+                        allocator: moonutil::compiler_flags::NativeAllocator::Default,
+                    },
+                    opt_level,
+                    action: RunMode::Build,
+                    debug_symbols: false,
+                    os: OperatingSystem::None,
+                    compiler_paths: None,
+                    std: false,
+                    warn_list: None,
+                };
+                let plan = build_plan(
+                    &resolved,
+                    Path::new(".mooncakes/bin"),
+                    &build_env,
+                    std::iter::empty(),
+                    &InputDirective::default(),
+                    None,
+                    &UserLog::new(log::LevelFilter::Off),
+                )
+                .expect("empty plan should not need host tools");
+                assert_eq!(
+                    plan.backend_plan().direct_native_target(),
+                    candidate.filter(|_| opt_level == OptLevel::Debug),
+                    "candidate={candidate:?}, opt_level={opt_level:?}"
+                );
+            }
+        }
+        let plain_exe = ArtifactKey::Executable {
+            package: plain,
+            target_kind: TargetKind::Source,
+        };
+        let flagged_exe = ArtifactKey::Executable {
+            package: with_flags,
+            target_kind: TargetKind::Source,
+        };
+        for (requested, permits_direct_object) in [
+            (vec![], true),
+            (vec![plain_exe.clone()], true),
+            (
+                vec![
+                    plain_exe.clone(),
+                    ArtifactKey::CoreIr {
+                        package: with_flags,
+                        target_kind: TargetKind::Source,
+                    },
+                ],
+                true,
+            ),
+            (vec![flagged_exe.clone()], false),
+            (vec![plain_exe, flagged_exe], false),
+        ] {
+            for candidate in [
+                None,
+                Some(NativeTarget::Aarch64AppleDarwin),
+                Some(NativeTarget::X86_64UnknownLinuxGnu),
+                Some(NativeTarget::X86_64PcWindowsMsvc),
+            ] {
+                let mode =
+                    resolve_native_backend_mode(&resolved, &requested, OptLevel::Debug, candidate);
+                assert_eq!(
+                    mode.direct_target(),
+                    if permits_direct_object {
+                        candidate
+                    } else {
+                        None
+                    },
+                    "requested={requested:?}, candidate={candidate:?}"
+                );
+                let release_mode = resolve_native_backend_mode(
+                    &resolved,
+                    &requested,
+                    OptLevel::Release,
+                    candidate,
+                );
+                assert!(release_mode.direct_target().is_none());
+            }
         }
     }
 

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -33,8 +33,8 @@ slotmap::new_key_type! {
 ///
 /// This is the single source of truth after the user-visible target backend is
 /// resolved. Keeping backend-specific options inside the matching variant
-/// prevents invalid combinations such as a native implementation mode on a
-/// Wasm build.
+/// prevents invalid combinations such as WASI linking on a Native build.
+/// Native payload form is derived by planning and is not a caller option.
 #[derive(Clone, Debug)]
 pub enum BackendConfig {
     Wasm {
@@ -46,7 +46,9 @@ pub enum BackendConfig {
     },
     Js,
     Native {
-        mode: NativeBackendMode,
+        /// Direct object target permitted by the caller's host/environment.
+        /// Planning may still select generated C based on profile and packages.
+        direct_object_candidate: Option<NativeTarget>,
         allocator: NativeAllocator,
     },
     Llvm {
@@ -69,7 +71,7 @@ pub enum NativeTarget {
 
 /// The native implementation selected under the user-visible `native` backend.
 #[derive(Clone, Debug)]
-pub enum NativeBackendMode {
+pub(crate) enum NativeBackendMode {
     /// Legacy generated-C native path.
     GeneratedC,
     /// Experimental direct object-code native path.
@@ -78,21 +80,13 @@ pub enum NativeBackendMode {
 
 /// Concrete direct object-code native implementation.
 #[derive(Clone, Debug)]
-pub enum DirectNativeMode {
+pub(crate) enum DirectNativeMode {
     Target(NativeTarget),
 }
 
 impl NativeTarget {
-    pub fn from_env_for_host() -> Option<Self> {
-        let env_value = std::env::var(ENV_MOONBIT_NEW_NATIVE).ok();
-        Self::from_host_with_new_native_env(
-            std::env::consts::ARCH,
-            std::env::consts::OS,
-            env_value.as_deref(),
-        )
-    }
-
-    fn from_host_with_new_native_env(
+    /// Interpret caller-supplied host and `MOONBIT_NEW_NATIVE` observations.
+    pub fn from_host_with_new_native_env(
         arch: &str,
         os: &str,
         env_value: Option<&str>,
@@ -144,13 +138,6 @@ impl BackendConfig {
             Self::Js => TargetBackend::Js,
             Self::Native { .. } => TargetBackend::Native,
             Self::Llvm { .. } => TargetBackend::LLVM,
-        }
-    }
-
-    pub fn direct_native_target(&self) -> Option<NativeTarget> {
-        match self {
-            Self::Native { mode, .. } => mode.direct_target(),
-            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js | Self::Llvm { .. } => None,
         }
     }
 

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -25,12 +25,25 @@ pub enum BackendConfig {
     Wasm { use_wat: bool, wasi_link: bool },
     WasmGc { use_wat: bool },
     Js,
-    Native(NativeBackendMode),
-    Llvm,
+    Native {
+        direct_object_candidate: Option<NativeTarget>,
+        allocator: NativeAllocator,
+    },
+    Llvm { allocator: NativeAllocator },
 }
 ```
 
-This value is the compile-wide source of truth passed through `CompileConfig`,
+The command adapter captures the Native direct-object candidate from the host
+and environment. Native payload form is derived inside build planning from that
+explicit candidate, the profile, and requested packages, then stored in private
+Backend Plan metadata. The selected mode is not a `BackendConfig` input; both
+Native planning and lowering consume the one value stored in the plan.
+Backend-specific metadata queries and action hydration belong to `BackendPlan`.
+The outer `BuildPlan` exposes artifact relationships and subplan composition;
+RR lowering borrows its backend subplan to read the selected mode and hydrate
+backend actions, without copying that state into another configuration.
+
+`BackendConfig` is the compile-wide source of truth passed through `CompileConfig`,
 `BuildEnvironment`, and `BuildOptions`. An `ArtifactKey` does not repeat the
 backend, optimization profile, or run mode because one `BuildPlan` is scoped
 to one such configuration. If one plan later contains multiple configurations,

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -269,6 +269,14 @@ The generated-C native backend does not require MSVC. If a user explicitly sets 
 whether an independently configured stub compiler is link-compatible with the executable compiler;
 incompatible objects or archives fail naturally when the final linker consumes them.
 
+Native payload selection is internal to RR build planning. `BackendConfig::Native`
+contains the allocator choice and a direct-object candidate captured by the CLI
+from the host and `MOONBIT_NEW_NATIVE`. Callers do not supply the final payload
+mode. The planner derives it from requested artifacts, the build profile, and
+that explicit candidate, without reading the process environment. It stores the
+mode once in its private Backend Plan metadata; toolchain selection and lowering
+consume that same derived value.
+
 Package-level `link.native.cc-flags` apply when compiling the C file emitted by `moonc link-core`.
 If any selected executable package sets these flags, Moon uses the generated-C native backend
 instead of direct object output so the configured flags are not skipped.

--- a/docs/dev/reference/rr-special-cases.md
+++ b/docs/dev/reference/rr-special-cases.md
@@ -33,7 +33,7 @@ important ones and why they exist.
 
 - **Tests can be dropped per package.** `special_cases::should_skip_tests` lists
   packages that should not produce test targets (currently just
-  `moonbitlang/core/abort`). `compile::filter_special_case_requested_artifact`
+  `moonbitlang/core/abort`). `build_plan::build_plan`
   uses this to discard matching test artifact requests before planning.
 - **Coverage rules differ per package.** `should_skip_coverage` ensures abort is
   never instrumented, while `is_self_coverage_lib` says builtin/coverage should


### PR DESCRIPTION
- Related issues: None
- PR kind: Refactor

## Summary

Follow-up to #2149. Native payload selection currently requires the CLI to inspect requested packages and supply a derived mode through public backend configuration. Move that decision into RR backend planning, where the profile and package rules belong.

The CLI captures the host/environment candidate only after Native is selected. RR applies the existing profile and executable-package C-flag rules, then stores the selected mode once in `BackendPlan` for planning and lowering to share. The caller-supplied `mode` field is removed, the mode types become crate-private, and selection uses explicit inputs without reading the process environment.

`BackendPlan` also supplies backend actions with their existing metadata attached. This removes eight individual metadata getters from `BuildPlan` and keeps its interface focused on artifact relationships and subplan composition. No new types or build behavior are introduced.

This is the first stage of the configuration cleanup. Broader `CompilePreConfig` changes and the remaining toolchain environment reads are deferred.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
