### PR TITLE
refactor(rr): share compile configuration with planning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,6 +2041,7 @@ dependencies = [
  "sha2",
  "shlex",
  "slotmap",
+ "tempfile",
  "thiserror 1.0.63",
  "tracing",
  "walkdir",

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -41,12 +41,14 @@ use indexmap::IndexMap;
 use moonbuild::entry::{N2RunStats, ResultCatcher, create_progress_console};
 use moonbuild_rupes_recta::{
     CompileConfig, ResolveConfig, ResolveOutput,
-    build_lower::{LoweringEnvironment, WarningCondition},
+    build_lower::WarningCondition,
     build_plan::{ArtifactKey, InputDirective},
     execution_plan::{ActionId, ExecutionPlan},
     fmt::{FmtConfig, FmtResolveOutput},
     intent::UserIntent,
-    model::{BackendConfig, ENV_MOONBIT_NEW_NATIVE, NativeTarget, PackageId, TargetKind},
+    model::{
+        BackendConfig, ENV_MOONBIT_NEW_NATIVE, NativeTarget, OperatingSystem, PackageId, TargetKind,
+    },
     target_layout::{ArtifactPathResolver, GENERATED_TEST_DRIVER_PREFIX, TargetLayout},
 };
 use moonutil::{
@@ -369,10 +371,18 @@ pub(crate) fn prepare_resolved_build(
                     new_native_env.as_deref(),
                 ),
                 allocator: compiler_flags::NativeAllocator::from_env()?,
+                os: std::env::consts::OS
+                    .parse::<OperatingSystem>()
+                    .expect("Unknown"),
+                compiler_paths: compiler_flags::CompilerPaths::from_moon_dirs(),
             }
         }
         TargetBackend::LLVM => BackendConfig::Llvm {
             allocator: compiler_flags::NativeAllocator::from_env()?,
+            os: std::env::consts::OS
+                .parse::<OperatingSystem>()
+                .expect("Unknown"),
+            compiler_paths: compiler_flags::CompilerPaths::from_moon_dirs(),
         },
     };
     info!("Final backend configuration: {:?}", backend);
@@ -388,7 +398,6 @@ pub(crate) fn prepare_resolved_build(
         debug_symbols: build_flags.debug_symbols_for(action, target_backend),
         stdlib_path,
         artifact_paths,
-        lowering_environment: LoweringEnvironment::default(),
         enable_coverage: build_flags.enable_coverage,
         debug_export_build_plan: cli.unstable_feature.rr_export_build_plan,
         // In legacy impl, dry run always forces no JSON.

--- a/crates/moonbuild-rupes-recta/Cargo.toml
+++ b/crates/moonbuild-rupes-recta/Cargo.toml
@@ -47,3 +47,6 @@ dunce.workspace = true
 
 serde = { workspace = true, features = ["rc"] }
 sha2.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
@@ -41,21 +41,9 @@ impl NativeBackendMode {
 
 #[cfg(test)]
 mod tests {
-    use moonutil::compiler_flags::NativeAllocator;
-
-    use crate::model::{BackendConfig, DirectNativeMode};
+    use crate::model::DirectNativeMode;
 
     use super::*;
-
-    #[test]
-    fn wasm_backend_carries_wat_setting() {
-        let backend = BackendConfig::Wasm {
-            use_wat: true,
-            wasi_link: false,
-        };
-
-        assert!(matches!(backend, BackendConfig::Wasm { use_wat: true, .. }));
-    }
 
     #[test]
     fn c_direct_object_realizes_linker_executable() {
@@ -66,14 +54,5 @@ mod tests {
             native_mode.executable_realization(),
             CExecutableRealization::LinkDirectObject
         );
-    }
-
-    #[test]
-    fn llvm_backend_is_not_c_realization() {
-        let backend = BackendConfig::Llvm {
-            allocator: NativeAllocator::Default,
-        };
-
-        assert!(matches!(backend, BackendConfig::Llvm { .. }));
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -36,7 +36,7 @@ use crate::{
     },
     discover::{DiscoverResult, DiscoveredPackage},
     execution_plan::{ActionId, ExecutionAction, ExecutionPlanBuilder, InputObservation},
-    model::{BackendConfig, BuildPlanNode, BuildTarget, OperatingSystem},
+    model::{BackendConfig, BuildPlanNode, BuildTarget},
     pkg_solve::DepRelationship,
     target_layout::{
         ArtifactPathOptions, ArtifactPathResolver, ExecutableArtifact, LinkedCoreArtifact,
@@ -201,14 +201,7 @@ impl<'a> LoweringContext<'a> {
     // Artifact forms combine compile-wide options with the Native mode already
     // selected in the Backend Plan.
     pub(super) fn artifact_path_options(&self) -> ArtifactPathOptions {
-        let os = match &self.opt.backend {
-            BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
-                OperatingSystem::None
-            }
-            BackendConfig::Native { .. } | BackendConfig::Llvm { .. } => {
-                self.opt.lowering_environment.os()
-            }
-        };
+        let os = self.opt.backend.os();
         let (executable, linked_core) = match &self.opt.backend {
             BackendConfig::Wasm { use_wat, .. } => (
                 ExecutableArtifact::Wasm { use_wat: *use_wat },
@@ -241,8 +234,19 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn toolchain_include_files(&mut self) -> Result<&[PathBuf], LoweringError> {
+        // TODO: Replace this walk with header paths observed by the toolchain
+        // module outside RR. Command orchestration should request that observation
+        // only when planned actions compile native sources; lowering then only
+        // attaches the supplied paths as inputs.
         if self.toolchain_include_files.is_none() {
-            let root = PathBuf::from(&self.opt.lowering_environment.compiler_paths().include_path);
+            let root = PathBuf::from(
+                &self
+                    .opt
+                    .backend
+                    .compiler_paths()
+                    .expect("native lowering requires compiler paths")
+                    .include_path,
+            );
             let mut files = Vec::new();
             for entry in WalkDir::new(&root).follow_links(true).sort_by_file_name() {
                 let entry = entry.map_err(|source| LoweringError::ToolchainInclude {
@@ -499,12 +503,15 @@ impl<'a> LoweringContext<'a> {
         // These are the only Moon-owned libraries that command construction
         // may append as standalone argv. Compare their exact rendered paths;
         // arbitrary command arguments remain opaque to lowering.
-        for name in ["libmoonbitrun.o", "libbacktrace.a"] {
-            let path =
-                Path::new(&self.opt.lowering_environment.compiler_paths().lib_path).join(name);
-            let rendered = path.display().to_string();
-            if command.args().iter().any(|argument| argument == &rendered) {
-                inputs.push(InputObservation::File(path));
+        // TODO: Remove this argv scan once native command construction returns
+        // the selected toolchain library paths together with its arguments.
+        if let Some(compiler_paths) = self.opt.backend.compiler_paths() {
+            for name in ["libmoonbitrun.o", "libbacktrace.a"] {
+                let path = Path::new(&compiler_paths.lib_path).join(name);
+                let rendered = path.display().to_string();
+                if command.args().iter().any(|argument| argument == &rendered) {
+                    inputs.push(InputObservation::File(path));
+                }
             }
         }
         inputs.extend(

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -185,6 +185,11 @@ impl<'a> super::LoweringContext<'a> {
         index: u32,
         info: &BuildRuntimeInfo,
     ) -> BuildCommand {
+        let compiler_paths = self
+            .opt
+            .backend
+            .compiler_paths()
+            .expect("native lowering requires compiler paths");
         let artifact_path = artifacts.single_output_path_matching(|artifact| {
             matches!(artifact, ArtifactKey::RuntimeObject { .. })
         });
@@ -198,7 +203,7 @@ impl<'a> super::LoweringContext<'a> {
                     runtime_toolchain,
                     source,
                     &artifact_path,
-                    &self.opt.lowering_environment.compiler_paths().include_path,
+                    &compiler_paths.include_path,
                     crt,
                     info.native_allocator,
                 )
@@ -218,7 +223,7 @@ impl<'a> super::LoweringContext<'a> {
                             (self.opt.debug_symbols
                                 || (self.opt.action == RunMode::Run
                                     && self.opt.opt_level == OptLevel::Debug))
-                                && self.opt.lowering_environment.os() != OperatingSystem::Windows,
+                                && self.opt.backend.os() != OperatingSystem::Windows,
                         )
                         .link_moonbitrun(true)
                         .define_use_shared_runtime_macro(false)
@@ -235,7 +240,7 @@ impl<'a> super::LoweringContext<'a> {
                         .display()
                         .to_string(),
                     Some(&artifact_path.display().to_string()),
-                    self.opt.lowering_environment.compiler_paths(),
+                    compiler_paths,
                 )
                 .into(),
                 Vec::new(),
@@ -276,7 +281,10 @@ impl<'a> super::LoweringContext<'a> {
             config,
             &member_args,
             &artifact_path.display().to_string(),
-            self.opt.lowering_environment.compiler_paths(),
+            self.opt
+                .backend
+                .compiler_paths()
+                .expect("native lowering requires compiler paths"),
         );
 
         BuildCommand {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -917,7 +917,10 @@ impl<'a> LoweringContext<'a> {
             [input_file.display().to_string()],
             &intermediate_dir,
             Some(&output_file.display().to_string()),
-            self.opt.lowering_environment.compiler_paths(),
+            self.opt
+                .backend
+                .compiler_paths()
+                .expect("native lowering requires compiler paths"),
         );
 
         let mut extra_inputs = Vec::with_capacity(1 + package.c_stub_header_files.len());
@@ -975,7 +978,10 @@ impl<'a> LoweringContext<'a> {
                 .map(|object| object.to_string_lossy())
                 .collect::<Vec<_>>(),
             &archive.display().to_string(),
-            self.opt.lowering_environment.compiler_paths(),
+            self.opt
+                .backend
+                .compiler_paths()
+                .expect("native lowering requires compiler paths"),
         );
 
         BuildCommand {
@@ -1141,7 +1147,10 @@ impl<'a> LoweringContext<'a> {
             sources.iter().map(|x| x.display().to_string()),
             &pkg_dir,
             Some(&dest),
-            self.opt.lowering_environment.compiler_paths(),
+            self.opt
+                .backend
+                .compiler_paths()
+                .expect("native lowering requires compiler paths"),
         );
 
         BuildCommand {
@@ -1157,6 +1166,11 @@ impl<'a> LoweringContext<'a> {
         target: BuildTarget,
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
+        let compiler_paths = self
+            .opt
+            .backend
+            .compiler_paths()
+            .expect("native lowering requires compiler paths");
         let sources = self.native_executable_dependency_paths(artifacts, info);
         let cc = info.effective_native_toolchain.cc().clone();
 
@@ -1190,7 +1204,7 @@ impl<'a> LoweringContext<'a> {
                 &source_args,
                 &info.link_flags,
                 &dest,
-                &self.opt.lowering_environment.compiler_paths().lib_path,
+                &compiler_paths.lib_path,
             )
             .into()
         } else {
@@ -1201,7 +1215,7 @@ impl<'a> LoweringContext<'a> {
                 &source_args,
                 &pkg_dir,
                 &dest,
-                &self.opt.lowering_environment.compiler_paths().lib_path,
+                &compiler_paths.lib_path,
             );
             linker_cmd.into()
         };

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -18,17 +18,15 @@
 
 //! Lowers the normalized action plan into an executor-neutral Execution Plan.
 
-use std::{path::PathBuf, str::FromStr, sync::OnceLock};
+use std::path::PathBuf;
 
 use log::{debug, info};
-use moonutil::compiler_flags::CompilerPaths;
 use tracing::instrument;
 
 use crate::{
     CompileConfig, ResolveOutput,
     build_plan::BuildPlan,
     execution_plan::{ExecutionPlan, ExecutionPlanBuilder},
-    model::OperatingSystem,
 };
 
 mod backend;
@@ -49,32 +47,6 @@ pub(crate) use backend::CExecutableRealization;
 
 use command::BuildCommand;
 use context::LoweringContext;
-
-/// Lazily resolved host/toolchain facts used during lowering.
-///
-/// The build pipeline passes this object explicitly so lower phases do not
-/// rediscover environment facts in place. Individual facts remain lazy because
-/// non-native backends do not need native OS/toolchain details.
-// TODO: Remove these lazy environment reads once command orchestration supplies
-// the selected OS and compiler paths explicitly.
-#[derive(Default)]
-pub struct LoweringEnvironment {
-    os: OnceLock<OperatingSystem>,
-    compiler_paths: OnceLock<CompilerPaths>,
-}
-
-impl LoweringEnvironment {
-    pub fn os(&self) -> OperatingSystem {
-        *self
-            .os
-            .get_or_init(|| OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"))
-    }
-
-    pub fn compiler_paths(&self) -> &CompilerPaths {
-        self.compiler_paths
-            .get_or_init(CompilerPaths::from_moon_dirs)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WarningCondition {
@@ -140,7 +112,9 @@ mod tests {
     use indexmap::IndexSet;
     use moonutil::{
         build_options::RunMode,
-        compiler_flags::{ARKind, CC, CCKind, MsvcEnvironment, NativeAllocator, Toolchain},
+        compiler_flags::{
+            ARKind, CC, CCKind, CompilerPaths, MsvcEnvironment, NativeAllocator, Toolchain,
+        },
         cond_expr::OptLevel,
         manifest::MoonMod,
         package::{MoonPkg, MoonPkgFormatter, SupportedTargetsDeclKind},
@@ -148,7 +122,6 @@ mod tests {
         target::TargetBackend,
         toolchain::BINARIES,
     };
-    use walkdir::WalkDir;
 
     use crate::{
         build_plan::{
@@ -158,7 +131,7 @@ mod tests {
         discover::{DiscoverResult, DiscoveredPackage},
         model::{
             BackendConfig, BuildPlanNode, BuildTarget, DirectNativeMode, NativeBackendMode,
-            NativeTarget, TargetKind,
+            NativeTarget, OperatingSystem, TargetKind,
         },
         pkg_name::{PackageFQN, PackagePath},
         pkg_solve::DepRelationship,
@@ -169,7 +142,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn non_native_artifact_options_do_not_resolve_operating_system() {
+    fn non_native_artifact_options_need_no_host_configuration() {
         let (resolve_output, _) = single_package_resolve_output();
         let plan = BuildPlan::default();
         for backend in [
@@ -204,13 +177,10 @@ mod tests {
                 warning_condition: WarningCondition::Default,
                 info_no_alias: false,
                 stdlib_path: None,
-                lowering_environment: LoweringEnvironment::default(),
             };
 
             let context = LoweringContext::new(&resolve_output, &plan, &options);
-            assert!(options.lowering_environment.os.get().is_none());
             assert_eq!(context.artifact_path_options().os, OperatingSystem::None);
-            assert!(options.lowering_environment.os.get().is_none());
         }
     }
 
@@ -470,7 +440,6 @@ mod tests {
             warning_condition: WarningCondition::Default,
             info_no_alias: false,
             stdlib_path: None,
-            lowering_environment: LoweringEnvironment::default(),
         };
 
         let lowered = adapt_execution_plan(
@@ -552,7 +521,6 @@ mod tests {
             warning_condition: WarningCondition::Default,
             info_no_alias: false,
             stdlib_path: None,
-            lowering_environment: LoweringEnvironment::default(),
         };
 
         let mut context = LoweringContext::new(&resolve_output, &plan, &options);
@@ -577,7 +545,18 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::disallowed_methods)] // File writes only set up the supplied test toolchain.
     fn lowered_windows_msvc_native_graph_contains_complete_commands_and_tool_inputs() {
+        let toolchain_dir = tempfile::tempdir().expect("create test toolchain");
+        let include_dir = toolchain_dir.path().join("include");
+        std::fs::create_dir_all(include_dir.join("internal")).expect("create header directory");
+        let toolchain_headers = [
+            include_dir.join("moonbit.h"),
+            include_dir.join("internal/runtime.h"),
+        ];
+        for header in &toolchain_headers {
+            std::fs::write(header, "/* test header */").expect("write test header");
+        }
         let (resolve_output, target) = single_package_resolve_output();
         let runtime_node = BuildPlanNode::BuildRuntimeLib;
         let runtime_object_node = BuildPlanNode::BuildRuntimeObject(0);
@@ -683,11 +662,6 @@ mod tests {
             },
         );
 
-        let lowering_environment = LoweringEnvironment::default();
-        lowering_environment
-            .os
-            .set(OperatingSystem::Windows)
-            .expect("test OS should be set once");
         let artifact_paths = ArtifactPathResolver::new(
             TargetLayout::new(
                 PathBuf::from("_build"),
@@ -710,6 +684,11 @@ mod tests {
             backend: BackendConfig::Native {
                 direct_object_candidate: Some(NativeTarget::X86_64PcWindowsMsvc),
                 allocator: NativeAllocator::Default,
+                os: OperatingSystem::Windows,
+                compiler_paths: CompilerPaths {
+                    include_path: include_dir.display().to_string(),
+                    lib_path: toolchain_dir.path().join("lib").display().to_string(),
+                },
             },
             opt_level: OptLevel::Debug,
             action: RunMode::Build,
@@ -720,7 +699,6 @@ mod tests {
             warning_condition: WarningCondition::Default,
             info_no_alias: false,
             stdlib_path: None,
-            lowering_environment,
         };
 
         let execution =
@@ -865,18 +843,6 @@ mod tests {
                 .any(|input| input == Path::new("main/native/stub.h")),
             "package-local C headers should be inputs of every C-stub action"
         );
-        let toolchain_headers =
-            WalkDir::new(&options.lowering_environment.compiler_paths().include_path)
-                .follow_links(true)
-                .into_iter()
-                .map(|entry| entry.expect("inspect test toolchain include directory"))
-                .filter(|entry| entry.file_type().is_file())
-                .map(|entry| entry.into_path())
-                .collect::<Vec<_>>();
-        assert!(
-            !toolchain_headers.is_empty(),
-            "test toolchain should contain headers"
-        );
         for header in toolchain_headers {
             assert!(
                 compiler_inputs.contains(&header),
@@ -911,7 +877,15 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::disallowed_methods)] // File writes only set up the supplied test toolchain.
     fn macos_debug_link_and_dsymutil_are_separate_structured_actions() {
+        let toolchain_dir = tempfile::tempdir().expect("create test toolchain");
+        let libbacktrace = toolchain_dir.path().join("libbacktrace.a");
+        std::fs::write(&libbacktrace, "").expect("write test runtime library");
+        let compiler_paths = CompilerPaths {
+            include_path: "/toolchain/include".into(),
+            lib_path: toolchain_dir.path().display().to_string(),
+        };
         let (resolve_output, target) = single_package_resolve_output();
         let executable_node = BuildPlanNode::MakeExecutable(target);
         let dsym_node = BuildPlanNode::GenerateDsym(target);
@@ -955,10 +929,14 @@ mod tests {
         for backend in [
             BackendConfig::Llvm {
                 allocator: NativeAllocator::Default,
+                os: OperatingSystem::MacOS,
+                compiler_paths: compiler_paths.clone(),
             },
             BackendConfig::Native {
                 direct_object_candidate: Some(NativeTarget::Aarch64AppleDarwin),
                 allocator: NativeAllocator::Default,
+                os: OperatingSystem::MacOS,
+                compiler_paths: compiler_paths.clone(),
             },
         ] {
             plan.test_backend_plan_mut().test_set_native_mode(
@@ -968,11 +946,6 @@ mod tests {
                     )),
                 ),
             );
-            let lowering_environment = LoweringEnvironment::default();
-            lowering_environment
-                .os
-                .set(OperatingSystem::MacOS)
-                .expect("test OS should be set once");
             let artifact_paths = ArtifactPathResolver::new(
                 TargetLayout::new(
                     PathBuf::from("_build"),
@@ -997,7 +970,6 @@ mod tests {
                 warning_condition: WarningCondition::Default,
                 info_no_alias: false,
                 stdlib_path: None,
-                lowering_environment,
             };
 
             let lowered = adapt_execution_plan(
@@ -1025,6 +997,14 @@ mod tests {
                 Some("/toolchain/bin/clang")
             );
             assert!(!link_args.iter().any(|arg| arg == "&&"));
+            assert!(link_args.contains(&libbacktrace.display().to_string()));
+            let link_inputs = n2_input_paths_for_command(&lowered, |command| {
+                command.first().map(String::as_str) == Some("/toolchain/bin/clang")
+            });
+            assert!(
+                link_inputs.contains(&libbacktrace),
+                "the library from the supplied compiler paths must be a linker input"
+            );
             assert_eq!(
                 lowered.command_args_by_output.get(&dsym_bundle),
                 Some(&vec![

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -114,7 +114,7 @@ impl<'a> BuildPlanConstructor<'a> {
     fn effective_native_toolchain(&mut self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
         // TODO: Consume explicit toolchain candidates and environment overrides
         // once native toolchain discovery moves to command orchestration.
-        debug_assert!(self.build_env.target_backend().is_native());
+        debug_assert!(self.config.backend.target_backend().is_native());
         if self.res.backend.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
             self.warn_incompatible_windows_msvc_env_override();
             return compiler_flags::windows_msvc_native_toolchain(package_cc);
@@ -124,7 +124,7 @@ impl<'a> BuildPlanConstructor<'a> {
     }
 
     pub(super) fn warn_moon_cc_overrides(&self) {
-        if !self.build_env.target_backend().is_native() {
+        if !self.config.backend.target_backend().is_native() {
             return;
         }
 
@@ -298,7 +298,7 @@ impl<'a> BuildPlanConstructor<'a> {
         importer_target: BuildTarget,
         dep: BuildTarget,
     ) -> Result<(), BuildPlanConstructError> {
-        let selected_backend = self.build_env.target_backend();
+        let selected_backend = self.config.backend.target_backend();
         let importer_pkg = self.input.pkg_dirs.get_package(importer_target.package);
         let dependency_pkg = self.input.pkg_dirs.get_package(dep.package);
 
@@ -354,7 +354,7 @@ impl<'a> BuildPlanConstructor<'a> {
         node: BuildPlanNode,
         dep: BuildTarget,
     ) -> Result<(), BuildPlanConstructError> {
-        if self.build_env.std && self.input.pkg_dirs.is_stdlib_package(dep.package) {
+        if self.config.stdlib_path.is_some() && self.input.pkg_dirs.is_stdlib_package(dep.package) {
             return Ok(());
         }
 
@@ -371,7 +371,7 @@ impl<'a> BuildPlanConstructor<'a> {
     }
 
     fn require_check_mi_of_dep(&mut self, node: BuildPlanNode, dep: BuildTarget) {
-        if self.build_env.std && self.input.pkg_dirs.is_stdlib_package(dep.package) {
+        if self.config.stdlib_path.is_some() && self.input.pkg_dirs.is_stdlib_package(dep.package) {
             return;
         }
 
@@ -390,7 +390,7 @@ impl<'a> BuildPlanConstructor<'a> {
     }
 
     fn require_build_mi_of_dep(&mut self, node: BuildPlanNode, dep: BuildTarget) {
-        if self.build_env.std && self.input.pkg_dirs.is_stdlib_package(dep.package) {
+        if self.config.stdlib_path.is_some() && self.input.pkg_dirs.is_stdlib_package(dep.package) {
             return;
         }
 
@@ -409,7 +409,7 @@ impl<'a> BuildPlanConstructor<'a> {
     }
 
     fn require_build_outputs_of_dep(&mut self, node: BuildPlanNode, dep: BuildTarget) {
-        if self.build_env.std && self.input.pkg_dirs.is_stdlib_package(dep.package) {
+        if self.config.stdlib_path.is_some() && self.input.pkg_dirs.is_stdlib_package(dep.package) {
             return;
         }
 
@@ -448,7 +448,7 @@ impl<'a> BuildPlanConstructor<'a> {
     fn need_proof_of_dep(&mut self, node: BuildPlanNode, dep: BuildTarget) {
         // As with normal `.mi` dependencies, stdlib packages are resolved via
         // the injected stdlib path rather than by planning local nodes.
-        if self.build_env.std && self.input.pkg_dirs.is_stdlib_package(dep.package) {
+        if self.config.stdlib_path.is_some() && self.input.pkg_dirs.is_stdlib_package(dep.package) {
             return;
         }
 
@@ -477,7 +477,7 @@ impl<'a> BuildPlanConstructor<'a> {
         // If the given target is a virtual package with default implementation,
         // we need to build its interface first. Injected stdlib contracts are
         // already supplied by `-std-path` and remain external to this plan.
-        if pkg.is_virtual() && !(self.build_env.std && pkg.is_stdlib) {
+        if pkg.is_virtual() && !(self.config.stdlib_path.is_some() && pkg.is_stdlib) {
             self.require_artifact(
                 node,
                 ArtifactKey::VirtualContractMi {
@@ -490,7 +490,8 @@ impl<'a> BuildPlanConstructor<'a> {
         // the virtual package's interface first, unless that contract comes
         // from the injected stdlib.
         if let Some(vpkg_id) = self.input.pkg_rel.virt_impl.get(target.package)
-            && !(self.build_env.std && self.input.pkg_dirs.is_stdlib_package(*vpkg_id))
+            && !(self.config.stdlib_path.is_some()
+                && self.input.pkg_dirs.is_stdlib_package(*vpkg_id))
         {
             self.require_artifact(node, ArtifactKey::VirtualContractMi { package: *vpkg_id });
         }
@@ -705,8 +706,8 @@ impl<'a> BuildPlanConstructor<'a> {
         for (file, file_kind) in cond_comp::classify_files(
             &pkg.raw,
             source_iter,
-            self.build_env.opt_level,
-            self.build_env.target_backend(),
+            self.config.opt_level,
+            self.config.backend.target_backend(),
         ) {
             match file_kind {
                 NoTest => no_test_files.insert(file.into_owned()),
@@ -749,7 +750,7 @@ impl<'a> BuildPlanConstructor<'a> {
             // Discovery keeps `.mbtp` files for metadata, but only verification
             // commands project them into compiler inputs.
             let uses_mbtp = matches!(
-                self.build_env.action,
+                self.config.action,
                 moonutil::build_options::RunMode::Check | moonutil::build_options::RunMode::Prove
             );
             let file_set = self.package_file_set(target.package);
@@ -787,14 +788,14 @@ impl<'a> BuildPlanConstructor<'a> {
         // and command-line settings.
         let proof_warn_list = (pkg.raw.proof_enabled
             && !matches!(
-                self.build_env.action,
+                self.config.action,
                 moonutil::build_options::RunMode::Check | moonutil::build_options::RunMode::Prove
             ))
         .then_some(PROOF_ENABLED_WARN_SUPPRESSIONS);
         let package_warn_list = cat_opt(pkg.raw.warn_list.clone(), proof_warn_list);
         let warn_list = cat_opt(
             cat_opt(module.warn_list.clone(), package_warn_list.as_deref()),
-            self.build_env.warn_list.as_deref(),
+            self.config.warn_list.as_deref(),
         );
 
         let specified_no_mi = self.input_directive.specify_no_mi_for == Some(target.package);
@@ -1047,7 +1048,6 @@ impl<'a> BuildPlanConstructor<'a> {
         let link_core_info = LinkCoreInfo {
             linked_order: targets,
             abort_overridden,
-            // std: self.build_env.std, // Can move std/nostd to per-package info
         };
         self.res
             .backend
@@ -1065,7 +1065,7 @@ impl<'a> BuildPlanConstructor<'a> {
         node: BuildPlanNode,
         target: BuildTarget,
     ) -> Result<(), BuildPlanConstructError> {
-        debug_assert!(self.build_env.target_backend().is_native());
+        debug_assert!(self.config.backend.target_backend().is_native());
 
         let (link_core_deps, c_stub_deps, _) = self.dfs_link_core_sources(target)?;
         let targets = link_core_deps.into_iter().collect::<Vec<_>>();
@@ -1136,16 +1136,16 @@ impl<'a> BuildPlanConstructor<'a> {
             &mut link_flags,
         );
 
-        let generate_dsym = match &self.build_env.backend {
-            BackendConfig::Llvm { .. } => {
-                should_generate_llvm_dsym(self.build_env.debug_symbols, self.build_env.os)
+        let generate_dsym = match &self.config.backend {
+            BackendConfig::Llvm { os, .. } => {
+                should_generate_llvm_dsym(self.config.debug_symbols, *os)
             }
             BackendConfig::Native { .. } => match self.res.backend.native_mode() {
                 NativeBackendMode::DirectObject(mode) => should_generate_direct_native_dsym(
                     mode,
-                    self.build_env.debug_symbols
-                        || (self.build_env.action == RunMode::Run
-                            && self.build_env.opt_level == OptLevel::Debug),
+                    self.config.debug_symbols
+                        || (self.config.action == RunMode::Run
+                            && self.config.opt_level == OptLevel::Debug),
                     &effective_native_toolchain,
                 ),
                 NativeBackendMode::GeneratedC => false,
@@ -1163,7 +1163,7 @@ impl<'a> BuildPlanConstructor<'a> {
         }
 
         let native_allocator = self
-            .build_env
+            .config
             .backend
             .native_allocator()
             .expect("native executable planning requires an allocator");
@@ -1206,7 +1206,7 @@ impl<'a> BuildPlanConstructor<'a> {
         // This DFS is shared by both LinkCore and MakeExecutable actions.
         let vp_info = self.input.pkg_rel.virtual_users.get(target.package);
 
-        let abort = if self.build_env.std {
+        let abort = if self.config.stdlib_path.is_some() {
             self.input.pkg_dirs.abort_pkg()
         } else {
             None
@@ -1278,7 +1278,8 @@ impl<'a> BuildPlanConstructor<'a> {
                     .filter(|dep| {
                         // Skip stdlib packages because they are always linked implicitly
                         // only when stdlib is injected. When building stdlib itself, keep them.
-                        !self.build_env.std || !self.input.pkg_dirs.is_stdlib_package(dep.package)
+                        self.config.stdlib_path.is_none()
+                            || !self.input.pkg_dirs.is_stdlib_package(dep.package)
                     })
                     .collect();
 
@@ -1323,7 +1324,7 @@ impl<'a> BuildPlanConstructor<'a> {
                         // Record emitted and collect c-stub if necessary
                         emitted.insert(cur);
                         let pkg = self.input.pkg_dirs.get_package(cur.package);
-                        if self.build_env.target_backend().is_native()
+                        if self.config.backend.target_backend().is_native()
                             && !pkg.c_stub_files.is_empty()
                         {
                             c_stub_deps.insert(cur.package);
@@ -1349,7 +1350,8 @@ impl<'a> BuildPlanConstructor<'a> {
                 emitted.insert(cur);
                 trace!(?cur, "Post-order: emitted");
 
-                if self.build_env.target_backend().is_native() && !pkg.c_stub_files.is_empty() {
+                if self.config.backend.target_backend().is_native() && !pkg.c_stub_files.is_empty()
+                {
                     c_stub_deps.insert(cur.package);
                 }
             }
@@ -1409,7 +1411,7 @@ impl<'a> BuildPlanConstructor<'a> {
         // Bundling a module gathers the build result of all its non-virtual packages, in topo order
         let topo_sorted_pkgs = self.topo_sort_module_packages(module_id);
         let mut bundle_targets = Vec::new();
-        let target_backend = self.build_env.target_backend();
+        let target_backend = self.config.backend.target_backend();
         for target in topo_sorted_pkgs.into_iter() {
             let pkg = self.input.pkg_dirs.get_package(target.package);
             if !pkg.effective_supported_targets.contains(&target_backend) {
@@ -1556,15 +1558,17 @@ impl<'a> BuildPlanConstructor<'a> {
         let effective_native_toolchain = self.effective_native_toolchain(None).map_err(|e| {
             BuildPlanConstructError::FailedToSetRuntimeCC(self.new_native_linker_context(e))
         })?;
+        // TODO: Consume supplied runtime sources and optional SIMDUTF objects
+        // once command orchestration captures the runtime file inventory.
         let source_files = toolchain::runtime_source_paths()
             .map_err(BuildPlanConstructError::FailedToFindRuntimeSources)?;
-        let simdutf_objects = if self.build_env.opt_level == OptLevel::Release
+        let simdutf_objects = if self.config.opt_level == OptLevel::Release
             && effective_native_toolchain.cc().can_use_simdutf()
         {
-            self.build_env
-                .compiler_paths
-                .as_ref()
-                .expect("native build environment should include compiler paths")
+            self.config
+                .backend
+                .compiler_paths()
+                .expect("native runtime planning requires compiler paths")
                 .simdutf_object_paths()
                 .map(|objects| objects.into_iter().collect())
                 .unwrap_or_default()
@@ -1576,7 +1580,7 @@ impl<'a> BuildPlanConstructor<'a> {
             .archiver_updates_existing_archive()
             .then(|| runtime_archive_fingerprint(&source_files, &simdutf_objects));
         let native_allocator = self
-            .build_env
+            .config
             .backend
             .native_allocator()
             .expect("native runtime planning requires an allocator");
@@ -1687,7 +1691,7 @@ impl<'a> BuildPlanConstructor<'a> {
             petgraph::Direction::Outgoing,
         ) {
             self.check_backend_compatibility_for_mi_dep(node, dep)?;
-            match self.build_env.action {
+            match self.config.action {
                 RunMode::Check | RunMode::Prove => self.require_check_mi_of_dep(node, dep),
                 RunMode::Build
                 | RunMode::Run
@@ -1714,7 +1718,7 @@ impl<'a> BuildPlanConstructor<'a> {
         // Documentation starts from backend-compatible packages in the
         // selected module. Their Check MI requirements expand the same
         // dependency closure used by ordinary package checks.
-        let target_backend = self.build_env.target_backend();
+        let target_backend = self.config.backend.target_backend();
         let packages = self
             .input
             .pkg_dirs

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use crate::{
-    ResolveOutput,
+    CompileConfig, ResolveOutput,
     build_plan::InputDirective,
     model::{BuildPlanNode, BuildTarget, PackageId},
     prebuild::PrebuildOutput,
@@ -33,7 +33,7 @@ use moonutil::user_log::UserLog;
 use tracing::{Level, instrument};
 
 use super::{
-    BuildEnvironment, BuildPlan, BuildPlanConstructError,
+    BuildPlan, BuildPlanConstructError,
     artifact::{ArtifactKey, package_file_key, runtime_source_key},
 };
 
@@ -43,7 +43,7 @@ pub(super) struct BuildPlanConstructor<'a> {
     // Input environment
     pub(super) input: &'a ResolveOutput,
     pub(super) mooncake_bin_dir: &'a Path,
-    pub(super) build_env: &'a BuildEnvironment,
+    pub(super) config: &'a CompileConfig,
     pub(super) input_directive: &'a InputDirective,
     pub(super) prebuild_config: Option<&'a PrebuildOutput>,
     pub(super) user_log: &'a UserLog,
@@ -77,7 +77,7 @@ impl<'a> BuildPlanConstructor<'a> {
     pub(super) fn new(
         resolved: &'a ResolveOutput,
         mooncake_bin_dir: &'a Path,
-        build_env: &'a BuildEnvironment,
+        config: &'a CompileConfig,
         input_directive: &'a InputDirective,
         prebuild_config: Option<&'a PrebuildOutput>,
         user_log: &'a UserLog,
@@ -85,7 +85,7 @@ impl<'a> BuildPlanConstructor<'a> {
         Self {
             input: resolved,
             mooncake_bin_dir,
-            build_env,
+            config,
             input_directive,
             prebuild_config,
             user_log,
@@ -312,7 +312,7 @@ impl<'a> BuildPlanConstructor<'a> {
                     .provide(node, ArtifactKey::CStubLibrary { package });
             }
             BuildPlanNode::LinkCore(target) => {
-                let artifact = if self.build_env.target_backend().is_native() {
+                let artifact = if self.config.backend.target_backend().is_native() {
                     ArtifactKey::LinkedCore {
                         package: target.package,
                         target_kind: target.kind,
@@ -465,7 +465,7 @@ impl<'a> BuildPlanConstructor<'a> {
                 target_kind,
             } => {
                 let target = package.build_target(*target_kind);
-                if self.build_env.target_backend().is_native() {
+                if self.config.backend.target_backend().is_native() {
                     BuildPlanNode::MakeExecutable(target)
                 } else {
                     BuildPlanNode::LinkCore(target)

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -55,8 +55,7 @@ use std::{
 use indexmap::IndexSet;
 use log::{debug, info};
 use moonutil::{
-    build_options::RunMode,
-    compiler_flags::{CompilerPaths, NativeAllocator, Toolchain},
+    compiler_flags::{NativeAllocator, Toolchain},
     cond_expr::OptLevel,
     resolution::ModuleId,
     target::TargetBackend,
@@ -66,10 +65,9 @@ use sha2::{Digest, Sha256};
 use tracing::instrument;
 
 use crate::{
-    ResolveOutput,
+    CompileConfig, ResolveOutput,
     model::{
-        BackendConfig, BuildPlanNode, BuildTarget, NativeBackendMode, NativeTarget,
-        OperatingSystem, PackageId,
+        BackendConfig, BuildPlanNode, BuildTarget, NativeBackendMode, NativeTarget, PackageId,
     },
     pkg_name::PackageFQNWithSource,
     prebuild::PrebuildOutput,
@@ -616,30 +614,6 @@ pub struct BuildBundleInfo {
     pub(crate) bundle_targets: Vec<BuildTarget>,
 }
 
-/// Represents the environment in which the build is being performed.
-pub struct BuildEnvironment {
-    // FIXME: Target backend should go into the solver, not here
-    pub backend: BackendConfig,
-    pub opt_level: OptLevel,
-    pub action: RunMode,
-    pub debug_symbols: bool,
-    pub os: OperatingSystem,
-    /// Toolchain include/lib paths selected for native-oriented backends.
-    pub compiler_paths: Option<CompilerPaths>,
-    /// Whether compiling requires the standard library.
-    ///
-    /// MAINTAINERS: Potentially useful to move this to per-package/module.
-    pub std: bool,
-    /// Commandline_level warnings to enable/disable
-    pub warn_list: Option<String>,
-}
-
-impl BuildEnvironment {
-    pub(crate) fn target_backend(&self) -> TargetBackend {
-        self.backend.target_backend()
-    }
-}
-
 /// How package-level prebuild participates in this plan.
 ///
 /// Package-level prebuild includes custom `pre-build` rules, `moonlex`, and
@@ -791,7 +765,7 @@ pub(super) fn resolve_native_backend_mode(
 pub fn build_plan(
     resolved: &ResolveOutput,
     mooncake_bin_dir: &Path,
-    build_env: &BuildEnvironment,
+    config: &CompileConfig,
     input: impl Iterator<Item = ArtifactKey>,
     input_directive: &InputDirective,
     prebuild_config: Option<&PrebuildOutput>,
@@ -799,15 +773,15 @@ pub fn build_plan(
 ) -> Result<BuildPlan, BuildPlanConstructError> {
     info!("Constructing build plan");
     debug!(
-        "Build environment: backend={:?}, opt_level={:?}",
-        build_env.target_backend(),
-        build_env.opt_level
+        "Compile configuration: backend={:?}, opt_level={:?}",
+        config.backend.target_backend(),
+        config.opt_level
     );
 
     let mut constructor = BuildPlanConstructor::new(
         resolved,
         mooncake_bin_dir,
-        build_env,
+        config,
         input_directive,
         prebuild_config,
         user_log,
@@ -816,12 +790,12 @@ pub fn build_plan(
     if let BackendConfig::Native {
         direct_object_candidate,
         ..
-    } = &build_env.backend
+    } = &config.backend
     {
         constructor.res.backend.native_mode = Some(resolve_native_backend_mode(
             resolved,
             &input,
-            build_env.opt_level,
+            config.opt_level,
             *direct_object_candidate,
         ));
     }

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -22,10 +22,10 @@ use std::path::{Path, PathBuf};
 use tracing::instrument;
 
 use crate::{
-    build_lower::{self, LoweringEnvironment, WarningCondition},
-    build_plan::{self, ArtifactKey, BuildEnvironment, InputDirective},
+    build_lower::{self, WarningCondition},
+    build_plan::{self, ArtifactKey, InputDirective},
     execution_plan::ExecutionPlan,
-    model::{BackendConfig, OperatingSystem},
+    model::BackendConfig,
     prebuild::PrebuildOutput,
     resolve::ResolveOutput,
     target_layout::ArtifactPathResolver,
@@ -49,8 +49,6 @@ pub struct CompileConfig {
     pub stdlib_path: Option<PathBuf>,
     /// Physical artifact path resolver selected for this compile run.
     pub artifact_paths: ArtifactPathResolver,
-    /// Host/toolchain facts resolved lazily during lowering.
-    pub lowering_environment: LoweringEnvironment,
     // MAINTAINERS: consider moving some of these to per-package/module options.
     /// Whether to export the build plan graph in the compile output.
     /// This should only be used in debugging scenarios.
@@ -101,11 +99,10 @@ pub fn compile(
         requested_artifacts.len()
     );
 
-    let build_env = build_environment(cx);
     let plan = build_plan::build_plan(
         resolve_output,
         mooncake_bin_dir,
-        &build_env,
+        cx,
         requested_artifacts.iter().cloned(),
         input_directive,
         prebuild_config,
@@ -116,27 +113,6 @@ pub fn compile(
     debug!("Build plan contains {} actions", plan.action_count());
 
     lower_plan(cx, resolve_output, plan)
-}
-
-// TODO: Remove `build_environment` once host/toolchain inputs are supplied
-// explicitly and planning borrows `CompileConfig` instead of copying it.
-fn build_environment(cx: &CompileConfig) -> BuildEnvironment {
-    let native_or_llvm = cx.backend.native_allocator().is_some();
-    let compiler_paths = native_or_llvm.then(|| cx.lowering_environment.compiler_paths().clone());
-    BuildEnvironment {
-        backend: cx.backend.clone(),
-        opt_level: cx.opt_level,
-        action: cx.action,
-        debug_symbols: cx.debug_symbols,
-        os: if native_or_llvm {
-            cx.lowering_environment.os()
-        } else {
-            OperatingSystem::None
-        },
-        compiler_paths,
-        std: cx.stdlib_path.is_some(),
-        warn_list: cx.warn_list.clone(),
-    }
 }
 
 fn lower_plan(
@@ -175,7 +151,7 @@ mod tests {
 
     use crate::{
         ResolveOutput,
-        build_lower::{LoweringEnvironment, WarningCondition},
+        build_lower::WarningCondition,
         build_plan::{ArtifactKey, InputDirective},
         discover::{DiscoverResult, DiscoveredPackage, SingleFileSourceKind},
         model::{BackendConfig, BuildPlanNode, TargetKind},
@@ -275,7 +251,7 @@ mod tests {
     #[test]
     fn native_payload_selection_uses_only_requested_executables() {
         use crate::{
-            build_plan::{BuildEnvironment, build_plan, resolve_native_backend_mode},
+            build_plan::{build_plan, resolve_native_backend_mode},
             model::{NativeTarget, OperatingSystem},
         };
 
@@ -330,23 +306,42 @@ mod tests {
             Some(NativeTarget::X86_64PcWindowsMsvc),
         ] {
             for opt_level in [OptLevel::Debug, OptLevel::Release] {
-                let build_env = BuildEnvironment {
+                let config = CompileConfig {
+                    target_dir: PathBuf::from("_build"),
                     backend: BackendConfig::Native {
                         direct_object_candidate: candidate,
                         allocator: moonutil::compiler_flags::NativeAllocator::Default,
+                        os: OperatingSystem::None,
+                        compiler_paths: moonutil::compiler_flags::CompilerPaths {
+                            include_path: "/unused/include".into(),
+                            lib_path: "/unused/lib".into(),
+                        },
                     },
                     opt_level,
                     action: RunMode::Build,
                     debug_symbols: false,
-                    os: OperatingSystem::None,
-                    compiler_paths: None,
-                    std: false,
+                    stdlib_path: None,
+                    artifact_paths: ArtifactPathResolver::new(
+                        TargetLayout::new(
+                            PathBuf::from("_build"),
+                            TargetLayoutMode::Workspace,
+                            opt_level,
+                            RunMode::Build,
+                        ),
+                        None,
+                    ),
+                    debug_export_build_plan: false,
+                    enable_coverage: false,
+                    moonc_output_json: false,
+                    docs_serve: false,
+                    warning_condition: WarningCondition::Default,
+                    info_no_alias: false,
                     warn_list: None,
                 };
                 let plan = build_plan(
                     &resolved,
                     Path::new(".mooncakes/bin"),
-                    &build_env,
+                    &config,
                     std::iter::empty(),
                     &InputDirective::default(),
                     None,
@@ -514,7 +509,6 @@ mod tests {
             debug_symbols: false,
             stdlib_path: None,
             artifact_paths,
-            lowering_environment: LoweringEnvironment::default(),
             debug_export_build_plan: true,
             enable_coverage: false,
             moonc_output_json: false,
@@ -630,7 +624,6 @@ mod tests {
             debug_symbols: false,
             stdlib_path: None,
             artifact_paths,
-            lowering_environment: LoweringEnvironment::default(),
             debug_export_build_plan: false,
             enable_coverage: false,
             moonc_output_json: false,

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -17,7 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use moonutil::{
-    compiler_flags::NativeAllocator,
+    compiler_flags::{CompilerPaths, NativeAllocator},
     resolution::{ModuleId, ResolvedEnv},
     target::TargetBackend,
 };
@@ -50,9 +50,14 @@ pub enum BackendConfig {
         /// Planning may still select generated C based on profile and packages.
         direct_object_candidate: Option<NativeTarget>,
         allocator: NativeAllocator,
+        /// Supplied by command orchestration; RR does not infer the host OS.
+        os: OperatingSystem,
+        compiler_paths: CompilerPaths,
     },
     Llvm {
         allocator: NativeAllocator,
+        os: OperatingSystem,
+        compiler_paths: CompilerPaths,
     },
 }
 
@@ -143,7 +148,23 @@ impl BackendConfig {
 
     pub fn native_allocator(&self) -> Option<NativeAllocator> {
         match self {
-            Self::Native { allocator, .. } | Self::Llvm { allocator } => Some(*allocator),
+            Self::Native { allocator, .. } | Self::Llvm { allocator, .. } => Some(*allocator),
+            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => None,
+        }
+    }
+
+    pub(crate) fn os(&self) -> OperatingSystem {
+        match self {
+            Self::Native { os, .. } | Self::Llvm { os, .. } => *os,
+            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => OperatingSystem::None,
+        }
+    }
+
+    pub(crate) fn compiler_paths(&self) -> Option<&CompilerPaths> {
+        match self {
+            Self::Native { compiler_paths, .. } | Self::Llvm { compiler_paths, .. } => {
+                Some(compiler_paths)
+            }
             Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => None,
         }
     }

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -804,7 +804,7 @@ pub fn resolve_cc(cc: &CC, user_cc: Option<&CC>) -> CC {
 }
 
 // Struct to hold path configuration for commands
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CompilerPaths {
     pub include_path: String,
     pub lib_path: String,

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -218,10 +218,11 @@ forward. In particular, `rr_build` chooses `stdlib_path` from `use_std &&
 consume an `ArtifactPathResolver` that composes the selected stdlib path with
 the target layout instead of rediscovering the installed stdlib. Such facts do
 not need to be eager: non-native builds do not resolve native-only OS/toolchain
-details. Native-oriented compilation resolves compiler paths before planning
-and passes them through the build environment, so planning can select optional
+details. `rr_build` captures OS and compiler paths only for Native and LLVM,
+and stores them in the selected backend variant of `CompileConfig`. Planning
+and lowering borrow that same configuration, so planning can select optional
 runtime members such as SIMDUTF objects and lowering can consume the same paths
-without rediscovery.
+without rediscovery or a copied planning configuration.
 
 Prebuild configuration is another environment-sensitive input. When prebuild
 configuration scripts run, `rr_build` captures the process environment

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -33,8 +33,14 @@ pub enum BackendConfig {
     Native {
         direct_object_candidate: Option<NativeTarget>,
         allocator: NativeAllocator,
+        os: OperatingSystem,
+        compiler_paths: CompilerPaths,
     },
-    Llvm { allocator: NativeAllocator },
+    Llvm {
+        allocator: NativeAllocator,
+        os: OperatingSystem,
+        compiler_paths: CompilerPaths,
+    },
 }
 ```
 
@@ -49,10 +55,11 @@ RR lowering borrows its backend subplan to read the selected mode and hydrate
 backend actions, without copying that state into another configuration.
 
 `BackendConfig` is the compile-wide source of truth held in `CompileConfig`.
-Lowering borrows that configuration and its artifact path resolver through
-`LoweringContext`; artifact-path selection rules stay in lowering. Planning
-still receives a `BuildEnvironment` populated from the configuration and
-resolved host/toolchain inputs.
+Planning and lowering borrow that same configuration. Lowering also borrows
+its artifact path resolver through `LoweringContext`; artifact-path selection
+rules stay in lowering. The command adapter supplies OS and compiler paths
+only for Native and LLVM, where the backend variants require them. These
+configuration values perform no lazy host or environment lookups inside RR.
 
 An `ArtifactKey` does not repeat the backend, optimization profile, or run mode
 because one `BuildPlan` is scoped to one such configuration. If one plan later

--- a/docs/dev/reference/rr-special-cases.md
+++ b/docs/dev/reference/rr-special-cases.md
@@ -75,8 +75,8 @@ important ones and why they exist.
 - **`abort_pkg` is discovery-only, not build-mode.** We always record the abort
   package ID if it exists, even when building the stdlib. Build-mode decisions
   (use prebuilt paths vs local artifacts) are gated by whether stdlib is
-  injected (`build_env.std` / `stdlib_dir.is_some()`), not by mutating
-  `abort_pkg`.
+  injected (`config.stdlib_path.is_some()` / `stdlib_dir.is_some()`), not by
+  mutating `abort_pkg`.
 - **Metadata files respect stdlib mode.** When either `packages.json` or
   `all_pkgs.json` is generated for the stdlib (core module), it is generated
   without a stdlib directory so package metadata and indirect dependency


### PR DESCRIPTION
- Related issues: None
- PR kind: Refactor

## Summary

Planning copied compile-wide settings into `BuildEnvironment`, while lowering borrowed `CompileConfig` and obtained OS/compiler paths through lazy lookups in `LoweringEnvironment`. This left parallel configurations to keep synchronized and hidden host/toolchain inputs inside RR.

Planning and lowering now borrow the same `CompileConfig`. The command adapter supplies OS and compiler paths only for Native/LLVM, whose existing backend variants carry those values. This removes `BuildEnvironment`, `build_environment()`, and `LoweringEnvironment` while preserving the existing planning and lowering decisions. Native lowering tests use supplied header and library fixtures to exercise those explicit inputs.

The change completes configuration sharing. Toolchain file observation and planned library dependencies remain separate follow-ups, with source TODOs identifying the remaining ownership issues and removal conditions.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
