### PR TITLE
refactor(build): unify standalone planning and execution

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,6 +104,12 @@ and provider edge. Check, build, proof, and virtual-contract `.mi` files are
 distinct Build Artifacts even when their physical forms match.
 _Avoid_: Output path, action ID, build product
 
+**Dependency Artifact**:
+A Build Artifact belonging to a resolved dependency module outside the current
+project's root modules. This role is independent of execution order, cache
+eligibility, and whether an existing result can satisfy the requirement.
+_Avoid_: Preparation result, cached artifact, reusable artifact
+
 **Artifact Requirement**:
 A declaration that a Build Plan action needs a Build Artifact. It does not name the action that provides the artifact.
 _Avoid_: Action dependency, producer edge

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -199,11 +199,10 @@ fn run_build_for_single_file_rr(
             user_log,
             &resolved,
         )?;
-        planned_runs.push(rr_build::plan_resolved_standalone_build_from_intent(
+        planned_runs.push(rr_build::plan_resolved_build_from_intent(
             compile_config,
             user_log,
             vec![UserIntent::Build(package)].into(),
-            package,
             mooncake_bin_dir,
             resolved.clone(),
         )?);
@@ -212,9 +211,9 @@ fn run_build_for_single_file_rr(
     let ok = if cli.dry_run {
         output.write_result(|writer| {
             let (build_metas, build_inputs): (Vec<_>, Vec<_>) = planned_runs.into_iter().unzip();
-            let build_input = rr_build::compose_standalone_build_inputs(build_inputs)
-                .map_err(std::io::Error::other)?;
-            rr_build::write_standalone_dry_run(
+            let build_input =
+                rr_build::compose_build_inputs(build_inputs).map_err(std::io::Error::other)?;
+            rr_build::write_dry_run(
                 writer,
                 &build_input,
                 build_metas.iter().flat_map(|meta| meta.artifacts.values()),
@@ -228,15 +227,14 @@ fn run_build_for_single_file_rr(
         for (build_meta, _) in &planned_runs {
             rr_build::generate_all_pkgs_json(build_meta)?;
         }
-        let build_input = rr_build::compose_standalone_build_inputs(
+        let build_input = rr_build::compose_build_inputs(
             planned_runs
                 .into_iter()
                 .map(|(_, build_input)| build_input)
                 .collect(),
         )?;
         let config = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);
-        let result =
-            rr_build::execute_standalone_build(&config, build_input, target_dir, user_log)?;
+        let result = rr_build::execute_build(&config, build_input, target_dir, user_log)?;
         result.print_info(cli.quiet, "building")?;
         result.successful()
     };

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -210,11 +210,6 @@ struct BuildExecutableFromPlanOptions {
     embedded_mbtx_policy: Option<EmbeddedMbtxPolicy>,
 }
 
-enum RunBuildInput {
-    Ordinary(rr_build::BuildInput),
-    Standalone(rr_build::StandaloneBuildInput),
-}
-
 impl RunExecutable {
     pub(crate) fn ensure_build_success(&self) -> anyhow::Result<()> {
         if let Some(build_exit_code) = self.build_exit_code
@@ -576,7 +571,7 @@ fn build_package_executable(
         source_dir,
         target_dir,
         &build_meta,
-        RunBuildInput::Ordinary(build_graph),
+        build_graph,
         BuildExecutableFromPlanOptions {
             print_dry_run_run_command: options.print_dry_run_run_command,
             output: options.output,
@@ -792,11 +787,10 @@ fn build_single_file_executable(
         Default::default()
     };
     let intent = (vec![UserIntent::Run(package)], directive).into();
-    let (build_meta, build_graph) = rr_build::plan_resolved_standalone_build_from_intent(
+    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         compile_config,
         user_log,
         intent,
-        package,
         mooncake_bin_dir,
         resolved,
     )?;
@@ -807,7 +801,7 @@ fn build_single_file_executable(
         source_dir,
         target_dir,
         &build_meta,
-        RunBuildInput::Standalone(build_graph),
+        build_graph,
         BuildExecutableFromPlanOptions {
             print_dry_run_run_command: options.print_dry_run_run_command,
             output: options.output,
@@ -827,7 +821,7 @@ fn build_executable_from_plan(
     source_dir: &Path,
     target_dir: &Path,
     build_meta: &rr_build::BuildMeta,
-    build_graph: RunBuildInput,
+    build_graph: rr_build::BuildInput,
     options: BuildExecutableFromPlanOptions,
     output: &CommandOutput,
 ) -> Result<RunExecutable, anyhow::Error> {
@@ -838,22 +832,13 @@ fn build_executable_from_plan(
     let user_log = output.user_log();
     if cli.dry_run {
         output.write_result(|writer| {
-            match &build_graph {
-                RunBuildInput::Ordinary(build_graph) => rr_build::write_dry_run(
-                    writer,
-                    build_graph,
-                    build_meta.artifacts.values(),
-                    source_dir,
-                    target_dir,
-                )?,
-                RunBuildInput::Standalone(build_graph) => rr_build::write_standalone_dry_run(
-                    writer,
-                    build_graph,
-                    build_meta.artifacts.values(),
-                    source_dir,
-                    target_dir,
-                )?,
-            }
+            rr_build::write_dry_run(
+                writer,
+                &build_graph,
+                build_meta.artifacts.values(),
+                source_dir,
+                target_dir,
+            )?;
 
             if options.print_dry_run_run_command {
                 let run_cmd = get_run_cmd(build_meta, &cmd.args, moonrun_policy, policy_source_dir);
@@ -884,14 +869,7 @@ fn build_executable_from_plan(
     let build_config =
         BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose)
             .with_suppressed_progress(options.output.suppress_build_progress());
-    let build_result = match build_graph {
-        RunBuildInput::Ordinary(build_graph) => {
-            rr_build::execute_build(&build_config, build_graph, target_dir, user_log)?
-        }
-        RunBuildInput::Standalone(build_graph) => {
-            rr_build::execute_standalone_build(&build_config, build_graph, target_dir, user_log)?
-        }
-    };
+    let build_result = rr_build::execute_build(&build_config, build_graph, target_dir, user_log)?;
 
     Ok(RunExecutable {
         executable: get_run_executable(build_meta).to_path_buf(),

--- a/crates/moon/src/rr_build/dry_run.rs
+++ b/crates/moon/src/rr_build/dry_run.rs
@@ -24,7 +24,7 @@ use std::{
     process::Command,
 };
 
-use crate::rr_build::{BuildInput, StandaloneBuildInput};
+use crate::rr_build::BuildInput;
 
 /// Write what would be executed in a dry-run.
 ///
@@ -38,7 +38,7 @@ pub fn write_dry_run<'a>(
 ) -> std::io::Result<()> {
     let (graph, command_args_by_output) = input
         .execution_plan
-        .to_n2_graph(input.action_ids.iter().copied())
+        .all_to_n2_graph()
         .map_err(std::io::Error::other)?;
     let default_files = graph
         .get_start_nodes()
@@ -71,7 +71,7 @@ pub fn write_dry_run_all(
 ) -> std::io::Result<()> {
     let (graph, command_args_by_output) = input
         .execution_plan
-        .to_n2_graph(input.action_ids.iter().copied())
+        .all_to_n2_graph()
         .map_err(std::io::Error::other)?;
     let default_files = graph.get_start_nodes();
     moonbuild::dry_run::write_build_commands(
@@ -82,20 +82,6 @@ pub fn write_dry_run_all(
         source_dir,
         target_dir,
     )
-}
-
-/// Write standalone dependency commands before the selected script commands.
-pub fn write_standalone_dry_run<'a>(
-    output: &mut dyn Write,
-    input: &StandaloneBuildInput,
-    artifacts: impl IntoIterator<Item = &'a Vec<PathBuf>>,
-    source_dir: &Path,
-    target_dir: &Path,
-) -> std::io::Result<()> {
-    if let Some(dependencies) = input.dependencies.as_ref() {
-        write_dry_run_all(output, dependencies, source_dir, target_dir)?;
-    }
-    write_dry_run(output, &input.script, artifacts, source_dir, target_dir)
 }
 
 /// Format a command as it would be executed, with the proper escaping.

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -70,9 +70,7 @@ use crate::build_flags::{BuildFlags, OutputStyle};
 
 pub mod action_identity;
 mod dry_run;
-pub use dry_run::{
-    format_dry_run_command, write_dry_run, write_dry_run_all, write_standalone_dry_run,
-};
+pub use dry_run::{format_dry_run_command, write_dry_run, write_dry_run_all};
 
 /// Synchronize dependencies and return resolved project data.
 /// Target-directory lock ownership remains with the command layer.
@@ -465,13 +463,9 @@ pub(crate) fn plan_resolved_build_from_intent(
         .requested_artifact_paths()
         .map(|(artifact, paths)| (artifact.clone(), paths.to_vec()))
         .collect();
-    let action_ids = compile_output
+    let action_backends = compile_output
         .execution_plan
         .action_ids()
-        .collect::<Vec<_>>();
-    let action_backends = action_ids
-        .iter()
-        .copied()
         .map(|id| (id, Some(cx.backend.target_backend())))
         .collect();
     let execution_plan = Rc::new(compile_output.execution_plan);
@@ -486,111 +480,12 @@ pub(crate) fn plan_resolved_build_from_intent(
     let db_path = cx.artifact_paths.target_layout().n2_db_path();
     let input = BuildInput {
         execution_plan,
-        action_ids,
         action_backends,
         db_path,
     };
 
     info!("Build planning completed successfully");
 
-    Ok((build_meta, input))
-}
-
-/// Plan dependency-package and synthesized script-package work independently.
-///
-/// This entry point is intentionally used only by standalone `.mbt`/`.mbtx`
-/// builds. Normal workspace commands continue through
-/// [`plan_resolved_build_from_intent`].
-#[instrument(level = Level::DEBUG, skip_all)]
-pub(crate) fn plan_resolved_standalone_build_from_intent(
-    cx: CompileConfig,
-    user_log: &UserLog,
-    intent: CalcUserIntentOutput,
-    script_package: PackageId,
-    mooncake_bin_dir: &Path,
-    resolve_output: ResolveOutput,
-) -> anyhow::Result<(BuildMeta, StandaloneBuildInput)> {
-    let target_dir = cx.target_dir.clone();
-    info!("Standalone user intent calculated: {:?}", intent.intents);
-
-    // Module-level configuration discovers native toolchains and flags; other
-    // backends do not need to execute these scripts.
-    let prebuild_config = if cx.action == RunMode::Check || !cx.backend.target_backend().is_native()
-    {
-        info!("Skipping prebuild configuration for check or non-native backend");
-        None
-    } else {
-        info!("Running prebuild configuration");
-        let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
-        Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
-    };
-
-    let requested_artifacts =
-        intent.requested_artifacts(&resolve_output, user_log, cx.backend.target_backend());
-    let compile_output = moonbuild_rupes_recta::compile_standalone(
-        &cx,
-        mooncake_bin_dir,
-        &resolve_output,
-        &requested_artifacts,
-        script_package,
-        &intent.directive,
-        prebuild_config.as_ref(),
-        user_log,
-    )?;
-
-    if cx.debug_export_build_plan
-        && let Some(plan) = compile_output.build_plan.as_deref()
-    {
-        moonbuild_rupes_recta::util::print_build_plan_dot(
-            plan,
-            &resolve_output.module_rel,
-            &resolve_output.pkg_dirs,
-            &mut std::fs::File::create(target_dir.join("build_plan.dot"))?,
-        )?;
-    }
-
-    let artifacts = compile_output
-        .execution_plan
-        .requested_artifact_paths()
-        .map(|(artifact, paths)| (artifact.clone(), paths.to_vec()))
-        .collect();
-    let build_meta = BuildMeta {
-        resolve_output,
-        artifacts,
-        backend: cx.backend.clone(),
-        opt_level: cx.opt_level,
-        artifact_paths: cx.artifact_paths.clone(),
-    };
-    let backend = cx.backend.target_backend();
-    let layout = cx.artifact_paths.target_layout();
-    let dependency_actions = compile_output.dependency_actions;
-    let script_actions = compile_output.script_actions;
-    let execution_plan = Rc::new(compile_output.execution_plan);
-    let action_backends = execution_plan
-        .action_ids()
-        .map(|id| (id, Some(backend)))
-        .collect::<HashMap<_, _>>();
-    let dependency_input = if dependency_actions.is_empty() {
-        None
-    } else {
-        Some(BuildInput {
-            execution_plan: Rc::clone(&execution_plan),
-            action_ids: dependency_actions,
-            action_backends: action_backends.clone(),
-            db_path: layout.n2_db_path(),
-        })
-    };
-    let input = StandaloneBuildInput {
-        dependencies: dependency_input,
-        script: BuildInput {
-            execution_plan,
-            action_ids: script_actions,
-            action_backends,
-            db_path: layout.n2_db_path(),
-        },
-    };
-
-    info!("Standalone build planning completed successfully");
     Ok((build_meta, input))
 }
 
@@ -615,11 +510,12 @@ pub fn plan_fmt(
         resolved,
         BuildProfile::Debug,
     );
-    let action_ids = execution_plan.action_ids().collect::<Vec<_>>();
-    let action_backends = action_ids.iter().map(|&action| (action, None)).collect();
+    let action_backends = execution_plan
+        .action_ids()
+        .map(|action| (action, None))
+        .collect();
     Ok(BuildInput {
         execution_plan,
-        action_ids,
         action_backends,
         db_path: layout.n2_db_path(),
     })
@@ -727,8 +623,8 @@ fn collect_check_commands_by_output(
     build_input: &BuildInput,
 ) -> moonbuild_rupes_recta::metadata::CheckCommandMap {
     let mut commands = BTreeMap::new();
-    for id in &build_input.action_ids {
-        let action = build_input.execution_plan.action(*id);
+    for id in build_input.execution_plan.action_ids() {
+        let action = build_input.execution_plan.action(id);
         let Some(command_args) = check_command_args_without_executable(action.command().args())
         else {
             continue;
@@ -851,48 +747,17 @@ impl Default for BuildConfig {
     }
 }
 
-/// The input to a build execution.
+/// A complete execution plan and the context needed to execute it.
 #[derive(Debug, Clone)]
 pub struct BuildInput {
     /// Executor-neutral actions shared by execution and its projections.
     execution_plan: Rc<ExecutionPlan>,
-
-    /// The portion of the Execution Plan owned by this execution phase.
-    action_ids: Vec<ActionId>,
 
     /// Target Backend for each action. Shared actions have no single backend.
     action_backends: HashMap<ActionId, Option<TargetBackend>>,
 
     /// The n2 database for the selected target directory.
     db_path: PathBuf,
-}
-
-/// Dependency-package and script-package inputs for a standalone build.
-///
-/// Keeping this orchestration outside [`BuildInput`] lets ordinary workspace
-/// execution remain a single-graph operation.
-#[derive(Debug, Clone)]
-pub struct StandaloneBuildInput {
-    dependencies: Option<BuildInput>,
-    script: BuildInput,
-}
-
-impl StandaloneBuildInput {
-    fn compose(inputs: Vec<Self>) -> anyhow::Result<Self> {
-        let mut dependencies = Vec::new();
-        let mut scripts = Vec::with_capacity(inputs.len());
-        for input in inputs {
-            dependencies.extend(input.dependencies);
-            scripts.push(input.script);
-        }
-
-        Ok(Self {
-            dependencies: (!dependencies.is_empty())
-                .then(|| BuildInput::compose(dependencies))
-                .transpose()?,
-            script: BuildInput::compose(scripts)?,
-        })
-    }
 }
 
 #[cfg(test)]
@@ -906,8 +771,7 @@ impl BuildInput {
         ),
         moonbuild_rupes_recta::execution_plan::N2AdapterError,
     > {
-        self.execution_plan
-            .to_n2_graph(self.action_ids.iter().copied())
+        self.execution_plan.all_to_n2_graph()
     }
 }
 
@@ -923,9 +787,7 @@ impl BuildInput {
         let db_path = first.db_path.clone();
 
         let mut execution_plan = ExecutionPlan::default();
-        let mut action_ids = Vec::new();
         let mut action_backends = HashMap::new();
-        let mut selected = HashSet::new();
 
         for input in std::iter::once(first)
             .chain(std::iter::once(second))
@@ -936,7 +798,6 @@ impl BuildInput {
                 "cannot compose build inputs with different target layouts"
             );
             let existing_actions = execution_plan.action_ids().collect::<HashSet<_>>();
-            let selected_actions = input.action_ids.iter().copied().collect::<HashSet<_>>();
             let remapped = execution_plan.merge(&input.execution_plan)?;
             for (old, new) in input.execution_plan.action_ids().zip(remapped) {
                 if existing_actions.contains(&new) {
@@ -946,15 +807,11 @@ impl BuildInput {
                 } else {
                     action_backends.insert(new, input.action_backends.get(&old).copied().flatten());
                 }
-                if selected_actions.contains(&old) && selected.insert(new) {
-                    action_ids.push(new);
-                }
             }
         }
 
         Ok(Self {
             execution_plan: Rc::new(execution_plan),
-            action_ids,
             action_backends,
             db_path,
         })
@@ -965,7 +822,7 @@ impl BuildInput {
     ) -> Result<N2ExecutionInput, moonbuild_rupes_recta::execution_plan::N2AdapterError> {
         let adapted = self
             .execution_plan
-            .adapt_to_n2(self.action_ids.iter().copied())?;
+            .adapt_to_n2(self.execution_plan.action_ids())?;
         let (graph, _, action_by_build) = adapted.into_parts_with_actions();
         let backend_by_build = action_by_build
             .into_iter()
@@ -987,12 +844,6 @@ struct N2ExecutionInput {
 
 pub(crate) fn compose_build_inputs(inputs: Vec<BuildInput>) -> anyhow::Result<BuildInput> {
     BuildInput::compose(inputs)
-}
-
-pub(crate) fn compose_standalone_build_inputs(
-    inputs: Vec<StandaloneBuildInput>,
-) -> anyhow::Result<StandaloneBuildInput> {
-    StandaloneBuildInput::compose(inputs)
 }
 
 struct CapturedBuildExecution {
@@ -1047,7 +898,7 @@ impl CapturedBuildExecution {
 /// Returns just the build result - callers should use the resolve data and
 /// artifacts from the planning phase for any metadata they need.
 ///
-/// The caller must hold the target-directory lock. All ordinary executions in
+/// The caller must hold the target-directory lock. All executions in
 /// that directory share one n2 database, and n2 does not lock it internally.
 #[instrument(skip_all)]
 pub fn execute_build(
@@ -1138,52 +989,6 @@ pub fn execute_build_json(
         hidden_warnings,
         diagnostics,
         non_diagnostic_output,
-    })
-}
-
-/// Execute standalone dependency-package work before script-package work.
-#[instrument(skip_all)]
-pub fn execute_standalone_build(
-    cfg: &BuildConfig,
-    input: StandaloneBuildInput,
-    target_dir: &Path,
-    user_log: &UserLog,
-) -> anyhow::Result<N2RunStats> {
-    let Some(dependencies) = input.dependencies else {
-        return execute_build(cfg, input.script, target_dir, user_log);
-    };
-
-    let dependency_execution = execute_build_capturing(cfg, dependencies, target_dir)?;
-    if !dependency_execution.successful() {
-        return Ok(finish_captured_build(
-            cfg,
-            &dependency_execution,
-            None,
-            user_log,
-        ));
-    }
-
-    let script_execution = match execute_build_capturing(cfg, input.script, target_dir) {
-        Ok(execution) => execution,
-        Err(error) => {
-            // Preserve dependency output if the second executor fails before it
-            // can return captured output for command-level processing.
-            finish_captured_build(cfg, &dependency_execution, None, user_log);
-            return Err(error);
-        }
-    };
-    let mut diagnostic_sources = dependency_execution.diagnostic_sources([]);
-    diagnostic_sources.extend(script_execution.diagnostic_sources([]));
-    let processed = process_captured_diagnostics(&diagnostic_sources, cfg);
-    processed.warn_if_limited(user_log);
-
-    Ok(N2RunStats {
-        n_tasks_executed: script_execution
-            .n_tasks_executed
-            .zip(dependency_execution.n_tasks_executed)
-            .map(|(script, dependencies)| script + dependencies),
-        n_errors: processed.n_errors,
-        n_warnings: processed.n_warnings,
     })
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -18,12 +18,7 @@
 
 //! Lowers the normalized action plan into an executor-neutral Execution Plan.
 
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-    str::FromStr,
-    sync::OnceLock,
-};
+use std::{path::PathBuf, str::FromStr, sync::OnceLock};
 
 use log::{debug, info};
 use moonutil::{
@@ -34,9 +29,9 @@ use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    build_plan::{BackendPlan, BuildPlan, BuildPlanActionKey},
-    execution_plan::{ActionId, ExecutionPlan, ExecutionPlanBuilder},
-    model::{BackendConfig, BuildPlanNode, OperatingSystem, PackageId},
+    build_plan::{BackendPlan, BuildPlan},
+    execution_plan::{ExecutionPlan, ExecutionPlanBuilder},
+    model::{BackendConfig, OperatingSystem},
     target_layout::{
         ArtifactPathOptions, ArtifactPathResolver, ExecutableArtifact, LinkedCoreArtifact,
     },
@@ -215,143 +210,17 @@ pub fn lower_build_plan(
         opt.debug_symbols
     );
 
-    let (result, _) = lower_actions(resolve_output, plan, opt)?;
-
-    info!("Action plan lowering completed successfully");
-    Ok(result)
-}
-
-pub(crate) struct StandaloneExecutionPlan {
-    pub(crate) plan: ExecutionPlan,
-    pub(crate) dependency_actions: Vec<ActionId>,
-    pub(crate) script_actions: Vec<ActionId>,
-}
-
-/// Lower one standalone Build Plan and retain its two execution projections.
-#[instrument(skip_all)]
-pub(crate) fn lower_standalone_build_plan(
-    resolve_output: &ResolveOutput,
-    plan: &BuildPlan,
-    opt: &BuildOptions,
-    script_package: PackageId,
-) -> Result<StandaloneExecutionPlan, LoweringError> {
-    info!("Projecting standalone dependency and script execution actions");
-    let (dependency_nodes, script_nodes) = partition_standalone_actions(plan, script_package);
-    debug!(
-        "Standalone execution projection contains {} dependency actions and {} script actions",
-        dependency_nodes.len(),
-        script_nodes.len()
-    );
-
-    let (plan, action_ids) = lower_actions(resolve_output, plan, opt)?;
-    Ok(StandaloneExecutionPlan {
-        plan,
-        dependency_actions: dependency_nodes
-            .into_iter()
-            .map(|node| action_ids[&node])
-            .collect(),
-        script_actions: script_nodes
-            .into_iter()
-            .map(|node| action_ids[&node])
-            .collect(),
-    })
-}
-
-fn lower_actions(
-    resolve_output: &ResolveOutput,
-    plan: &BuildPlan,
-    opt: &BuildOptions,
-) -> Result<(ExecutionPlan, HashMap<BuildPlanActionKey, ActionId>), LoweringError> {
     let mut ctx = LoweringContext::new(opt.artifact_paths.clone(), resolve_output, plan, opt);
     let mut execution = ExecutionPlanBuilder::default();
-    let mut action_ids = HashMap::new();
 
     for action_key in plan.all_actions() {
         debug!("Lowering action: {:?}", action_key);
-        let action = ctx.lower_action(&action_key, &mut execution)?;
-        action_ids.insert(action_key, action);
+        ctx.lower_action(&action_key, &mut execution)?;
     }
 
-    Ok((
-        execution.finish(plan.requested_artifacts().cloned()),
-        action_ids,
-    ))
-}
-
-/// Separate reusable package preparation from work owned by the synthesized
-/// script package while preserving the semantic plan's dependency closure.
-fn partition_standalone_actions(
-    plan: &BuildPlan,
-    script_package: PackageId,
-) -> (Vec<BuildPlanActionKey>, Vec<BuildPlanActionKey>) {
-    let action_package = |action: &BuildPlanActionKey| match action {
-        BuildPlanActionKey::Backend(node) => match node {
-            BuildPlanNode::Check(target)
-            | BuildPlanNode::EmitProof(target)
-            | BuildPlanNode::Prove(target)
-            | BuildPlanNode::BuildCore(target)
-            | BuildPlanNode::LinkCore(target)
-            | BuildPlanNode::MakeExecutable(target)
-            | BuildPlanNode::GenerateDsym(target)
-            | BuildPlanNode::GenerateTestInfo(target)
-            | BuildPlanNode::GenerateMbti(target) => Some(target.package),
-            BuildPlanNode::BuildCStub(package, _)
-            | BuildPlanNode::ArchiveOrLinkCStubs(package)
-            | BuildPlanNode::GenerateNodeTestPackageConfig(package)
-            | BuildPlanNode::BuildVirtual(package) => Some(*package),
-            BuildPlanNode::Bundle(_)
-            | BuildPlanNode::BuildRuntimeObject(_)
-            | BuildPlanNode::BuildRuntimeLib
-            | BuildPlanNode::BuildDocs(_) => None,
-        },
-        BuildPlanActionKey::PackagePrebuild(key) => Some(key.package()),
-    };
-    let actions = plan.all_actions().collect::<Vec<_>>();
-    let script_owned_actions = actions
-        .iter()
-        .filter(|action| action_package(action) == Some(script_package))
-        .cloned()
-        .collect::<HashSet<_>>();
-    assert!(
-        !script_owned_actions.is_empty(),
-        "standalone action plan should contain work for the synthesized script package"
-    );
-
-    let mut dependency_actions = actions
-        .iter()
-        .filter(|action| action_package(action).is_some_and(|package| package != script_package))
-        .cloned()
-        .collect::<HashSet<_>>();
-    let mut pending = dependency_actions.iter().cloned().collect::<Vec<_>>();
-    while let Some(action) = pending.pop() {
-        for dependency in plan.dependency_actions(&action) {
-            assert!(
-                !script_owned_actions.contains(&dependency),
-                "standalone dependency preparation action {action:?} depends on \
-                 script action {dependency:?}"
-            );
-            if dependency_actions.insert(dependency.clone()) {
-                pending.push(dependency);
-            }
-        }
-    }
-    assert!(
-        plan.requested_artifacts()
-            .map(|artifact| plan.artifact_provider(artifact))
-            .all(|action| !dependency_actions.contains(&action)),
-        "standalone root action should remain in the script execution phase"
-    );
-
-    let dependencies = actions
-        .iter()
-        .filter(|action| dependency_actions.contains(action))
-        .cloned()
-        .collect();
-    let script = actions
-        .into_iter()
-        .filter(|action| !dependency_actions.contains(action))
-        .collect();
-    (dependencies, script)
+    let mut execution = execution.finish(plan.requested_artifacts().cloned());
+    execution.mark_dependency_artifacts(resolve_output);
+    Ok(execution)
 }
 
 #[cfg(test)]
@@ -370,13 +239,12 @@ mod tests {
         target::TargetBackend,
         toolchain::BINARIES,
     };
-    use slotmap::KeyData;
     use walkdir::WalkDir;
 
     use crate::{
         build_plan::{
-            ArtifactKey, BuildCStubsInfo, BuildPlan, BuildRuntimeInfo, BuildTargetInfo,
-            LinkCoreInfo, MakeExecutableInfo,
+            ArtifactKey, BuildCStubsInfo, BuildPlan, BuildPlanActionKey, BuildRuntimeInfo,
+            BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo,
         },
         discover::{DiscoverResult, DiscoveredPackage},
         model::{
@@ -791,145 +659,6 @@ mod tests {
     }
 
     #[test]
-    fn standalone_projection_uses_dependency_closure_for_shared_actions() {
-        let script_package = PackageId::from(KeyData::from_ffi(1));
-        let dependency_package = PackageId::from(KeyData::from_ffi(2));
-        let script_target = script_package.build_target(TargetKind::Source);
-        let script_node = BuildPlanNode::MakeExecutable(script_target);
-        let dependency_node = BuildPlanNode::ArchiveOrLinkCStubs(dependency_package);
-        let runtime_node = BuildPlanNode::BuildRuntimeLib;
-
-        let mut plan = BuildPlan::default();
-        plan.test_add_node(script_node);
-        plan.test_add_node(dependency_node);
-        plan.test_add_node(runtime_node);
-        connect_artifact(
-            &mut plan,
-            script_node,
-            dependency_node,
-            ArtifactKey::CStubLibrary {
-                package: dependency_package,
-            },
-        );
-        connect_artifact(
-            &mut plan,
-            script_node,
-            runtime_node,
-            ArtifactKey::RuntimeLibrary,
-        );
-        connect_artifact(
-            &mut plan,
-            dependency_node,
-            runtime_node,
-            ArtifactKey::RuntimeLibrary,
-        );
-        plan.test_insert_c_stubs_info(
-            dependency_package,
-            BuildCStubsInfo {
-                effective_native_toolchain: msvc_toolchain(),
-                cc_flags: Vec::new(),
-                link_flags: Vec::new(),
-                static_archive_fingerprint: None,
-            },
-        );
-        plan.test_insert_runtime_info(BuildRuntimeInfo {
-            effective_native_toolchain: msvc_toolchain(),
-            source_files: vec![PathBuf::from("runtime.c")],
-            simdutf_objects: Vec::new(),
-            static_archive_fingerprint: Some("runtime-test".to_string()),
-            native_allocator: NativeAllocator::Default,
-        });
-
-        let (dependency_nodes, script_nodes) = partition_standalone_actions(&plan, script_package);
-        let dependency_nodes = dependency_nodes.into_iter().collect::<HashSet<_>>();
-        let script_nodes = script_nodes.into_iter().collect::<HashSet<_>>();
-
-        assert_eq!(
-            dependency_nodes,
-            HashSet::from([
-                BuildPlanActionKey::Backend(dependency_node),
-                BuildPlanActionKey::Backend(runtime_node),
-            ])
-        );
-        assert_eq!(
-            script_nodes,
-            HashSet::from([BuildPlanActionKey::Backend(script_node)])
-        );
-    }
-
-    #[test]
-    fn standalone_projection_keeps_script_only_shared_actions_with_script() {
-        let script_package = PackageId::from(KeyData::from_ffi(1));
-        let script_target = script_package.build_target(TargetKind::Source);
-        let script_node = BuildPlanNode::MakeExecutable(script_target);
-        let runtime_node = BuildPlanNode::BuildRuntimeLib;
-
-        let mut plan = BuildPlan::default();
-        plan.test_add_node(script_node);
-        plan.test_add_node(runtime_node);
-        connect_artifact(
-            &mut plan,
-            script_node,
-            runtime_node,
-            ArtifactKey::RuntimeLibrary,
-        );
-        plan.test_insert_runtime_info(BuildRuntimeInfo {
-            effective_native_toolchain: msvc_toolchain(),
-            source_files: vec![PathBuf::from("runtime.c")],
-            simdutf_objects: Vec::new(),
-            static_archive_fingerprint: Some("runtime-test".to_string()),
-            native_allocator: NativeAllocator::Default,
-        });
-
-        let (dependency_actions, script_nodes) =
-            partition_standalone_actions(&plan, script_package);
-        let script_nodes = script_nodes.into_iter().collect::<HashSet<_>>();
-
-        assert!(dependency_actions.is_empty());
-        assert_eq!(
-            script_nodes,
-            HashSet::from([
-                BuildPlanActionKey::Backend(script_node),
-                BuildPlanActionKey::Backend(runtime_node),
-            ])
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "depends on script action")]
-    fn standalone_projection_rejects_dependency_work_requiring_script_action() {
-        let script_package = PackageId::from(KeyData::from_ffi(1));
-        let dependency_package = PackageId::from(KeyData::from_ffi(2));
-        let script_node =
-            BuildPlanNode::MakeExecutable(script_package.build_target(TargetKind::Source));
-        let dependency_node = BuildPlanNode::ArchiveOrLinkCStubs(dependency_package);
-
-        let mut plan = BuildPlan::default();
-        plan.test_add_node(script_node);
-        plan.test_add_node(dependency_node);
-        connect_artifact(
-            &mut plan,
-            dependency_node,
-            script_node,
-            ArtifactKey::Executable {
-                package: script_package,
-                target_kind: TargetKind::Source,
-            },
-        );
-        plan.test_insert_c_stubs_info(
-            dependency_package,
-            BuildCStubsInfo {
-                effective_native_toolchain: msvc_toolchain(),
-                cc_flags: Vec::new(),
-                link_flags: Vec::new(),
-                static_archive_fingerprint: None,
-            },
-        );
-
-        partition_standalone_actions(&plan, script_package);
-    }
-
-    #[test]
     fn lowered_windows_msvc_native_graph_contains_complete_commands_and_tool_inputs() {
         let (resolve_output, target) = single_package_resolve_output();
         let runtime_node = BuildPlanNode::BuildRuntimeLib;
@@ -1073,21 +802,30 @@ mod tests {
             lowering_environment,
         };
 
-        let nodes = [c_stub_node, exe_node];
-        let (execution, actions) =
-            lower_actions(&resolve_output, &plan, &options).expect("lowering should succeed");
-        for node in nodes {
+        let execution =
+            lower_build_plan(&resolve_output, &plan, &options).expect("lowering should succeed");
+        let opaque_actions = execution
+            .action_ids()
+            .filter(|id| {
+                execution.action(*id).outputs().iter().any(|path| {
+                    matches!(
+                        execution
+                            .declared_output(path)
+                            .and_then(|output| output.artifact()),
+                        Some(ArtifactKey::CStubObject { .. } | ArtifactKey::Executable { .. })
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(opaque_actions.len(), 2);
+        for action in opaque_actions {
             assert!(
-                !execution
-                    .action(actions[&BuildPlanActionKey::Backend(node)])
-                    .is_cache_eligible(),
-                "{node:?} with opaque flags should be ineligible"
+                !execution.action(action).is_cache_eligible(),
+                "C stub and executable actions with opaque flags should be ineligible"
             );
         }
 
-        let lowered = adapt_execution_plan(
-            lower_build_plan(&resolve_output, &plan, &options).expect("lowering should succeed"),
-        );
+        let lowered = adapt_execution_plan(execution);
         let exe_path = artifact_paths.target_layout().executable_of_build_target(
             &resolve_output.pkg_dirs,
             &target,

--- a/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
@@ -130,6 +130,18 @@ pub enum ArtifactKey {
 }
 
 impl ArtifactKey {
+    /// Package ownership used to identify an artifact's module membership.
+    /// This does not form part of an artifact's execution or cache policy.
+    pub(crate) fn package(&self) -> Option<PackageId> {
+        match self {
+            Self::VirtualContractMi { package }
+            | Self::NodeTestPackageConfig { package }
+            | Self::CStubObject { package, .. }
+            | Self::CStubLibrary { package } => Some(*package),
+            _ => self.package_target().map(|target| target.package),
+        }
+    }
+
     /// The package target whose compilation lifecycle owns this artifact.
     /// Module-wide, package-wide, and runtime artifacts have no
     /// `BuildTarget` identity.

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -243,6 +243,7 @@ impl BuildPlan {
         .cloned()
     }
 
+    #[cfg(test)]
     pub(crate) fn artifact_provider(&self, artifact: &ArtifactKey) -> BuildPlanActionKey {
         BuildPlanActionKey::Backend(
             self.artifacts

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -24,7 +24,7 @@ use tracing::instrument;
 use crate::{
     build_lower::{self, LoweringEnvironment, WarningCondition},
     build_plan::{self, ArtifactKey, BuildEnvironment, InputDirective},
-    execution_plan::{ActionId, ExecutionPlan},
+    execution_plan::ExecutionPlan,
     model::{BackendConfig, OperatingSystem},
     prebuild::PrebuildOutput,
     resolve::ResolveOutput,
@@ -78,16 +78,6 @@ pub struct CompileOutput {
     pub build_plan: Option<Box<build_plan::BuildPlan>>,
 }
 
-/// Dependency preparation and script execution projected from one logical
-/// standalone build plan.
-pub struct StandaloneCompileOutput {
-    /// One concrete plan shared by dependency preparation and script execution.
-    pub execution_plan: ExecutionPlan,
-    pub dependency_actions: Vec<ActionId>,
-    pub script_actions: Vec<ActionId>,
-    pub build_plan: Option<Box<build_plan::BuildPlan>>,
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum CompileGraphError {
     #[error("Failed to build a build plan for the modules")]
@@ -126,52 +116,6 @@ pub fn compile(
     debug!("Build plan contains {} actions", plan.action_count());
 
     lower_plan(cx, resolve_output, plan)
-}
-
-#[allow(clippy::too_many_arguments)]
-#[instrument(skip_all)]
-pub fn compile_standalone(
-    cx: &CompileConfig,
-    mooncake_bin_dir: &Path,
-    resolve_output: &ResolveOutput,
-    requested_artifacts: &[ArtifactKey],
-    script_package: crate::model::PackageId,
-    input_directive: &InputDirective,
-    prebuild_config: Option<&PrebuildOutput>,
-    user_log: &UserLog,
-) -> Result<StandaloneCompileOutput, CompileGraphError> {
-    info!("Building one logical plan for standalone dependency and script work");
-    let build_env = build_environment(cx);
-    let plan = build_plan::build_plan(
-        resolve_output,
-        mooncake_bin_dir,
-        &build_env,
-        requested_artifacts.iter().cloned(),
-        input_directive,
-        prebuild_config,
-        user_log,
-    )?;
-
-    info!("Standalone build plan created successfully");
-    debug!(
-        "Standalone build plan contains {} actions",
-        plan.action_count()
-    );
-
-    let lower_env = lowering_options(cx);
-    let lowered = build_lower::lower_standalone_build_plan(
-        resolve_output,
-        &plan,
-        &lower_env,
-        script_package,
-    )?;
-
-    Ok(StandaloneCompileOutput {
-        execution_plan: lowered.plan,
-        dependency_actions: lowered.dependency_actions,
-        script_actions: lowered.script_actions,
-        build_plan: cx.debug_export_build_plan.then(|| Box::new(plan)),
-    })
 }
 
 // TODO: Remove `build_environment` and `lowering_options` once planning and
@@ -258,7 +202,7 @@ mod tests {
         target_layout::{ArtifactPathResolver, TargetLayout, TargetLayoutMode},
     };
 
-    use super::{CompileConfig, compile, compile_standalone};
+    use super::{CompileConfig, compile};
 
     fn moon_mod() -> MoonMod {
         MoonMod {
@@ -487,7 +431,16 @@ mod tests {
     }
 
     #[test]
-    fn standalone_compile_separates_dependency_preparation_from_script_graph() {
+    fn project_packages_are_not_marked_as_dependency_artifacts() {
+        assert_compiled_artifact_roles(false);
+    }
+
+    #[test]
+    fn local_path_dependencies_are_marked_before_execution_policy() {
+        assert_compiled_artifact_roles(true);
+    }
+
+    fn assert_compiled_artifact_roles(separate_module: bool) {
         let module_source = ModuleSource::local_path(
             "test/single"
                 .parse::<ModuleName>()
@@ -495,18 +448,40 @@ mod tests {
             PathBuf::from("."),
             DEFAULT_VERSION.clone(),
         );
-        let (modules, module) = ResolvedEnv::only_one_module(module_source.clone(), moon_mod());
+        let (mut modules, module) = ResolvedEnv::only_one_module(module_source.clone(), moon_mod());
+        let dependency_source = if separate_module {
+            ModuleSource::local_path(
+                "test/dependency"
+                    .parse()
+                    .expect("dependency module should parse"),
+                PathBuf::from("../dependency"),
+                DEFAULT_VERSION.clone(),
+            )
+        } else {
+            module_source.clone()
+        };
+        let mut dependency_info = moon_mod();
+        dependency_info.name = dependency_source.name().to_string();
+        let dependency_module =
+            modules.add_module(dependency_source.clone(), dependency_info.clone().into());
         let mut packages = DiscoverResult::default();
         packages.test_register_module(module, moon_mod());
+        packages.test_register_module(dependency_module, dependency_info);
         let script = packages.test_add_package(
             module,
             PackagePath::new("script").expect("script path should parse"),
             package(module, &module_source, "script", true, true),
         );
         let dependency = packages.test_add_package(
-            module,
+            dependency_module,
             PackagePath::new("dependency").expect("dependency path should parse"),
-            package(module, &module_source, "dependency", false, false),
+            package(
+                dependency_module,
+                &dependency_source,
+                "dependency",
+                false,
+                false,
+            ),
         );
         let script_target = script.build_target(TargetKind::Source);
         let dependency_target = dependency.build_target(TargetKind::Source);
@@ -530,6 +505,7 @@ mod tests {
             .realizable_supported_targets
             .insert(dependency_target, supported);
         let mut module_dirs = DirSyncResult::default();
+        module_dirs.insert(dependency_module, PathBuf::from("../dependency"));
         module_dirs.insert(module, PathBuf::from("."));
         let resolved = ResolveOutput {
             module_rel: modules,
@@ -572,7 +548,7 @@ mod tests {
         }];
         let input_directive = InputDirective::default();
         let user_log = UserLog::new(log::LevelFilter::Error);
-        let ordinary = compile(
+        let output = compile(
             &config,
             Path::new("."),
             &resolved,
@@ -582,22 +558,22 @@ mod tests {
             &user_log,
         )
         .expect("ordinary compile should lower one graph");
-        assert_eq!(ordinary.execution_plan.action_ids().count(), 3);
-
-        let output = compile_standalone(
-            &config,
-            Path::new("."),
-            &resolved,
-            &requested_artifacts,
-            script,
-            &input_directive,
-            None,
-            &user_log,
-        )
-        .expect("standalone plan should lower");
-
-        assert_eq!(output.dependency_actions.len(), 1);
-        assert_eq!(output.script_actions.len(), 2);
+        assert_eq!(output.execution_plan.action_ids().count(), 3);
+        // The marker is already present before any scheduling policy reads it.
+        for id in output.execution_plan.action_ids() {
+            for path in output.execution_plan.action(id).outputs() {
+                let declared = output
+                    .execution_plan
+                    .declared_output(path)
+                    .expect("output should be declared");
+                let belongs_to_dependency =
+                    declared.artifact().and_then(ArtifactKey::package) == Some(dependency);
+                assert_eq!(
+                    declared.is_dependency_artifact(),
+                    separate_module && belongs_to_dependency
+                );
+            }
+        }
         let plan = output
             .build_plan
             .as_deref()
@@ -620,64 +596,11 @@ mod tests {
                 .any(|action| action == BuildPlanNode::BuildCore(dependency_target).into())
         );
 
-        let dependency_outputs = output
-            .dependency_actions
-            .iter()
-            .flat_map(|action| output.execution_plan.action(*action).outputs())
-            .map(|path| path.to_string_lossy().into_owned())
-            .collect::<Vec<_>>();
-        assert!(
-            dependency_outputs
-                .iter()
-                .any(|path| path.ends_with("dependency.mi"))
-        );
-        assert!(
-            dependency_outputs
-                .iter()
-                .any(|path| path.ends_with("dependency.core"))
-        );
-        assert!(
-            !dependency_outputs
-                .iter()
-                .any(|path| path.ends_with("script.core"))
-        );
-
-        let (script_graph, _) = output
+        let (graph, _) = output
             .execution_plan
-            .to_n2_graph(output.script_actions.iter().copied())
-            .expect("script actions should adapt to n2");
-        let script_inputs = script_graph
-            .builds
-            .iter()
-            .flat_map(|build| build.ins.ids.iter())
-            .map(|id| script_graph.files.by_id[*id].name.clone())
-            .collect::<Vec<_>>();
-        assert!(
-            script_inputs
-                .iter()
-                .any(|path| path.ends_with("dependency.mi"))
-        );
-        assert!(
-            script_inputs
-                .iter()
-                .any(|path| path.ends_with("dependency.core"))
-        );
-        let script_outputs = script_graph
-            .builds
-            .iter()
-            .flat_map(|build| build.outs.ids.iter())
-            .map(|id| script_graph.files.by_id[*id].name.clone())
-            .collect::<Vec<_>>();
-        assert!(
-            !script_outputs
-                .iter()
-                .any(|path| path.ends_with("dependency.mi"))
-        );
-        assert!(
-            !script_outputs
-                .iter()
-                .any(|path| path.ends_with("dependency.core"))
-        );
+            .all_to_n2_graph()
+            .expect("complete plan should adapt to n2");
+        assert_eq!(graph.builds.iter().count(), 3);
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/execution_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/execution_plan/mod.rs
@@ -23,7 +23,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{build_plan::ArtifactKey, pkg_name::OptionalPackageFQNWithSource};
+use crate::{ResolveOutput, build_plan::ArtifactKey, pkg_name::OptionalPackageFQNWithSource};
 
 mod n2_adapter;
 
@@ -195,9 +195,17 @@ pub struct DeclaredOutput {
     producer: ActionId,
     path: PathBuf,
     artifact: Option<ArtifactKey>,
+    /// The artifact belongs to a dependency module outside the resolved project's
+    /// root modules. Independent of scheduling, freshness, and cache eligibility.
+    /// Outputs without module ownership (including runtime artifacts) are unmarked.
+    is_dependency_artifact: bool,
 }
 
 impl DeclaredOutput {
+    pub fn is_dependency_artifact(&self) -> bool {
+        self.is_dependency_artifact
+    }
+
     pub fn producer(&self) -> ActionId {
         self.producer
     }
@@ -317,6 +325,29 @@ pub struct ExecutionPlan {
 }
 
 impl ExecutionPlan {
+    /// Retain project membership on artifact realizations before execution policy
+    /// is chosen. Local-path dependencies have the same role as registry dependencies.
+    pub(crate) fn mark_dependency_artifacts(&mut self, resolved: &ResolveOutput) {
+        let project_modules = resolved
+            .local_modules()
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        for output in self.outputs.values_mut() {
+            let module = match output.artifact.as_ref() {
+                Some(ArtifactKey::BundleResult { module } | ArtifactKey::DocsDir { module }) => {
+                    Some(*module)
+                }
+                Some(artifact) => artifact
+                    .package()
+                    .map(|package| resolved.pkg_dirs.get_package(package).module),
+                None => None,
+            };
+            output.is_dependency_artifact =
+                module.is_some_and(|module| !project_modules.contains(&module));
+        }
+    }
+
     pub fn action_ids(&self) -> impl Iterator<Item = ActionId> + '_ {
         (0..self.actions.len()).map(ActionId)
     }
@@ -339,8 +370,9 @@ impl ExecutionPlan {
     ///
     /// Concrete output paths form the composition boundary. Plans may share an
     /// action only when every part of its execution behavior and every output
-    /// annotation agree. A partial overlap or a different producer is rejected
-    /// before the executor sees an ambiguous graph.
+    /// artifact identity and project membership agree. A partial overlap, a
+    /// different producer, or conflicting membership is rejected before the executor
+    /// sees an ambiguous graph.
     pub fn merge(
         &mut self,
         other: &ExecutionPlan,
@@ -368,6 +400,7 @@ impl ExecutionPlan {
                             producer: action_id,
                             path: path.clone(),
                             artifact: output.artifact.clone(),
+                            is_dependency_artifact: output.is_dependency_artifact,
                         },
                     );
                 }
@@ -381,10 +414,11 @@ impl ExecutionPlan {
                     && action.outputs.iter().all(|path| {
                         self.outputs.get(path).is_some_and(|current| {
                             current.producer == existing
-                                && other
-                                    .outputs
-                                    .get(path)
-                                    .is_some_and(|incoming| current.artifact == incoming.artifact)
+                                && other.outputs.get(path).is_some_and(|incoming| {
+                                    current.artifact == incoming.artifact
+                                        && current.is_dependency_artifact
+                                            == incoming.is_dependency_artifact
+                                })
                         })
                     });
                 if !outputs_match || self.actions[existing.0] != *action {
@@ -427,7 +461,9 @@ impl ExecutionPlan {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExecutionPlanMergeError {
-    #[error("cannot compose execution plans: output `{path}` has incompatible producers")]
+    #[error(
+        "cannot compose execution plans: output `{path}` has incompatible producers or artifact roles"
+    )]
     ConflictingOutput { path: PathBuf },
 }
 
@@ -491,6 +527,7 @@ impl ExecutionPlanBuilder {
                 producer,
                 path: path.clone(),
                 artifact,
+                is_dependency_artifact: false,
             },
         );
         assert!(
@@ -531,6 +568,7 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use super::*;
+    use crate::model::PackageId;
 
     fn execution_action(
         inputs: Vec<PathBuf>,
@@ -682,6 +720,12 @@ mod tests {
             [producer, consumer]
         );
         assert_eq!(composed.action_ids().count(), 2);
+        assert!(
+            !composed
+                .declared_output(Path::new("build/libmoonbitrun.a"))
+                .expect("shared output should be declared")
+                .is_dependency_artifact()
+        );
         assert_eq!(
             composed
                 .declared_output(Path::new("build/libmoonbitrun.a"))
@@ -706,20 +750,60 @@ mod tests {
     fn merge_remaps_plan_local_action_ids() {
         let (first, _, _) = producer_and_consumer_plan();
         let mut builder = ExecutionPlanBuilder::default();
+        let mut packages = slotmap::SlotMap::<PackageId, ()>::with_key();
+        let package = packages.insert(());
         let (action, outputs) = execution_action(
             Vec::new(),
+            vec![(
+                ArtifactKey::CoreIr {
+                    package,
+                    target_kind: crate::model::TargetKind::Source,
+                },
+                vec![PathBuf::from("build/other-output")],
+            )],
             Vec::new(),
-            vec![PathBuf::from("build/other-output")],
             "other-command",
         );
         builder.add_action(action, outputs);
-        let second = builder.finish([]);
+        let mut second = builder.finish([]);
+        second
+            .outputs
+            .get_mut(Path::new("build/other-output"))
+            .expect("second plan's output should be declared")
+            .is_dependency_artifact = true;
         let mut composed = ExecutionPlan::default();
 
         composed.merge(&first).expect("first plan should merge");
         let remapped = composed.merge(&second).expect("second plan should merge");
 
         assert_eq!(remapped, [ActionId(2)]);
+        assert_eq!(
+            composed
+                .declared_output(Path::new("build/other-output"))
+                .expect("second plan's output should be declared")
+                .producer(),
+            ActionId(2)
+        );
+        assert!(
+            !composed
+                .declared_output(Path::new("build/libmoonbitrun.a"))
+                .expect("runtime library should be declared")
+                .is_dependency_artifact()
+        );
+        assert!(
+            composed
+                .declared_output(Path::new("build/other-output"))
+                .expect("second plan's output should be declared")
+                .is_dependency_artifact()
+        );
+        second
+            .outputs
+            .get_mut(Path::new("build/other-output"))
+            .expect("second plan's output should be declared")
+            .is_dependency_artifact = false;
+        composed
+            .merge(&second)
+            .expect_err("shared outputs must agree on dependency membership");
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/lib.rs
+++ b/crates/moonbuild-rupes-recta/src/lib.rs
@@ -127,7 +127,5 @@ mod special_cases;
 pub mod util;
 
 // Reexports
-pub use compile::{
-    CompileConfig, CompileOutput, StandaloneCompileOutput, compile, compile_standalone,
-};
+pub use compile::{CompileConfig, CompileOutput, compile};
 pub use resolve::{ResolveConfig, ResolveOutput, resolve_synced_project, sync_dependencies};

--- a/docs/adr/0005-plan-standalone-dependencies-separately.md
+++ b/docs/adr/0005-plan-standalone-dependencies-separately.md
@@ -2,68 +2,44 @@
 status: accepted
 ---
 
-# Prepare Standalone Dependencies Before Script Execution
+# Use Unified Planning and Execution for Standalone Builds
 
-Standalone script builds have two stages: prepare the required dependency
-products, then plan, build, and run the synthesized script package using the
-materialized outputs. The durable boundary is dependency product requirements
-in and concrete outputs out; neither n2 nor a second `BuildPlan` is part of that
-long-term contract.
+Standalone scripts and ordinary projects use the same planning, lowering, and
+execution path. Each backend produces one complete `BuildPlan` and
+`ExecutionPlan`; multi-backend invocations compose those plans before one n2
+execution. Synthesizing a project for a script does not introduce an execution
+mode or a separate dependency graph.
 
-The current incremental implementation constructs one complete logical
-`BuildPlan` and one normalized `BuildActionPlan`, then projects the actions into
-two disjoint n2 graphs. Package dependencies remain ordinary producer-consumer
-edges rather than a second planning vocabulary. All actions owned by dependency
-packages seed the dependency projection; their dependency closure also includes
-any package-less shared actions they need. The remaining actions form the script
-projection. A dependency action depending on a script-owned action is an invalid
-phase ordering.
+This revises the earlier decision to execute all dependency work before script
+work. That adapter duplicated orchestration without enabling cross-invocation
+artifact reuse. Both phases were already planned upfront and used the same n2
+database. Unified execution preserves dependency ordering through producer
+edges and allows otherwise independent actions to proceed without a phase
+barrier. Failure handling and diagnostic limits follow the ordinary executor.
 
-Dependency outputs remain under `_build/.../.mooncakes`. When their producer
-actions are omitted from the script n2 graph, the same concrete output paths
-remain ordinary file inputs to script actions. Moon executes the dependency
-graph first, then executes the script graph. Both graphs use the target
-directory's persistent n2 database; records whose outputs do not belong to the
-current graph are ignored when n2 loads them. There is no file-existence scan
-between the phases: n2 currently owns dependency freshness and guarantees that
-the requested products are materialized.
+## Dependency Semantics
 
-The dependency n2 projection is a temporary preparation adapter, not a permanent
-second planner. A future action-to-output implementation can replace this first
-stage and feed its concrete outputs into a narrower script plan.
+Lowering retains a semantic `is_dependency_artifact` marker on artifact
+realizations. Artifacts in the resolved project's root modules belong to the
+project; artifacts in other resolved modules belong to its dependencies,
+including local-path dependencies. Outputs without module ownership remain
+unmarked. This role does not change artifact identity, provider relationships,
+execution order, freshness, or cache eligibility.
 
-Standalone `.mbt` and `.mbtx` files built from persistent paths retain the
-target-directory n2 database across invocations. `moon run -e` and `moon run -`
-use the same split planning path, but their synthesized temporary projects are
-deleted after each invocation, so they do not currently reuse dependency work
-across invocations. Stable or global cache storage for those entry points is
-deferred.
+Faster script builds through validated dependency-artifact reuse remain an
+intended experiment. The marker preserves the domain distinction that such
+an experiment may interpret. No phase partitioner, execution-mode interface,
+or artifact-cache execution is introduced in anticipation of that experiment.
 
 ## Consequences
 
-- The initial change is limited to standalone `.mbt` and `.mbtx` builds.
-- Ordinary project and workspace commands keep their existing single-plan,
-  single-n2-graph path.
-- Registry resolution remains unchanged.
-- Standalone planning uses the same complete build rules as ordinary planning.
-- The temporary dependency projection is isolated after action normalization,
-  where it can later be replaced without changing planning semantics.
-- SHA identities, action-to-outcome caching, global storage, and a generalized
-  dependency executor interface remain deferred.
-- Splitting execution introduces a phase barrier. Cold and warm performance
-  must be measured against the single-graph implementation.
-
-## Considered Options
-
-- Two independent `BuildPlan` constructors were rejected because they duplicate
-  one semantic graph and require special "external product" edges and paths to
-  reconnect it. They also make ownership of package-less shared actions
-  ambiguous.
-- Splitting or detaching nodes after n2 lowering was rejected because the phase
-  boundary would be expressed through executor graph surgery rather than
-  normalized build actions.
-- Projecting one complete normalized action plan is the selected temporary n2
-  adapter. It keeps one source of planning truth during this incremental change
-  while making dependency preparation independently replaceable.
-- Designing the complete action-to-output cache interface now was rejected
-  because it would expand this change before the required interface is known.
+- Standalone builds use the same complete build rules and executor as projects.
+- Dependency source acquisition and artifact paths remain unchanged.
+- Persistent scripts retain their target-directory n2 database and incremental
+  reuse. Inline and stdin scripts still use temporary projects; their build
+  outputs are not retained across invocations.
+- Dependency artifacts remain distinguishable without selecting an execution
+  strategy. A future reuse implementation can consume that metadata and the
+  existing artifact/provider relationships.
+- New execution structure requires evidence from the reuse experiment, rather
+  than the presence of a standalone input.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -73,7 +73,7 @@ teaches coding agents how to use this index without copying its routing table.
 - [0002: Native ABI Policy Belongs to Toolchains](../adr/0002-native-abi-policy-belongs-to-toolchains.md)
 - [0003: Dispatch Moonx By Executable Name](../adr/0003-dispatch-moonx-by-executable-name.md)
 - [0004: Separate Command Results from User Logs](../adr/0004-separate-command-results-from-user-logs.md)
-- [0005: Prepare Standalone Dependencies Before Script Execution](../adr/0005-plan-standalone-dependencies-separately.md)
+- [0005: Use Unified Planning and Execution for Standalone Builds](../adr/0005-plan-standalone-dependencies-separately.md)
 - [0006: Model Providers as Build Graph Topology](../adr/0006-model-providers-as-build-graph-topology.md)
 
 ## How to Build and Test

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -133,12 +133,11 @@ Implementation-wise:
 [n2]: https://github.com/moonbitlang/n2
 
 Rupes Recta executions in one target directory share the n2 database at
-`<target-dir>/.moon_db`. Target backend, profile, run mode, and standalone build
-phase are represented by concrete output paths and build hashes rather than
-separate database files. Separately planned graphs still open and load that
-database for each execution; sharing persistent state does not compose the
-graphs or reuse one open database handle. The dependency and script graphs of a
-standalone build execute sequentially against this database.
+`<target-dir>/.moon_db`. Target backend, profile, and run mode are represented
+by concrete output paths and build hashes rather than separate database files.
+Both ordinary projects and standalone scripts execute one complete graph per
+invocation, composing backend plans before n2 adaptation. Dependency ordering
+comes from producer edges, with no separate dependency phase.
 
 n2 records completed builds in an append-only log. When the database is at
 least 2 MiB, opening it compacts the log if all path records and live build

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -285,9 +285,9 @@ physical outputs and are not used as a cross-backend namespace.
 
 Concrete output paths are the composition boundary. If two plans declare the
 same physical output, composition shares the provider only when the complete
-Execution Action, its complete output set, and all output annotations agree.
-Partial overlap or different execution behavior is rejected before n2 sees the
-graph. Package prebuild actions therefore collapse naturally without a
+Execution Action, its complete output set, all output artifact identities,
+and project/dependency membership agree. Conflicting membership, partial
+overlap, or different execution behavior is rejected before n2 sees the graph. Package prebuild actions therefore collapse naturally without a
 prebuild-specific merge rule, while backend outputs remain separate under
 their backend-specific paths.
 
@@ -350,24 +350,35 @@ consume `ExecutionPlan` directly: each input path resolves to its declared
 output and producer action, while requested artifacts and physical-only outputs
 retain the distinct root semantics that n2 otherwise flattens into file IDs.
 
-## Standalone build boundary
+## Project and dependency artifacts
 
-Standalone `.mbt` and `.mbtx` execution, and standalone `.mbtx` compilation
-through `moon build`, start from one complete `BuildPlan` per Target Backend
-and lower it once into one `ExecutionPlan`. Dependency preparation and script
-compilation are two `ActionId` selections over that plan. Following artifact
-providers to a fixed point includes package-less prerequisites such as the
-runtime library and runtime objects. Multi-backend standalone builds compose
-dependency selections separately from script selections so the phase ordering
-remains explicit.
+Manifest projects and synthesized single-file projects use the same planning,
+compilation, and execution entry points. `BuildInput` contains the complete
+`ExecutionPlan`, action-backend information for diagnostics, and the target
+directory's n2 database path. It has no execution mode or phase selection.
 
-The dependency graph executes first, followed by the script graph. Both use the
-target directory's `.moon_db`; n2 ignores records whose outputs do not belong
-to the graph it is currently loading. If a provider belongs to dependency
-preparation, the script graph retains its realized path as an n2 input without
-duplicating the provider.
+Lowering records `is_dependency_artifact` on each artifact's declared physical
+outputs using the owning module's membership in the resolved project's root
+modules. Packages in a root module remain part of the project, including
+libraries imported by a requested main package. Local-path dependencies
+outside the root modules have the same role as registry dependencies.
+Module-wide artifacts use their module identity. Physical-only outputs and
+runtime artifacts without module ownership remain unmarked.
 
-Ordinary project and workspace commands execute one n2 graph per invocation.
+The marker expresses project membership independently of execution order,
+freshness, and cache eligibility. It preserves the distinction for future
+experiments with dependency-artifact reuse without adding a phase partitioner
+or a second artifact registry. Classification occurs before composition while
+package and module IDs belong to their originating resolution. Shared outputs
+must agree on this membership.
+
+All planned actions enter the same n2 graph. Each artifact's existing producer
+edges determine dependency ordering. Persistent scripts use the same
+incremental database as before; changing only the script does not require
+rebuilding unchanged dependencies. There is no invocation-wide barrier between
+dependency and project work.
+
+Project, workspace, and standalone builds execute one n2 graph per invocation.
 A single-backend invocation projects one Execution Plan directly; a
 multi-backend invocation first composes its independently lowered Execution
 Plans as described above. The n2 adapter preserves each Build ID's originating


### PR DESCRIPTION
- Related issues: None
- PR kind: Refactor

## Summary

Standalone build/run duplicates ordinary project planning and splits the resulting complete plan into dependency and script executions. This makes shared rules, such as native prebuild configuration, require changes in two places. The two-stage orchestration does not itself provide cross-invocation artifact reuse.

Route synthesized single-file projects through the ordinary planner, lowering, dry-run, and executor. Remove the standalone input/output wrappers, action partitioning, and phase-specific composition and diagnostics handling. `BuildInput` carries one complete execution plan, backend information for diagnostics, and the n2 database path.

Existing producer edges preserve required dependency ordering, and the same target-directory database preserves incremental reuse. Independent actions can proceed without a phase barrier; failure handling and diagnostic limits follow the ordinary executor. Dependency acquisition and target-directory isolation retain their existing behavior.

Keep only the semantic `is_dependency_artifact` marker on artifact outputs: artifacts outside the resolved project's root modules are dependencies, including local-path dependencies. The marker does not select execution order or promise cache eligibility. Tests cover module membership and composition, and the architecture references and ADR describe the unified flow. Artifact reuse and its execution interface remain separate future work.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
