### PR TITLE
refactor(build): prefix per-script build directories with a dot

### DIFF
--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -83,7 +83,9 @@ fn target_scoped_packages_json_path(
 }
 
 fn standalone_target_dir(dir: impl AsRef<Path>, source_filename: &str) -> PathBuf {
-    dir.as_ref().join("_build").join(source_filename)
+    dir.as_ref()
+        .join("_build")
+        .join(format!(".{source_filename}"))
 }
 
 pub fn moon_cmd(dir: &impl AsRef<Path>) -> snapbox::cmd::Command {

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -89,7 +89,7 @@ fn test_moon_help() {
               -C <DIR>
                       Change to DIR before doing anything else (must appear before the subcommand). Relative paths in other options and arguments are interpreted relative to DIR. Example: `moon -C a run .` runs the same as invoking `moon run .` from within `a`
                   --target-dir <TARGET_DIR>
-                      The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build/<file-name>` for a standalone file
+                      The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build/.<file-name>` for a standalone file
               -q, --quiet
                       Suppress output
               -v, --verbose
@@ -176,10 +176,10 @@ native
         .stderr_eq("");
 
     assert!(
-        dir.join("_build/moonx_args.mbtx/wasm/debug/build/single/single.wasm")
+        dir.join("_build/.moonx_args.mbtx/wasm/debug/build/single/single.wasm")
             .is_file()
     );
-    assert!(!dir.join("_build/moonx_args.mbtx/wasm-gc").exists());
+    assert!(!dir.join("_build/.moonx_args.mbtx/wasm-gc").exists());
 }
 
 #[test]
@@ -1632,7 +1632,7 @@ fn test_moon_explain_without_flags_shows_guidance() {
               -h, --help                       Print help
 
             Common Options:
-                  --target-dir <TARGET_DIR>  The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build/<file-name>` for a standalone file
+                  --target-dir <TARGET_DIR>  The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build/.<file-name>` for a standalone file
               -q, --quiet                    Suppress output
               -v, --verbose                  Increase verbosity
                   --trace                    Trace the execution of the program
@@ -1986,7 +1986,7 @@ fn test_moon_run_command_string_defaults_to_wasm() {
 
     assert!(stdout.contains("-target wasm"), "stdout: {stdout}");
     assert!(
-        stdout.contains("./_build/command.mbtx/wasm/debug/build/single/single.core"),
+        stdout.contains("./_build/.command.mbtx/wasm/debug/build/single/single.core"),
         "stdout: {stdout}"
     );
     assert!(!stdout.contains("-target wasm-gc"), "stdout: {stdout}");
@@ -2014,12 +2014,12 @@ fn test_moon_run_command_string_explicit_target_overrides_wasm_default() {
     assert!(stdout.contains("-target wasm-gc"), "stdout: {stdout}");
     assert!(
         stdout.contains(
-            "'$MOONRUN_OVERRIDE' ./_build/command.mbtx/wasm-gc/debug/build/single/single.wasm --"
+            "'$MOONRUN_OVERRIDE' ./_build/.command.mbtx/wasm-gc/debug/build/single/single.wasm --"
         ),
         "stdout: {stdout}"
     );
     assert!(
-        !stdout.contains("./_build/command.mbtx/wasm/debug/"),
+        !stdout.contains("./_build/.command.mbtx/wasm/debug/"),
         "stdout: {stdout}"
     );
     assert!(!stdout.contains("-target native"), "stdout: {stdout}");
@@ -2043,7 +2043,7 @@ fn test_moon_run_command_string_short_alias_c_defaults_to_wasm() {
 
     assert!(stdout.contains("-target wasm"), "stdout: {stdout}");
     assert!(
-        stdout.contains("./_build/command.mbtx/wasm/debug/build/single/single.core"),
+        stdout.contains("./_build/.command.mbtx/wasm/debug/build/single/single.core"),
         "stdout: {stdout}"
     );
     assert!(!stdout.contains("-target wasm-gc"), "stdout: {stdout}");

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -89,7 +89,7 @@ fn test_moon_help() {
               -C <DIR>
                       Change to DIR before doing anything else (must appear before the subcommand). Relative paths in other options and arguments are interpreted relative to DIR. Example: `moon -C a run .` runs the same as invoking `moon run .` from within `a`
                   --target-dir <TARGET_DIR>
-                      The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build/.<file-name>` for a standalone file
+                      The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build` for a standalone file
               -q, --quiet
                       Suppress output
               -v, --verbose
@@ -1632,7 +1632,7 @@ fn test_moon_explain_without_flags_shows_guidance() {
               -h, --help                       Print help
 
             Common Options:
-                  --target-dir <TARGET_DIR>  The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build/.<file-name>` for a standalone file
+                  --target-dir <TARGET_DIR>  The target directory. Defaults to `<project-root>/_build`, or `<source-dir>/_build` for a standalone file
               -q, --quiet                    Suppress output
               -v, --verbose                  Increase verbosity
                   --trace                    Trace the execution of the program

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -34,16 +34,16 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::Native),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/single.mbt/native/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target native -O0 -workspace-path . -all-pkgs ./_build/single.mbt/native/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/single.mbt/native/debug/build/single/single.core -main moon/test/single -o ./_build/single.mbt/native/debug/build/single/single.c -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native -O0
-            cc -o ./_build/single.mbt/native/debug/build/runtime-utf.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/utf.c'
-            cc -o ./_build/single.mbt/native/debug/build/runtime-sync_io.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/sync_io.c'
-            cc -o ./_build/single.mbt/native/debug/build/runtime-runtime.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/runtime.c'
-            cc -o ./_build/single.mbt/native/debug/build/runtime-env.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/env.c'
-            cc -o ./_build/single.mbt/native/debug/build/runtime-backtrace.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/backtrace.c'
-            [ARCHIVER] [CREATE_ARGS] ./_build/single.mbt/native/debug/build/libruntime[FINGER_PRINT].a ./_build/single.mbt/native/debug/build/runtime-backtrace.o ./_build/single.mbt/native/debug/build/runtime-env.o ./_build/single.mbt/native/debug/build/runtime-runtime.o ./_build/single.mbt/native/debug/build/runtime-sync_io.o ./_build/single.mbt/native/debug/build/runtime-utf.o
-            cc -o ./_build/single.mbt/native/debug/build/single/single.exe '-I$MOON_HOME/include' -fwrapv -fno-strict-aliasing -Og '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/libmoonbitrun.o' ./_build/single.mbt/native/debug/build/single/single.c ./_build/single.mbt/native/debug/build/libruntime[FINGER_PRINT].a -lm '$MOON_HOME/lib/libbacktrace.a'
-            ./_build/single.mbt/native/debug/build/single/single.exe
+            moonc build-package ./single.mbt -o ./_build/.single.mbt/native/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target native -O0 -workspace-path . -all-pkgs ./_build/.single.mbt/native/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/.single.mbt/native/debug/build/single/single.core -main moon/test/single -o ./_build/.single.mbt/native/debug/build/single/single.c -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native -O0
+            cc -o ./_build/.single.mbt/native/debug/build/runtime-utf.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/utf.c'
+            cc -o ./_build/.single.mbt/native/debug/build/runtime-sync_io.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/sync_io.c'
+            cc -o ./_build/.single.mbt/native/debug/build/runtime-runtime.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/runtime.c'
+            cc -o ./_build/.single.mbt/native/debug/build/runtime-env.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/env.c'
+            cc -o ./_build/.single.mbt/native/debug/build/runtime-backtrace.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_ALLOW_STACKTRACE '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/backtrace.c'
+            [ARCHIVER] [CREATE_ARGS] ./_build/.single.mbt/native/debug/build/libruntime[FINGER_PRINT].a ./_build/.single.mbt/native/debug/build/runtime-backtrace.o ./_build/.single.mbt/native/debug/build/runtime-env.o ./_build/.single.mbt/native/debug/build/runtime-runtime.o ./_build/.single.mbt/native/debug/build/runtime-sync_io.o ./_build/.single.mbt/native/debug/build/runtime-utf.o
+            cc -o ./_build/.single.mbt/native/debug/build/single/single.exe '-I$MOON_HOME/include' -fwrapv -fno-strict-aliasing -Og '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/libmoonbitrun.o' ./_build/.single.mbt/native/debug/build/single/single.c ./_build/.single.mbt/native/debug/build/libruntime[FINGER_PRINT].a -lm '$MOON_HOME/lib/libbacktrace.a'
+            ./_build/.single.mbt/native/debug/build/single/single.exe
         "#]],
     );
 
@@ -64,16 +64,16 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::Native),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/single.mbt/native/release/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target native -workspace-path . -all-pkgs ./_build/single.mbt/native/release/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/single.mbt/native/release/build/single/single.core -main moon/test/single -o ./_build/single.mbt/native/release/build/single/single.c -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native
-            cc -o ./_build/single.mbt/native/release/build/runtime-utf.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/utf.c'
-            cc -o ./_build/single.mbt/native/release/build/runtime-sync_io.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/sync_io.c'
-            cc -o ./_build/single.mbt/native/release/build/runtime-runtime.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/runtime.c'
-            cc -o ./_build/single.mbt/native/release/build/runtime-env.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/env.c'
-            cc -o ./_build/single.mbt/native/release/build/runtime-backtrace.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/backtrace.c'
-            [ARCHIVER] [CREATE_ARGS] ./_build/single.mbt/native/release/build/libruntime[FINGER_PRINT].a ./_build/single.mbt/native/release/build/runtime-backtrace.o ./_build/single.mbt/native/release/build/runtime-env.o ./_build/single.mbt/native/release/build/runtime-runtime.o ./_build/single.mbt/native/release/build/runtime-sync_io.o ./_build/single.mbt/native/release/build/runtime-utf.o '$MOON_HOME/lib/moonbit_simdutf.o' '$MOON_HOME/lib/simdutf.o'
-            cc -o ./_build/single.mbt/native/release/build/single/single.exe '-I$MOON_HOME/include' -fwrapv -fno-strict-aliasing -O2 '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/libmoonbitrun.o' ./_build/single.mbt/native/release/build/single/single.c ./_build/single.mbt/native/release/build/libruntime[FINGER_PRINT].a -lm '$MOON_HOME/lib/libbacktrace.a'
-            ./_build/single.mbt/native/release/build/single/single.exe
+            moonc build-package ./single.mbt -o ./_build/.single.mbt/native/release/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target native -workspace-path . -all-pkgs ./_build/.single.mbt/native/release/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/.single.mbt/native/release/build/single/single.core -main moon/test/single -o ./_build/.single.mbt/native/release/build/single/single.c -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native
+            cc -o ./_build/.single.mbt/native/release/build/runtime-utf.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/utf.c'
+            cc -o ./_build/.single.mbt/native/release/build/runtime-sync_io.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/sync_io.c'
+            cc -o ./_build/.single.mbt/native/release/build/runtime-runtime.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/runtime.c'
+            cc -o ./_build/.single.mbt/native/release/build/runtime-env.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/env.c'
+            cc -o ./_build/.single.mbt/native/release/build/runtime-backtrace.o '-I$MOON_HOME/include' -g -c -fwrapv -fno-strict-aliasing -O2 -DMOONBIT_USE_SIMDUTF '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/runtime/backtrace.c'
+            [ARCHIVER] [CREATE_ARGS] ./_build/.single.mbt/native/release/build/libruntime[FINGER_PRINT].a ./_build/.single.mbt/native/release/build/runtime-backtrace.o ./_build/.single.mbt/native/release/build/runtime-env.o ./_build/.single.mbt/native/release/build/runtime-runtime.o ./_build/.single.mbt/native/release/build/runtime-sync_io.o ./_build/.single.mbt/native/release/build/runtime-utf.o '$MOON_HOME/lib/moonbit_simdutf.o' '$MOON_HOME/lib/simdutf.o'
+            cc -o ./_build/.single.mbt/native/release/build/single/single.exe '-I$MOON_HOME/include' -fwrapv -fno-strict-aliasing -O2 '-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_MIMALLOC' '$MOON_HOME/lib/libmoonbitrun.o' ./_build/.single.mbt/native/release/build/single/single.c ./_build/.single.mbt/native/release/build/libruntime[FINGER_PRINT].a -lm '$MOON_HOME/lib/libbacktrace.a'
+            ./_build/.single.mbt/native/release/build/single/single.exe
         "#]],
     );
 
@@ -91,9 +91,9 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::Js),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/single.mbt/js/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/single.mbt/js/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/js/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/js/release/bundle/core.core' ./_build/single.mbt/js/debug/build/single/single.core -main moon/test/single -o ./_build/single.mbt/js/debug/build/single/single.js -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target js -g -O0 -source-map
-            node --enable-source-maps ./_build/single.mbt/js/debug/build/single/single.js
+            moonc build-package ./single.mbt -o ./_build/.single.mbt/js/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/.single.mbt/js/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/js/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/js/release/bundle/core.core' ./_build/.single.mbt/js/debug/build/single/single.core -main moon/test/single -o ./_build/.single.mbt/js/debug/build/single/single.js -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target js -g -O0 -source-map
+            node --enable-source-maps ./_build/.single.mbt/js/debug/build/single/single.js
         "#]],
     );
 
@@ -104,9 +104,9 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::WasmGC),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/single.mbt/wasm-gc/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/single.mbt/wasm-gc/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/single.mbt/wasm-gc/debug/build/single/single.core -main moon/test/single -o ./_build/single.mbt/wasm-gc/debug/build/single/single.wasm -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
-            '$MOONRUN_OVERRIDE' ./_build/single.mbt/wasm-gc/debug/build/single/single.wasm --
+            moonc build-package ./single.mbt -o ./_build/.single.mbt/wasm-gc/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/.single.mbt/wasm-gc/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/.single.mbt/wasm-gc/debug/build/single/single.core -main moon/test/single -o ./_build/.single.mbt/wasm-gc/debug/build/single/single.wasm -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
+            '$MOONRUN_OVERRIDE' ./_build/.single.mbt/wasm-gc/debug/build/single/single.wasm --
         "#]],
     );
 
@@ -117,9 +117,9 @@ fn test_moon_run_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::Js),
         expect![[r#"
-            moonc build-package ./single.mbt -o ./_build/single.mbt/js/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/single.mbt/js/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/js/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/js/release/bundle/core.core' ./_build/single.mbt/js/debug/build/single/single.core -main moon/test/single -o ./_build/single.mbt/js/debug/build/single/single.js -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target js -g -O0 -source-map
-            node --enable-source-maps ./_build/single.mbt/js/debug/build/single/single.js
+            moonc build-package ./single.mbt -o ./_build/.single.mbt/js/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/.single.mbt/js/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/js/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/js/release/bundle/core.core' ./_build/.single.mbt/js/debug/build/single/single.core -main moon/test/single -o ./_build/.single.mbt/js/debug/build/single/single.js -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target js -g -O0 -source-map
+            node --enable-source-maps ./_build/.single.mbt/js/debug/build/single/single.js
         "#]],
     );
 
@@ -130,11 +130,11 @@ fn test_moon_run_single_file_dry_run() {
     check(
         &output,
         expect![[r#"
-            {"artifacts_path":["$ROOT/a/b/_build/single.mbt/js/debug/build/single/single.js"]}
+            {"artifacts_path":["$ROOT/a/b/_build/.single.mbt/js/debug/build/single/single.js"]}
         "#]],
     );
     assert!(
-        dir.join("a/b/_build/single.mbt/js/debug/build/single/single.js")
+        dir.join("a/b/_build/.single.mbt/js/debug/build/single/single.js")
             .exists()
     );
 }

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -249,7 +249,7 @@ fn test_single_file_mbtx_build() {
     );
     assert!(stdout.contains("moonc link-core"), "stdout: {stdout}");
     assert!(
-        stdout.contains("_build/moonx_args.mbtx/wasm/"),
+        stdout.contains("_build/.moonx_args.mbtx/wasm/"),
         "stdout: {stdout}"
     );
     assert!(!stdout.contains("moonrun"), "stdout: {stdout}");
@@ -261,11 +261,11 @@ fn test_single_file_mbtx_build_accepts_multiple_targets() {
     let _ = get_stdout(&dir, ["build", "moonx_args.mbtx", "--target", "wasm,js"]);
 
     assert!(
-        dir.join("_build/moonx_args.mbtx/wasm/debug/build/single/single.wasm")
+        dir.join("_build/.moonx_args.mbtx/wasm/debug/build/single/single.wasm")
             .is_file()
     );
     assert!(
-        dir.join("_build/moonx_args.mbtx/js/debug/build/single/single.js")
+        dir.join("_build/.moonx_args.mbtx/js/debug/build/single/single.js")
             .is_file()
     );
 }
@@ -414,9 +414,9 @@ fn test_single_file_mbtx_reuses_dependency_graph_after_script_change() {
     let stdout = get_stdout(&dir, args);
     assert!(stdout.contains("hello"));
 
-    let build_dir = dir.join("_build/import_ok.mbtx/wasm/debug/build");
+    let build_dir = dir.join("_build/.import_ok.mbtx/wasm/debug/build");
     let dependency_core = build_dir.join(".mooncakes/moonbitlang/x/stack/stack.core");
-    let n2_db = dir.join("_build/import_ok.mbtx/.moon_db");
+    let n2_db = dir.join("_build/.import_ok.mbtx/.moon_db");
     assert!(dependency_core.is_file());
     assert!(n2_db.is_file());
 

--- a/crates/moon/tests/test_cases/value_tracing/mod.rs
+++ b/crates/moon/tests/test_cases/value_tracing/mod.rs
@@ -180,9 +180,9 @@ fn test_tracing_value_for_single_file_dry_run() {
     check(
         collapse_core_import_args(&output, TargetBackend::WasmGC),
         expect![[r#"
-            moonc build-package ./main.mbt -o ./_build/main.mbt/wasm-gc/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target wasm-gc -g -O0 -source-map -enable-value-tracing -workspace-path . -all-pkgs ./_build/main.mbt/wasm-gc/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/main.mbt/wasm-gc/debug/build/single/single.core -main moon/test/single -o ./_build/main.mbt/wasm-gc/debug/build/single/single.wasm -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
-            '$MOONRUN_OVERRIDE' ./_build/main.mbt/wasm-gc/debug/build/single/single.wasm --
+            moonc build-package ./main.mbt -o ./_build/.main.mbt/wasm-gc/debug/build/single/single.core -pkg moon/test/single -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/<imports>' -pkg-sources moon/test/single:. -target wasm-gc -g -O0 -source-map -enable-value-tracing -workspace-path . -all-pkgs ./_build/.main.mbt/wasm-gc/debug/build/all_pkgs.json
+            moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/.main.mbt/wasm-gc/debug/build/single/single.core -main moon/test/single -o ./_build/.main.mbt/wasm-gc/debug/build/single/single.wasm -pkg-config-path ./moon.pkg.json -pkg-sources moon/test/single:. -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
+            '$MOONRUN_OVERRIDE' ./_build/.main.mbt/wasm-gc/debug/build/single/single.wasm --
         "#]],
     );
 }

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -150,7 +150,7 @@ impl TargetLayoutMode {
 #[derive(Clone, Debug)]
 pub struct TargetLayout {
     /// The base target directory, usually `<project-root>/_build` or
-    /// `<source-dir>/_build/<file-name>` for a standalone file.
+    /// `<source-dir>/_build/.<file-name>` for a standalone file.
     target_base_dir: PathBuf,
     mode: TargetLayoutMode,
     /// The optimization level, debug or release.

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -149,8 +149,8 @@ impl TargetLayoutMode {
 /// Target folder layout for generated artifacts.
 #[derive(Clone, Debug)]
 pub struct TargetLayout {
-    /// The base target directory, usually `<project-root>/_build` or
-    /// `<source-dir>/_build/.<file-name>` for a standalone file.
+    /// The base directory for this artifact layout. Standalone files use a
+    /// `.<file-name>` subdirectory beneath the configured target root.
     target_base_dir: PathBuf,
     mode: TargetLayoutMode,
     /// The optimization level, debug or release.

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -81,7 +81,7 @@ pub struct SourceTargetDirs {
     pub cwd: Option<PathBuf>,
 
     /// The target directory. Defaults to `<project-root>/_build`, or
-    /// `<source-dir>/_build/.<file-name>` for a standalone file.
+    /// `<source-dir>/_build` for a standalone file.
     #[clap(long, global = true)]
     pub target_dir: Option<PathBuf>,
 }

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -81,7 +81,7 @@ pub struct SourceTargetDirs {
     pub cwd: Option<PathBuf>,
 
     /// The target directory. Defaults to `<project-root>/_build`, or
-    /// `<source-dir>/_build/<file-name>` for a standalone file.
+    /// `<source-dir>/_build/.<file-name>` for a standalone file.
     #[clap(long, global = true)]
     pub target_dir: Option<PathBuf>,
 }
@@ -155,14 +155,16 @@ impl SourceTargetDirs {
             .context("file path must have a parent directory")
             .map(Path::to_path_buf)
             .map_err(PackageDirsError::from)?;
-        // Keep the complete filename so supported source extensions with the
-        // same stem cannot share build state.
+        // Prefix the complete filename with a dot to keep script build state
+        // hidden, without sharing it between source extensions with the same stem.
         let file_name = file_path
             .file_name()
             .context("file path must have a file name")
             .map_err(PackageDirsError::from)?;
         let package_dirs = self.source_root_package_dirs(source_dir)?;
-        let target_dir = prepare_target_dir(package_dirs.target_dir.join(file_name))?;
+        let mut build_dir_name = OsString::from(".");
+        build_dir_name.push(file_name);
+        let target_dir = prepare_target_dir(package_dirs.target_dir.join(build_dir_name))?;
         let package_dirs = PackageDirs {
             mooncake_bin_dir: target_dir.join(MOON_BIN_DIR),
             mooncakes_dir: target_dir.join(DEP_PATH),
@@ -860,11 +862,11 @@ mod tests {
 
         assert_eq!(
             first.package_dirs.target_dir,
-            canonical(project.path().join("_build/first.mbt"))
+            canonical(project.path().join("_build/.first.mbt"))
         );
         assert_eq!(
             second.package_dirs.target_dir,
-            canonical(project.path().join("_build/second.mbtx"))
+            canonical(project.path().join("_build/.second.mbtx"))
         );
         assert_ne!(
             first.package_dirs.target_dir,
@@ -897,7 +899,7 @@ mod tests {
 
         assert_eq!(
             dirs.package_dirs.target_dir,
-            canonical(project.path().join("target/main.mbt.md"))
+            canonical(project.path().join("target/.main.mbt.md"))
         );
         assert_eq!(
             dirs.package_dirs.mooncake_bin_dir,
@@ -910,10 +912,12 @@ mod tests {
     }
 
     #[test]
-    fn single_file_package_dirs_reject_target_aliasing_source_file() {
+    fn single_file_package_dirs_reject_target_aliasing_existing_file() {
         let project = tempfile::tempdir().expect("create test project");
         let source_file = project.path().join("main.mbtx");
         write_file(&source_file, "fn main {}\n");
+        let conflicting_file = project.path().join(".main.mbtx");
+        write_file(&conflicting_file, "existing file\n");
 
         let result = SourceTargetDirs {
             cwd: None,
@@ -924,7 +928,7 @@ mod tests {
         assert!(matches!(
             result,
             Err(PackageDirsError::TargetDirNotDirectory(path))
-                if path == canonical(source_file)
+                if path == canonical(conflicting_file)
         ));
     }
 

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -68,7 +68,7 @@ resolution.
 and stdin programs passed as `-`. Single-file check and test commands retain
 private dependency directories. Whenever a standalone command uses private
 dependencies, its `.mooncakes` directory lives under the per-script build root
-(for example, `_build/script.mbtx/.mooncakes`) and follows `--target-dir`.
+(for example, `_build/.script.mbtx/.mooncakes`) and follows `--target-dir`.
 Ordinary projects and workspaces retain their project-local dependency
 directories.
 `MOON_BUILD_CACHE` still configures and cleans its future root only.

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -191,10 +191,11 @@ forward instead of letting later phases infer it again. In particular:
 - package and module directories come from discovery results, not from later
   path guessing.
 
-Standalone-file commands scope this target directory by prefixing the input's
-complete filename, including its extension, with a dot. The default is
-`<source-dir>/_build/.<filename>`; an explicit `--target-dir <dir>` produces
-`<dir>/.<filename>`. The source-local default separates files in different
+For standalone-file commands, `--target-dir` selects the target root, which
+defaults to `<source-dir>/_build`. The layout places each script's build state
+in a `.<filename>` subdirectory, preserving the complete filename and extension.
+Thus `--target-dir <dir>` places that state in `<dir>/.<filename>`.
+The source-local default separates files in different
 source directories, while the complete filename separates differently named
 files within one target root. Callers that reuse an explicit target root for
 files with the same complete filename also reuse their synthetic package

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -191,10 +191,10 @@ forward instead of letting later phases infer it again. In particular:
 - package and module directories come from discovery results, not from later
   path guessing.
 
-Standalone-file commands scope this target directory by the input's complete
-filename, including its extension. The default is
-`<source-dir>/_build/<filename>`; an explicit `--target-dir <dir>` produces
-`<dir>/<filename>`. The source-local default separates files in different
+Standalone-file commands scope this target directory by prefixing the input's
+complete filename, including its extension, with a dot. The default is
+`<source-dir>/_build/.<filename>`; an explicit `--target-dir <dir>` produces
+`<dir>/.<filename>`. The source-local default separates files in different
 source directories, while the complete filename separates differently named
 files within one target root. Callers that reuse an explicit target root for
 files with the same complete filename also reuse their synthetic package
@@ -659,9 +659,9 @@ Standalone-file checks publish the same relative metadata layout within their
 filename-scoped target directory:
 
 ```text
-_build/<filename>/packages.json
-_build/<filename>/index.json
-_build/<filename>/<backend>/<profile>/check/packages.json
+_build/.<filename>/packages.json
+_build/.<filename>/index.json
+_build/.<filename>/<backend>/<profile>/check/packages.json
 ```
 
 Project checks without a package or path selector publish metadata; focused

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -37,14 +37,15 @@ extension discovered in ordinary packages.
 standalone representation, even when the file is located under an ordinary
 package root. Each command accepts one standalone `.mbtx` path and supports
 single- and multi-backend target selection; watch mode remains project-only.
-All standalone-file commands use `<source-dir>/_build/.<filename>` as their
-default target directory, prefixing the complete filename and extension with a
-dot, so differently named inputs in one source directory do not share synthetic
-package artifacts or incremental build state. With `--target-dir <dir>`, the target
-directory is `<dir>/.<filename>`; the option relocates the target root without
-adding source-path identity, so callers are responsible for using distinct
-target roots for equal filenames from different source directories.
-Private `.mooncakes` dependencies also live under that per-script target root,
+For all standalone-file commands, the target root defaults to
+`<source-dir>/_build`. `--target-dir` overrides that root.
+The layout adds a `.<filename>` subdirectory beneath that root, including the
+complete extension, so differently named inputs in one source directory do not
+share synthetic package artifacts or incremental build state. For example,
+`--target-dir out` places a script's build state in `out/.<filename>`.
+The option does not add source-path identity, so callers are responsible for
+using distinct target roots for equal filenames from different source directories.
+Private `.mooncakes` dependencies also live under that per-script directory,
 so standalone commands do not install dependencies beside the source file.
 
 ### Build targets

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -37,11 +37,11 @@ extension discovered in ordinary packages.
 standalone representation, even when the file is located under an ordinary
 package root. Each command accepts one standalone `.mbtx` path and supports
 single- and multi-backend target selection; watch mode remains project-only.
-All standalone-file commands use `<source-dir>/_build/<filename>` as their
-default target directory, including the complete extension in `<filename>`, so
-differently named inputs in one source directory do not share synthetic package
-artifacts or incremental build state. With `--target-dir <dir>`, the target
-directory is `<dir>/<filename>`; the option relocates the target root without
+All standalone-file commands use `<source-dir>/_build/.<filename>` as their
+default target directory, prefixing the complete filename and extension with a
+dot, so differently named inputs in one source directory do not share synthetic
+package artifacts or incremental build state. With `--target-dir <dir>`, the target
+directory is `<dir>/.<filename>`; the option relocates the target root without
 adding source-path identity, so callers are responsible for using distinct
 target roots for equal filenames from different source directories.
 Private `.mooncakes` dependencies also live under that per-script target root,


### PR DESCRIPTION
- Related issues: None
- PR kind: Enhancement

## Summary

Prefix per-script build directories with a dot: `_build/example.mbtx` becomes `_build/.example.mbtx`, and `--target-dir out` uses `out/.example.mbtx`.

The change is made in the shared standalone directory constructor, preserving the complete filename and keeping compiler artifacts, metadata, locks, and private dependencies together across standalone commands and prebuild scripts. Existing directory tests, command snapshots, help text, and layout documentation are updated to match.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
