### PR TITLE
refactor(moon): remove preliminary compile configuration

### DIFF
--- a/crates/moon/src/build_flags.rs
+++ b/crates/moon/src/build_flags.rs
@@ -170,11 +170,6 @@ impl OutputStyle {
     pub fn needs_moonc_json(&self) -> bool {
         matches!(self, OutputStyle::Fancy | OutputStyle::Json)
     }
-
-    /// Whether the output style requires no rendering (i.e., raw diagnostics).
-    pub fn needs_no_render(&self) -> bool {
-        matches!(self, OutputStyle::Raw | OutputStyle::Json)
-    }
 }
 
 impl BuildFlags {
@@ -186,22 +181,6 @@ impl BuildFlags {
             (true, true) => unreachable!(
                 "unreachable: both std and no_std flags are set (should be prevented by conflicts_with)"
             ),
-        }
-    }
-
-    pub fn apply_default_debug(&mut self) {
-        if !self.debug && !self.release {
-            self.debug = true;
-        }
-    }
-
-    pub fn strip(&self) -> bool {
-        if self.strip {
-            true
-        } else if self.no_strip {
-            false
-        } else {
-            !self.debug
         }
     }
 
@@ -235,9 +214,15 @@ impl BuildFlags {
         }
     }
 
-    /// Resolve whether to emit debug symbols for Rupes Recta compilation.
-    pub fn debug_symbols_for(&self, run_mode: RunMode) -> bool {
+    /// Resolve debug symbols after the compilation's backend is selected.
+    pub fn debug_symbols_for(&self, run_mode: RunMode, backend: TargetBackend) -> bool {
+        // A default Native run retains stack-trace support without full debug
+        // information. Explicit debug or no-strip requests retain that information.
         !self.strip_for(run_mode)
+            && (run_mode != RunMode::Run
+                || backend != TargetBackend::Native
+                || self.debug
+                || self.no_strip)
     }
 
     pub fn output_style(&self) -> OutputStyle {

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -39,7 +39,6 @@ use crate::filter::{
 use crate::rr_build;
 use crate::rr_build::BuildConfig;
 use crate::rr_build::CalcUserIntentOutput;
-use crate::rr_build::preconfig_compile;
 use crate::watch::prebuild_output::{PrebuildWatchPaths, rr_get_prebuild_watch_paths};
 use crate::watch::{WatchOutput, watching};
 
@@ -191,26 +190,18 @@ fn run_build_for_single_file_rr(
         .context("single-file project must resolve exactly one local package")?;
     let mut planned_runs = Vec::with_capacity(target_backends.len());
     for target_backend in target_backends {
-        let preconfig = preconfig_compile(
-            &cmd.auto_sync_flags,
+        let compile_config = rr_build::prepare_resolved_build(
             cli,
             &cmd.build_flags,
             target_backend,
             target_dir,
             RunMode::Build,
-        );
-        let planning_context = rr_build::prepare_resolved_build(
-            &preconfig,
-            &cli.unstable_feature,
-            target_dir,
             user_log,
             &resolved,
         )?;
         planned_runs.push(rr_build::plan_resolved_standalone_build_from_intent(
-            preconfig,
-            &cli.unstable_feature,
+            compile_config,
             user_log,
-            planning_context,
             vec![UserIntent::Build(package)].into(),
             package,
             mooncake_bin_dir,
@@ -425,19 +416,12 @@ pub(crate) fn plan_build_rr_from_resolved(
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
     user_log: &UserLog,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
         selected_target_backend,
         target_dir,
         RunMode::Build,
-    );
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
@@ -445,14 +429,12 @@ pub(crate) fn plan_build_rr_from_resolved(
         &cmd.path,
         cmd.package.as_deref(),
         &resolve_output,
-        planning_context.target_backend(),
+        compile_config.backend.target_backend(),
         user_log,
     )?;
     rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolve_output,
@@ -470,33 +452,24 @@ fn plan_build_rr_from_resolved_with_scope(
     scoped_packages: Vec<PackageId>,
     user_log: &UserLog,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
         Some(target_backend),
         target_dir,
         RunMode::Build,
-    );
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
-    debug_assert_eq!(planning_context.target_backend(), target_backend);
+    debug_assert_eq!(compile_config.backend.target_backend(), target_backend);
     let intent = calc_user_intent_from_scoped_packages(
         &resolve_output,
         &scoped_packages,
-        planning_context.target_backend(),
+        compile_config.backend.target_backend(),
     )?;
     rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolve_output,
@@ -514,28 +487,19 @@ fn plan_build_rr_from_selection(
     selection: ResolvedBuildSelection,
     user_log: &UserLog,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
         Some(target_backend),
         target_dir,
         RunMode::Build,
-    );
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
-    debug_assert_eq!(planning_context.target_backend(), target_backend);
+    debug_assert_eq!(compile_config.backend.target_backend(), target_backend);
     rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         selection.into_user_intent(),
         mooncake_bin_dir,
         resolve_output,

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -223,46 +223,28 @@ pub(crate) fn plan_bundle_rr_from_resolved(
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
     user_log: &UserLog,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
-    let preconfig = bundle_preconfig(cli, cmd, target_dir, selected_target_backend);
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
-        user_log,
-        &resolve_output,
-    )?;
-    let intent = bundle_user_intent(&resolve_output);
-    rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
-        user_log,
-        planning_context,
-        intent,
-        mooncake_bin_dir,
-        resolve_output,
-    )
-}
-
-fn bundle_preconfig(
-    cli: &UniversalFlags,
-    cmd: &BundleSubcommand,
-    target_dir: &Path,
-    selected_target_backend: Option<TargetBackend>,
-) -> rr_build::CompilePreConfig {
-    let mut preconfig = rr_build::preconfig_compile(
-        &cmd.auto_sync_flags,
+    let mut compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
         selected_target_backend,
         target_dir,
         RunMode::Bundle,
-    );
-    preconfig.warning_condition = if cmd.build_flags.deny_warn {
+        user_log,
+        &resolve_output,
+    )?;
+    compile_config.warning_condition = if cmd.build_flags.deny_warn {
         WarningCondition::Deny
     } else {
         WarningCondition::Allow
     };
-    preconfig
+    let intent = bundle_user_intent(&resolve_output);
+    rr_build::plan_resolved_build_from_intent(
+        compile_config,
+        user_log,
+        intent,
+        mooncake_bin_dir,
+        resolve_output,
+    )
 }
 
 fn bundle_user_intent(

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -56,7 +56,7 @@ use crate::filter::{
     group_packages_by_preferred_backend, package_supports_backend, select_packages,
     select_supported_packages,
 };
-use crate::rr_build::{self, BuildConfig, CalcUserIntentOutput, preconfig_compile};
+use crate::rr_build::{self, BuildConfig, CalcUserIntentOutput};
 use crate::watch::prebuild_output::{PrebuildWatchPaths, rr_get_prebuild_watch_paths};
 use crate::watch::{WatchOutput, watching};
 
@@ -589,28 +589,21 @@ fn run_check_for_single_file_rr(
 
     let mut planned_runs = Vec::with_capacity(target_backends.len());
     for target_backend in target_backends {
-        let preconfig = preconfig_compile(
-            &cmd.auto_sync_flags,
+        let compile_config = rr_build::prepare_resolved_build(
             cli,
             &cmd.build_flags,
             target_backend,
             target_dir,
             RunMode::Check,
-        );
-        let planning_context = rr_build::prepare_resolved_build(
-            &preconfig,
-            &cli.unstable_feature,
-            target_dir,
             user_log,
             &resolved,
         )?;
-        let intent = get_user_intents_single_file(&resolved, planning_context.target_backend())?;
+        let intent =
+            get_user_intents_single_file(&resolved, compile_config.backend.target_backend())?;
         planned_runs.push(
             rr_build::plan_resolved_build_from_intent(
-                preconfig,
-                &cli.unstable_feature,
+                compile_config,
                 user_log,
-                planning_context,
                 intent,
                 mooncake_bin_dir,
                 resolved.clone(),
@@ -997,19 +990,12 @@ pub(crate) fn plan_check_rr_from_resolved(
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
     user_log: &UserLog,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
         selected_target_backend,
         target_dir,
         RunMode::Check,
-    );
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
@@ -1018,23 +1004,21 @@ pub(crate) fn plan_check_rr_from_resolved(
             &resolve_output,
             source_dir,
             filter_path,
-            planning_context.target_backend(),
+            compile_config.backend.target_backend(),
             cmd.patch_file.as_deref(),
         )?
     } else {
         calc_user_intent(
             &resolve_output,
             &cmd.path,
-            planning_context.target_backend(),
+            compile_config.backend.target_backend(),
             cmd.patch_file.as_deref(),
             user_log,
         )?
     };
     rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolve_output,
@@ -1052,28 +1036,19 @@ fn plan_check_rr_from_selection(
     selection: ResolvedCheckSelection,
     user_log: &UserLog,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
         Some(target_backend),
         target_dir,
         RunMode::Check,
-    );
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
-    debug_assert_eq!(planning_context.target_backend(), target_backend);
+    debug_assert_eq!(compile_config.backend.target_backend(), target_backend);
     rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         selection.into_user_intent()?,
         mooncake_bin_dir,
         resolve_output,

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -31,7 +31,7 @@ use tracing::instrument;
 use super::UniversalFlags;
 
 use crate::cli::BuildFlags;
-use crate::rr_build::{self, BuildConfig, preconfig_compile};
+use crate::rr_build::{self, BuildConfig};
 
 /// Generate documentation or searching documentation for a symbol.
 #[derive(Debug, clap::Parser)]
@@ -127,16 +127,13 @@ pub(crate) fn run_doc_rr(
 
     // Resolve the complete selected project before choosing the member-scoped
     // documentation backend.
-    let resolve_preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
-        &cli,
-        &BuildFlags::default(),
-        None,
-        target_dir,
-        RunMode::Check,
+    let build_flags = BuildFlags::default();
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
+        cmd.auto_sync_flags.clone(),
+        !build_flags.std(),
+        build_flags.enable_coverage,
+        cli.workspace_env.clone(),
     );
-
-    let resolve_cfg = resolve_preconfig.resolve_config();
     let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
@@ -146,29 +143,21 @@ pub(crate) fn run_doc_rr(
         .module_info(module_id)
         .preferred_target
         .unwrap_or_default();
-    let mut preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+
+    let mut compile_config = rr_build::prepare_resolved_build(
         &cli,
-        &BuildFlags::default(),
+        &build_flags,
         Some(target_backend),
         target_dir,
         RunMode::Check,
-    );
-    preconfig.docs_serve = cmd.serve;
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
+    compile_config.docs_serve = cmd.serve;
     let intent = vec![UserIntent::Doc(module_id)].into();
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolve_output,
@@ -196,7 +185,7 @@ pub(crate) fn run_doc_rr(
     rr_build::generate_metadata(source_dir, &build_meta, &build_graph)?;
 
     // Execute the build
-    let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);
+    let cfg = BuildConfig::from_flags(&build_flags, &cli.unstable_feature, cli.verbose);
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
     result.print_info(cli.quiet, "checking")?;
 

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -372,35 +372,30 @@ fn plan_info_rr(
     output_plan: &imp::InfoOutputPlan,
     user_log: &UserLog,
 ) -> anyhow::Result<(BuildMeta, rr_build::BuildInput)> {
-    let mut preconfig = rr_build::preconfig_compile(
-        &cmd.auto_sync_flags,
-        cli,
-        &BuildFlags::default(),
-        Some(target),
-        target_dir,
-        RunMode::Check,
-    );
-    preconfig.info_no_alias = cmd.no_alias;
     let ctx = InfoIntentContext {
         selection,
         output_plan,
         target_kind,
         user_log,
     };
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
+    let mut compile_config = rr_build::prepare_resolved_build(
+        cli,
+        &BuildFlags::default(),
+        Some(target),
         target_dir,
+        RunMode::Check,
         user_log,
         &resolve_output,
     )?;
-    let intent =
-        calc_user_intent_for_info(&ctx, &resolve_output, planning_context.target_backend())?;
+    compile_config.info_no_alias = cmd.no_alias;
+    let intent = calc_user_intent_for_info(
+        &ctx,
+        &resolve_output,
+        compile_config.backend.target_backend(),
+    )?;
     rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolve_output,

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -45,7 +45,7 @@ use tracing::debug;
 
 use crate::{
     cli::BuildFlags,
-    rr_build::{self, BuildConfig, preconfig_compile},
+    rr_build::{self, BuildConfig},
 };
 
 /// Represents a parsed package specification from the command line.
@@ -585,28 +585,20 @@ fn build_selected_package(
         warn_list: Some("-a".to_string()),
         ..BuildFlags::default()
     };
-    let preconfig = preconfig_compile(
-        &moonutil::cli_support::AutoSyncFlags { frozen: false },
+
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &build_flags,
         Some(TargetBackend::Native),
         &prepared.target_dir,
         RunMode::Build,
-    );
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        &prepared.target_dir,
         user_log,
         &prepared.resolve_output,
     )?;
     let intent = vec![UserIntent::Build(pkg.pkg_id)].into();
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         &prepared.mooncake_bin_dir,
         prepared.resolve_output.clone(),

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -35,7 +35,7 @@ use crate::{
         canonicalize_with_filename, ensure_package_supports_backend, filter_pkg_by_dir,
         package_supports_backend,
     },
-    rr_build::{self, BuildConfig, CalcUserIntentOutput, preconfig_compile},
+    rr_build::{self, BuildConfig, CalcUserIntentOutput},
 };
 
 const MOON_PROVE_PRELUDE_OVERRIDE: &str = "MOON_PROVE_PRELUDE_OVERRIDE";
@@ -152,26 +152,25 @@ pub(crate) fn run_prove(
         ensure_why3_config(&generated_why3_config_path)?;
     }
 
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+    let path_filter = cmd.path.as_deref();
+    let prove_why3_config = why3_config_path.clone();
+
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
+        cmd.auto_sync_flags.clone(),
+        !build_flags.std(),
+        build_flags.enable_coverage,
+        cli.workspace_env.clone(),
+    );
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
+    let resolve_output =
+        moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
+
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &build_flags,
         None,
         target_dir,
         RunMode::Prove,
-    );
-    let path_filter = cmd.path.as_deref();
-    let prove_why3_config = why3_config_path.clone();
-
-    let resolve_cfg = preconfig.resolve_config();
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
-    let resolve_output =
-        moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
@@ -179,16 +178,14 @@ pub(crate) fn run_prove(
         path_filter,
         module_dir.as_deref(),
         &resolve_output,
-        planning_context.target_backend(),
+        compile_config.backend.target_backend(),
         prove_why3_config.as_deref(),
         &proof_prelude,
         user_log,
     )?;
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolve_output,

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -44,7 +44,6 @@ use tracing::{Level, instrument};
 
 use crate::filter::ensure_package_supports_backend;
 use crate::rr_build;
-use crate::rr_build::preconfig_compile;
 use crate::rr_build::{BuildConfig, CalcUserIntentOutput};
 
 use super::{BuildFlags, UniversalFlags};
@@ -613,20 +612,15 @@ pub(crate) fn plan_run_rr_from_resolved(
             })
             .unwrap_or_default(),
     );
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+
+    let value_tracing = cmd.build_flags.enable_value_tracing;
+
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
         selected_target_backend,
         target_dir,
         RunMode::Run,
-    );
-    let value_tracing = cmd.build_flags.enable_value_tracing;
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
@@ -634,13 +628,11 @@ pub(crate) fn plan_run_rr_from_resolved(
         &input_path,
         &resolve_output,
         value_tracing,
-        planning_context.target_backend(),
+        compile_config.backend.target_backend(),
     )?;
     rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolve_output,
@@ -782,18 +774,12 @@ fn build_single_file_executable(
         .or(backend)
         .unwrap_or(options.default_target_backend);
 
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
         Some(selected_target_backend),
         target_dir,
         RunMode::Run,
-    );
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolved,
     )?;
@@ -807,10 +793,8 @@ fn build_single_file_executable(
     };
     let intent = (vec![UserIntent::Run(package)], directive).into();
     let (build_meta, build_graph) = rr_build::plan_resolved_standalone_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         package,
         mooncake_bin_dir,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -27,7 +27,6 @@ use crate::filter::match_packages_with_fuzzy;
 use crate::filter::package_supports_backend;
 use crate::filter::select_packages;
 use crate::rr_build;
-use crate::rr_build::preconfig_compile;
 use crate::rr_build::{BuildConfig, CalcUserIntentOutput};
 use crate::run::collect_test_outline;
 use crate::run::perform_promotion;
@@ -550,18 +549,13 @@ fn run_test_in_single_file_rr(
     };
 
     let build_flags = effective_test_build_flags(&cmd.build_flags, cmd.profile);
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &build_flags,
         selected_target_backend,
         target_dir,
         RunMode::Test,
-    );
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolved,
     )?;
@@ -590,10 +584,8 @@ fn run_test_in_single_file_rr(
     let directive = rr_build::build_patch_directive_for_package(pkg, false, trace_pkg, None, true)?;
     let intent = (vec![UserIntent::Test(pkg)], directive).into();
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolved,
@@ -704,11 +696,15 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
 ) -> Result<(rr_build::BuildMeta, rr_build::BuildInput, TestFilter), anyhow::Error> {
     // Keep the planning flow explicit:
     // 1. derive the effective build flags used by test/bench,
-    // 2. build the compile preconfig,
+    // 2. resolve the backend and construct the compile configuration,
     // 3. let RR turn resolved packages plus user intent into a graph and filter.
     let build_flags = effective_test_build_flags(cmd.build_flags, cmd.profile);
-    let preconfig = preconfig_compile(
-        cmd.auto_sync_flags,
+
+    let mut filter = TestFilter {
+        name_filter: cmd.filter.clone(),
+        ..Default::default()
+    };
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &build_flags,
         selected_target_backend,
@@ -718,16 +714,6 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
         } else {
             RunMode::Test
         },
-    );
-
-    let mut filter = TestFilter {
-        name_filter: cmd.filter.clone(),
-        ..Default::default()
-    };
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
@@ -735,14 +721,12 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
         &resolve_output,
         cmd,
         &mut filter,
-        planning_context.target_backend(),
+        compile_config.backend.target_backend(),
         user_log,
     )?;
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolve_output,
@@ -855,8 +839,8 @@ fn plan_test_or_bench_rr_from_resolved_scoped(
         no_strip: !cmd.build_flags.strip && !cmd.build_flags.release,
         ..cmd.build_flags.clone()
     };
-    let preconfig = preconfig_compile(
-        cmd.auto_sync_flags,
+
+    let compile_config = rr_build::prepare_resolved_build(
         cli,
         &build_flags,
         Some(target_backend),
@@ -866,28 +850,20 @@ fn plan_test_or_bench_rr_from_resolved_scoped(
         } else {
             RunMode::Test
         },
-    );
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
         user_log,
         &resolve_output,
     )?;
-    debug_assert_eq!(planning_context.target_backend(), target_backend);
+    debug_assert_eq!(compile_config.backend.target_backend(), target_backend);
     let filter = resolved_selection.to_runtime_filter(&resolve_output, cmd)?;
     let intent = resolved_selection.to_build_intent(
         &resolve_output,
         cmd,
-        planning_context.target_backend(),
+        compile_config.backend.target_backend(),
         &filter,
     )?;
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
+        compile_config,
         user_log,
-        planning_context,
         intent,
         mooncake_bin_dir,
         resolve_output,

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -40,14 +40,14 @@ use moonbuild_rupes_recta::{
     model::PackageId,
 };
 use moonutil::{
-    build_options::RunMode, cli_support::AutoSyncFlags, cli_support::UniversalFlags,
-    locks::lock_directory, project::PackageDirs, target::TargetBackend, user_log::UserLog,
+    build_options::RunMode, cli_support::UniversalFlags, locks::lock_directory,
+    project::PackageDirs, target::TargetBackend, user_log::UserLog,
 };
 
 use crate::{
     cli::BuildFlags,
     filter::match_packages_by_name_rr,
-    rr_build::{self, BuildConfig, BuildMeta, preconfig_compile},
+    rr_build::{self, BuildConfig, BuildMeta},
 };
 
 #[derive(clap::Args, Debug)]
@@ -153,18 +153,13 @@ pub(crate) fn run_build_binary_dep(
             release: true,
             ..BuildFlags::default()
         };
-        let preconfig = preconfig_compile(
-            &AutoSyncFlags { frozen: false },
+
+        let compile_config = rr_build::prepare_resolved_build(
             cli,
             &build_flags,
             Some(target),
             target_dir,
             RunMode::Build,
-        );
-        let planning_context = rr_build::prepare_resolved_build(
-            &preconfig,
-            &cli.unstable_feature,
-            target_dir,
             user_log,
             &resolve_output,
         )?;
@@ -177,10 +172,8 @@ pub(crate) fn run_build_binary_dep(
         )
             .into();
         let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
-            preconfig,
-            &cli.unstable_feature,
+            compile_config,
             user_log,
-            planning_context,
             intent,
             mooncake_bin_dir,
             // FIXME: cloning is not the best way to do this, it takes in this

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -52,14 +52,13 @@ use moonbuild_rupes_recta::{
 };
 use moonutil::{
     build_options::RunMode,
-    cli_support::AutoSyncFlags,
     cli_support::UniversalFlags,
     compiler_flags,
     cond_expr::OptLevel as BuildProfile,
     constants::{BLACKBOX_TEST_PATCH, MOONBITLANG_CORE, WHITEBOX_TEST_PATCH},
     features::FeatureGate,
     package::SupportedTargetsDeclKind,
-    project::{PackageDirs, ProjectManifest, WorkspaceEnv},
+    project::{PackageDirs, ProjectManifest},
     render::MooncDiagnostic,
     target::TargetBackend,
     test_metadata::DiagnosticLevel,
@@ -290,217 +289,30 @@ impl BuildResult {
     }
 }
 
-/// A preliminary configuration that does not require run-time information to
-/// populate. Will be transformed into [`CompileConfig`] later in the pipeline.
+/// Select the backend and construct the final configuration for a resolved project.
 ///
-/// This type might be subject to change.
-#[derive(Debug)]
-pub struct CompilePreConfig {
-    frozen: bool,
-    target_backend: Option<TargetBackend>,
-    opt_level: BuildProfile,
-    action: RunMode,
-    debug_symbols: bool,
-    /// Whether a default `moon run` may omit full debug symbols after the
-    /// selected backend is resolved to Native.
-    omit_native_run_debug_symbols: bool,
-    use_std: bool,
-    debug_export_build_plan: bool,
-    wasi_link: bool,
-    enable_coverage: bool,
-    workspace_env: WorkspaceEnv,
-    output_wat: bool,
-    /// Whether to output JSON when compiling with moonc.
-    moonc_output_json: bool,
-    target_dir: PathBuf,
-    /// Whether to execute `moondoc` in serve mode, which outputs HTML
-    pub docs_serve: bool,
-    pub warning_condition: WarningCondition,
-    /// Whether to not emit alias when running `mooninfo`
-    pub info_no_alias: bool,
-    warn_list: Option<String>,
-}
-
-impl CompilePreConfig {
-    pub(crate) fn resolve_config(&self) -> ResolveConfig {
-        ResolveConfig::new_with_load_defaults(
-            self.frozen,
-            !self.use_std,
-            self.enable_coverage,
-            self.workspace_env.clone(),
-        )
-    }
-
-    fn into_compile_config(
-        self,
-        final_target_backend: TargetBackend,
-        is_core: bool,
-        resolve_output: &ResolveOutput,
-    ) -> anyhow::Result<CompileConfig> {
-        info!("Determining compilation configuration");
-
-        let std = self.use_std && !is_core;
-        info!(
-            "std: self.use_std = {}, is_core = {} => std = {}",
-            self.use_std, is_core, std
-        );
-
-        let target_backend = final_target_backend;
-        info!(
-            "Target backend: explicit = {:?} => selected = {:?}",
-            self.target_backend, target_backend
-        );
-        assert!(
-            self.target_backend.is_none_or(|x| x == target_backend),
-            "The final selected target backend must either be default or match the explicit one"
-        );
-
-        let debug_symbols = self.debug_symbols
-            && !(self.omit_native_run_debug_symbols && target_backend == TargetBackend::Native);
-
-        let backend = match target_backend {
-            TargetBackend::Wasm => BackendConfig::Wasm {
-                use_wat: self.output_wat,
-                wasi_link: self.wasi_link,
-            },
-            TargetBackend::WasmGC => BackendConfig::WasmGc {
-                use_wat: self.output_wat,
-            },
-            TargetBackend::Js => BackendConfig::Js,
-            TargetBackend::Native => {
-                let new_native_env = std::env::var(ENV_MOONBIT_NEW_NATIVE).ok();
-                BackendConfig::Native {
-                    direct_object_candidate: NativeTarget::from_host_with_new_native_env(
-                        std::env::consts::ARCH,
-                        std::env::consts::OS,
-                        new_native_env.as_deref(),
-                    ),
-                    allocator: compiler_flags::NativeAllocator::from_env()?,
-                }
-            }
-            TargetBackend::LLVM => BackendConfig::Llvm {
-                allocator: compiler_flags::NativeAllocator::from_env()?,
-            },
-        };
-        info!("Final backend configuration: {:?}", backend);
-        let stdlib_path = if std {
-            Some(moonutil::toolchain::core())
-        } else {
-            None
-        };
-        let target_layout = TargetLayout::from_resolve_output(
-            self.target_dir.clone(),
-            resolve_output,
-            self.opt_level,
-            self.action,
-        );
-        let artifact_paths = ArtifactPathResolver::new(target_layout, stdlib_path.clone());
-        Ok(CompileConfig {
-            target_dir: self.target_dir,
-            backend,
-            opt_level: self.opt_level,
-            action: self.action,
-            debug_symbols,
-            stdlib_path,
-            artifact_paths,
-            lowering_environment: LoweringEnvironment::default(),
-            enable_coverage: self.enable_coverage,
-            debug_export_build_plan: self.debug_export_build_plan,
-            moonc_output_json: self.moonc_output_json,
-            docs_serve: self.docs_serve,
-            warning_condition: self.warning_condition,
-            warn_list: self.warn_list,
-            info_no_alias: self.info_no_alias,
-        })
-    }
-}
-
-/// Read in the commandline flags and build flags to create a
-/// [`CompilePreConfig`] for compilation usage.
-///
-/// - `auto_sync_flags`: The flags to control module download & sync behavior.
-/// - `cli`: The universal CLI flags.
-/// - `build_flags`: The build-specific flags.
-/// - `selected_target_backend`: The backend selected for this invocation, if explicit.
-/// - `target_dir`: The target directory for the build.
-/// - `action`: The run mode (build, test, bench, etc.). This also affects the
-///   default build profile (`moon build`/`run`/`test`/`fmt`/`check` default to
-///   debug; `moon bench`/`bundle` default to release).
+/// CLI policy is resolved here while both the original flags and selected backend
+/// are available. Command adapters may then use that backend to expand their
+/// intent; RR receives one completed configuration with no CLI parsing types.
 #[instrument(level = Level::DEBUG, skip_all)]
-pub fn preconfig_compile(
-    auto_sync_flags: &AutoSyncFlags,
+pub(crate) fn prepare_resolved_build(
     cli: &UniversalFlags,
     build_flags: &BuildFlags,
     selected_target_backend: Option<TargetBackend>,
     target_dir: &Path,
     action: RunMode,
-) -> CompilePreConfig {
-    let opt_level = build_flags.effective_profile(action);
-
-    CompilePreConfig {
-        frozen: auto_sync_flags.frozen,
-        target_dir: target_dir.to_owned(),
-        target_backend: selected_target_backend,
-        opt_level,
-        action,
-        debug_symbols: build_flags.debug_symbols_for(action),
-        omit_native_run_debug_symbols: action == RunMode::Run
-            && !build_flags.debug
-            && !build_flags.no_strip,
-        use_std: build_flags.std(),
-        enable_coverage: build_flags.enable_coverage,
-        workspace_env: cli.workspace_env.clone(),
-        output_wat: build_flags.output_wat,
-        debug_export_build_plan: cli.unstable_feature.rr_export_build_plan,
-        wasi_link: cli.unstable_feature.wasi_link
-            && std::env::var("MOON_WASI_LINK").as_deref() != Ok("0"),
-        // In legacy impl, dry run always force no json
-        moonc_output_json: !cli.dry_run && build_flags.output_style().needs_moonc_json(),
-        docs_serve: false,
-        info_no_alias: false,
-        warning_condition: if build_flags.deny_warn {
-            WarningCondition::Deny
-        } else {
-            WarningCondition::Default
-        },
-        warn_list: build_flags.warn_list.clone(),
-    }
-}
-
-pub(crate) struct ResolvedBuildPlanningContext {
-    target_backend: TargetBackend,
-    is_core: bool,
-}
-
-impl ResolvedBuildPlanningContext {
-    pub(crate) fn target_backend(&self) -> TargetBackend {
-        self.target_backend
-    }
-}
-
-/// Prepare the resolved build context before command intent is calculated.
-///
-/// This step emits resolve-time diagnostics and determines the effective target
-/// backend. Commands that already resolved raw CLI selectors can use the
-/// returned backend to compute `CalcUserIntentOutput` outside the shared RR
-/// planning pipeline.
-#[instrument(level = Level::DEBUG, skip_all)]
-pub(crate) fn prepare_resolved_build(
-    preconfig: &CompilePreConfig,
-    unstable_features: &FeatureGate,
-    target_dir: &Path,
     user_log: &UserLog,
     resolve_output: &ResolveOutput,
-) -> anyhow::Result<ResolvedBuildPlanningContext> {
+) -> anyhow::Result<CompileConfig> {
     // A couple of debug things:
-    if unstable_features.rr_export_module_graph {
+    if cli.unstable_feature.rr_export_module_graph {
         info!("Exporting module graph DOT file");
         moonbuild_rupes_recta::util::print_resolved_env_dot(
             &resolve_output.module_rel,
             &mut std::fs::File::create(target_dir.join("module_graph.dot"))?,
         )?;
     }
-    if unstable_features.rr_export_package_graph {
+    if cli.unstable_feature.rr_export_package_graph {
         info!("Exporting package graph DOT file");
         moonbuild_rupes_recta::util::print_dep_relationship_dot(
             &resolve_output.pkg_rel,
@@ -515,15 +327,14 @@ pub(crate) fn prepare_resolved_build(
         &[module_id] => Some(resolve_output.module_info(module_id)),
         _ => None,
     };
-    let preferred_target = if preconfig.target_backend.is_some() {
+    let preferred_target = if selected_target_backend.is_some() {
         None
     } else {
         local_modules_preferred_target(resolve_output, user_log)
     };
     info!("Preferred backend: {:?}", preferred_target);
 
-    let target_backend = preconfig
-        .target_backend
+    let target_backend = selected_target_backend
         .or(preferred_target)
         .unwrap_or_default();
 
@@ -540,9 +351,58 @@ pub(crate) fn prepare_resolved_build(
     let is_core = main_module.is_some_and(|module| module.name == MOONBITLANG_CORE);
     info!("is_core: {}", is_core);
 
-    Ok(ResolvedBuildPlanningContext {
-        target_backend,
-        is_core,
+    let opt_level = build_flags.effective_profile(action);
+    let backend = match target_backend {
+        TargetBackend::Wasm => BackendConfig::Wasm {
+            use_wat: build_flags.output_wat,
+            wasi_link: cli.unstable_feature.wasi_link
+                && std::env::var("MOON_WASI_LINK").as_deref() != Ok("0"),
+        },
+        TargetBackend::WasmGC => BackendConfig::WasmGc {
+            use_wat: build_flags.output_wat,
+        },
+        TargetBackend::Js => BackendConfig::Js,
+        TargetBackend::Native => {
+            let new_native_env = std::env::var(ENV_MOONBIT_NEW_NATIVE).ok();
+            BackendConfig::Native {
+                direct_object_candidate: NativeTarget::from_host_with_new_native_env(
+                    std::env::consts::ARCH,
+                    std::env::consts::OS,
+                    new_native_env.as_deref(),
+                ),
+                allocator: compiler_flags::NativeAllocator::from_env()?,
+            }
+        }
+        TargetBackend::LLVM => BackendConfig::Llvm {
+            allocator: compiler_flags::NativeAllocator::from_env()?,
+        },
+    };
+    info!("Final backend configuration: {:?}", backend);
+    let stdlib_path = (build_flags.std() && !is_core).then(moonutil::toolchain::core);
+    let target_layout =
+        TargetLayout::from_resolve_output(target_dir.to_owned(), resolve_output, opt_level, action);
+    let artifact_paths = ArtifactPathResolver::new(target_layout, stdlib_path.clone());
+    Ok(CompileConfig {
+        target_dir: target_dir.to_owned(),
+        backend,
+        opt_level,
+        action,
+        debug_symbols: build_flags.debug_symbols_for(action, target_backend),
+        stdlib_path,
+        artifact_paths,
+        lowering_environment: LoweringEnvironment::default(),
+        enable_coverage: build_flags.enable_coverage,
+        debug_export_build_plan: cli.unstable_feature.rr_export_build_plan,
+        // In legacy impl, dry run always forces no JSON.
+        moonc_output_json: !cli.dry_run && build_flags.output_style().needs_moonc_json(),
+        docs_serve: false,
+        warning_condition: if build_flags.deny_warn {
+            WarningCondition::Deny
+        } else {
+            WarningCondition::Default
+        },
+        warn_list: build_flags.warn_list.clone(),
+        info_no_alias: false,
     })
 }
 
@@ -553,37 +413,30 @@ pub(crate) fn prepare_resolved_build(
 /// identities plus precomputed build-context paths from the command adapter.
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(crate) fn plan_resolved_build_from_intent(
-    preconfig: CompilePreConfig,
-    unstable_features: &FeatureGate,
+    cx: CompileConfig,
     user_log: &UserLog,
-    planning_context: ResolvedBuildPlanningContext,
     intent: CalcUserIntentOutput,
     mooncake_bin_dir: &Path,
     resolve_output: ResolveOutput,
 ) -> anyhow::Result<(BuildMeta, BuildInput)> {
-    let target_dir = preconfig.target_dir.clone();
+    let target_dir = cx.target_dir.clone();
     info!("User intent calculated: {:?}", intent.intents);
 
     // Module-level configuration discovers native toolchains and flags; other
     // backends do not need to execute these scripts.
-    let prebuild_config =
-        if preconfig.action == RunMode::Check || !planning_context.target_backend.is_native() {
-            info!("Skipping prebuild configuration for check or non-native backend");
-            None
-        } else {
-            info!("Running prebuild configuration");
-            let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
-            Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
-        };
+    let prebuild_config = if cx.action == RunMode::Check || !cx.backend.target_backend().is_native()
+    {
+        info!("Skipping prebuild configuration for check or non-native backend");
+        None
+    } else {
+        info!("Running prebuild configuration");
+        let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
+        Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
+    };
 
     info!("Expanding user intents to requested artifacts");
     let requested_artifacts =
-        intent.requested_artifacts(&resolve_output, user_log, planning_context.target_backend);
-    let cx = preconfig.into_compile_config(
-        planning_context.target_backend,
-        planning_context.is_core,
-        &resolve_output,
-    )?;
+        intent.requested_artifacts(&resolve_output, user_log, cx.backend.target_backend());
     info!("Begin lowering to build graph");
     let compile_output = moonbuild_rupes_recta::compile(
         &cx,
@@ -595,7 +448,7 @@ pub(crate) fn plan_resolved_build_from_intent(
         user_log,
     )?;
 
-    if unstable_features.rr_export_build_plan
+    if cx.debug_export_build_plan
         && let Some(plan) = compile_output.build_plan
     {
         info!("Exporting build plan DOT file");
@@ -648,40 +501,32 @@ pub(crate) fn plan_resolved_build_from_intent(
 /// This entry point is intentionally used only by standalone `.mbt`/`.mbtx`
 /// builds. Normal workspace commands continue through
 /// [`plan_resolved_build_from_intent`].
-#[allow(clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(crate) fn plan_resolved_standalone_build_from_intent(
-    preconfig: CompilePreConfig,
-    unstable_features: &FeatureGate,
+    cx: CompileConfig,
     user_log: &UserLog,
-    planning_context: ResolvedBuildPlanningContext,
     intent: CalcUserIntentOutput,
     script_package: PackageId,
     mooncake_bin_dir: &Path,
     resolve_output: ResolveOutput,
 ) -> anyhow::Result<(BuildMeta, StandaloneBuildInput)> {
-    let target_dir = preconfig.target_dir.clone();
+    let target_dir = cx.target_dir.clone();
     info!("Standalone user intent calculated: {:?}", intent.intents);
 
     // Module-level configuration discovers native toolchains and flags; other
     // backends do not need to execute these scripts.
-    let prebuild_config =
-        if preconfig.action == RunMode::Check || !planning_context.target_backend.is_native() {
-            info!("Skipping prebuild configuration for check or non-native backend");
-            None
-        } else {
-            info!("Running prebuild configuration");
-            let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
-            Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
-        };
+    let prebuild_config = if cx.action == RunMode::Check || !cx.backend.target_backend().is_native()
+    {
+        info!("Skipping prebuild configuration for check or non-native backend");
+        None
+    } else {
+        info!("Running prebuild configuration");
+        let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
+        Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
+    };
 
     let requested_artifacts =
-        intent.requested_artifacts(&resolve_output, user_log, planning_context.target_backend);
-    let cx = preconfig.into_compile_config(
-        planning_context.target_backend,
-        planning_context.is_core,
-        &resolve_output,
-    )?;
+        intent.requested_artifacts(&resolve_output, user_log, cx.backend.target_backend());
     let compile_output = moonbuild_rupes_recta::compile_standalone(
         &cx,
         mooncake_bin_dir,
@@ -693,7 +538,7 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
         user_log,
     )?;
 
-    if unstable_features.rr_export_build_plan
+    if cx.debug_export_build_plan
         && let Some(plan) = compile_output.build_plan.as_deref()
     {
         moonbuild_rupes_recta::util::print_build_plan_dot(

--- a/crates/moon/src/tests/planner/profile_planning.rs
+++ b/crates/moon/src/tests/planner/profile_planning.rs
@@ -355,38 +355,45 @@ fn run_graph_uses_selected_profile() {
 
 #[test]
 fn default_native_run_uses_o0_without_full_debug_info() {
-    let fixture = PlanningFixture::new("debug_flag_test").expect("fixture should resolve");
-    for (label, extra_args, expect_debug_info) in [
-        ("default", [].as_slice(), false),
-        ("debug", ["--debug"].as_slice(), true),
-        ("no-strip", ["--no-strip"].as_slice(), true),
+    for (case, package, target_args) in [
+        ("debug_flag_test", "main", ["--target", "native"].as_slice()),
+        (
+            "workspace_conflicting_run_preferred_targets.in",
+            "native_preferred/src/main",
+            [].as_slice(),
+        ),
     ] {
-        let mut args = vec![
-            "run",
-            "main",
-            "--target",
-            "native",
-            "--dry-run",
-            "--nostd",
-            "--sort-input",
-        ];
-        args.extend_from_slice(extra_args);
-        let (cli, cmd) = parse_run_command(&args);
-        let graph = fixture
-            .plan_run_with_cli(&cli, &cmd)
-            .unwrap_or_else(|err| panic!("{label} native run graph should plan: {err:#}"));
-
-        for (command, filter) in [
-            ("moonc build-package", ["./lib/hello.mbt"].as_slice()),
-            ("moonc link-core", ["-main", "hello/main"].as_slice()),
+        let fixture = PlanningFixture::new(case).expect("fixture should resolve");
+        for (label, extra_args, expect_debug_info) in [
+            ("default", [].as_slice(), false),
+            ("debug", ["--debug"].as_slice(), true),
+            ("no-strip", ["--no-strip"].as_slice(), true),
+            ("strip", ["--debug", "--strip"].as_slice(), false),
         ] {
-            let tokens = command_tokens(&graph, command, filter);
-            assert!(tokens.iter().any(|token| token == "-O0"), "{tokens:?}");
-            assert_eq!(
-                tokens.iter().any(|token| token == "-g"),
-                expect_debug_info,
-                "{tokens:?}"
-            );
+            let mut args = vec!["run", package, "--dry-run", "--nostd", "--sort-input"];
+            args.extend_from_slice(target_args);
+            args.extend_from_slice(extra_args);
+            let (cli, cmd) = parse_run_command(&args);
+            let graph = fixture
+                .plan_run_with_cli(&cli, &cmd)
+                .unwrap_or_else(|err| panic!("{case}: {label} native run should plan: {err:#}"));
+
+            for (command, filter) in [
+                ("moonc build-package", ["main.mbt"].as_slice()),
+                ("moonc link-core", ["-main"].as_slice()),
+            ] {
+                let tokens = command_tokens(&graph, command, filter);
+                assert!(
+                    tokens.iter().any(|token| token.contains("/native/debug/")),
+                    "{tokens:?}"
+                );
+                assert!(tokens.iter().any(|token| token == "-O0"), "{tokens:?}");
+                assert_eq!(
+                    tokens.iter().any(|token| token == "-g"),
+                    expect_debug_info,
+                    "{case}: {label}: {tokens:?}"
+                );
+            }
         }
     }
 }

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -174,6 +174,8 @@ pub fn compile_standalone(
     })
 }
 
+// TODO: Remove `build_environment` and `lowering_options` once planning and
+// lowering both borrow `CompileConfig` instead of copying its configuration.
 fn build_environment(cx: &CompileConfig) -> BuildEnvironment {
     let native_or_llvm = cx.backend.native_allocator().is_some();
     let compiler_paths = native_or_llvm.then(|| cx.lowering_environment.compiler_paths().clone());

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -17,8 +17,13 @@ as the context needed to realize the artifact's physical path.
 
 ## Backend configuration
 
-After command adapters resolve the Target Backend and expand user intent to
-requested `ArtifactKey` values, Moon selects one `BackendConfig` value:
+Once the project is resolved, the CLI adapter selects the Target Backend and
+constructs `CompileConfig` directly from the original flags and captured
+environment inputs. Commands use its backend to expand user intent to requested
+`ArtifactKey` values. There is no preliminary compilation configuration;
+dependency synchronization and resolution use their own `ResolveConfig`.
+
+Each compilation has one `BackendConfig` value:
 
 ```rust
 pub enum BackendConfig {

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -107,8 +107,8 @@ default optimization profile by subcommand:
 - `moon bench` and `moon bundle` use the release profile.
 
 This policy is centralized in `BuildFlags::effective_profile()` in
-`crates/moon/src/cli.rs`. Individual commands may still layer additional
-symbol or strip behavior on top of that default profile. A default `moon run`
+`crates/moon/src/build_flags.rs`. `BuildFlags::debug_symbols_for()` resolves
+symbol policy once the backend is selected. A default `moon run`
 for the Native target backend keeps `-O0` and stack-trace metadata but omits
 full `-g` debug information; explicit `--debug` or `--no-strip` retains it.
 


### PR DESCRIPTION
- Related issues: None
- PR kind: Refactor

## Summary

`CompilePreConfig` copies CLI flags into an intermediate configuration that mixes dependency-resolution options with backend-specific compilation options. It also carries `omit_native_run_debug_symbols` to revise symbol policy after backend selection, while `ResolvedBuildPlanningContext` separately stores the selected backend.

Construct `CompileConfig` directly in `prepare_resolved_build`, where the original flags and resolved project are already available and the backend is selected. Remove both intermediate types and let command adapters read the backend from that configuration. Compute debug-symbol policy from the original flags and selected backend, preserving the default Native run behavior and explicit debug/strip overrides. Docs and prove construct `ResolveConfig` directly. Backend-specific host and environment observations remain in the CLI adapter.

This is a focused follow-up to #2161: most command changes remove the intermediate construction and arguments. Native mode selection stays in RR, and sharing `CompileConfig` between planning and lowering remains a separate follow-up, marked in source. Planner coverage now exercises both explicit and project-preferred Native selection.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
