### PR TITLE
feat(moonrun): support async SQLite jobs on Wasm

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -294,7 +294,7 @@ and reports Host Errors.
 _Avoid_: Host state, native-stub implementation
 
 **Async Host**:
-Moonrun-owned async state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Runtime's shared Host Key namespace, materializes its reserved standard-stream Resources from the Runtime Stdio, and contains no SQLite state.
+Moonrun-owned async state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Runtime's shared Host Key namespace and materializes its reserved standard-stream Resources from the Runtime Stdio. It owns the common Job lifecycle for Filesystem, Network, Process, Run Signal, and SQLite payloads; domain semantics remain with their Host Domains.
 It owns one Run Signal receiver, translates guest cancellation registration
 into that receiver's interest, and constructs the Unix virtual signal-wait Job
 against the Run's Completion target.
@@ -307,8 +307,12 @@ _Avoid_: SQLite Host, SQLite wrapper SDK
 **SQLite Host**:
 The backend-neutral SQLite implementation owned by one Runtime. It owns SQLite
 admission rules and operations, uses the Runtime's shared Host Key namespace,
-and contains the Database, Database Mutex, and Statement state, teardown, and
-leak accounting. Its Database Mutex depth counts recursive entries made through
+and contains Database, Database Mutex, and Statement state, teardown, and leak
+accounting. Its Job payloads pin their inputs and capture owned results while
+the Async Host owns their Handles, shared workers, completion, and release.
+The guest orders operations with a per-connection async Mutex. See
+[SQLite jobs](docs/dev/sqlite-jobs.md) for the shared-pool ABI and
+result acceptance and discard protocol. Its Database Mutex depth counts recursive entries made through
 the SQLite Host interface, not SQLite's internal mutex ownership. This protects
 the Database lifetime from unbalanced guest calls: the Host rejects unmatched
 leaves and Database close while entries remain, and releases those entries
@@ -334,7 +338,7 @@ _Avoid_: V8 adapter, placeholder unsupported imports
 **Thread Pool**:
 The shared host facility that schedules Jobs outside the guest coroutine loop.
 It owns the common Job result envelope, Workers, and Completion delivery. It
-does not interpret Filesystem, Network, Process, or Run Signal semantics.
+does not interpret Filesystem, Network, Process, Run Signal, or SQLite semantics.
 _Avoid_: Filesystem executor, Network executor, Process executor, SQLite executor
 
 **Host Poller**:

--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -2,6 +2,8 @@
 
 ## Developer workflows
 
+- [SQLite jobs](sqlite-jobs.md): SQLite payloads in the shared async pool,
+  result ownership, asynchronous discard, and upstream Wasm wrapper integration.
 - [Porting `moonbitlang/async` changes](async-upstream-porting.md): audit the
   one-way upstream runtime-port request queue, preserve exact provenance,
   deliver one upstream port at a time, and mark the originating async pull

--- a/crates/moonrun/docs/dev/sqlite-jobs.md
+++ b/crates/moonrun/docs/dev/sqlite-jobs.md
@@ -1,0 +1,130 @@
+# SQLite jobs
+
+The SQLite job payloads provide the Wasm counterpart of
+[sqlite3.mbt PR #23](https://github.com/moonbit-community/sqlite3.mbt/pull/23),
+reviewed at commit `70c02598aa924fa0bb7c6cedd75dc74d3af00657`. Native retains its dedicated C
+executor. The Wasm wrapper privately adapts
+SQLite jobs to the existing async thread pool; that pool supplies execution
+mechanism, while SQLite owns operation semantics and result lifetimes.
+
+## Ownership and execution
+
+The Async Host owns Job Handles, scheduling, Workers, Completions, and Job
+destruction. The SQLite Host owns SQLite inputs, captured results, and lifetime
+leases. There are no SQLite executor Handles, dedicated threads, or per-job
+notification pipes. The guest uses a FIFO async Mutex per connection to order
+its operations; independent connections and other async domains share the pool.
+
+Job creation copies filenames and UTF-16 SQL out of Guest Memory. A prepare,
+step, or finalizer Job pins its Database until destruction, including when a
+worker retains a detached Job. Step also pins its Statement. Closing a pinned
+Database or accessing a pinned Statement traps. Synchronous operations on other
+Statements remain available and may block on SQLite's connection mutex.
+Guest mutex entries must be balanced before creating Jobs.
+
+Statement lookup only validates liveness and rejects conflicting Job use; it
+does not acquire the connection mutex. That exclusion also keeps statement-owned
+column buffers stable during one synchronous host call. SQLite's own locking
+handles synchronous calls that need serialized connection access.
+
+Explicit host guards cover connection-field reads (`errcode`,
+`extended_errcode`, and `changes64`, whose SQLite implementations do not lock)
+and copying borrowed error-message memory. These guards prevent host data races
+and invalid memory access. They do not associate a later synchronous error read
+with an earlier call: intervening operations may replace that connection state.
+A guest needing a `step`/error-read sequence uses the exposed Database Mutex
+around the whole sequence. Untrusted call ordering need not preserve a guest's
+intended result, but it must not violate host memory safety or resource lifetime.
+
+Workers hold that mutex through the SQLite operation and capture of diagnostics
+and change counts. Getters read the Job's owned snapshot, so later operations
+cannot replace an earlier result. A successful open or prepare transfers its
+Database or Statement exactly once. After transfer an open Job no longer owns
+or refers to its Database; prepare keeps its Database lease until Job release.
+
+SQLite Jobs follow the common release lifecycle. Freeing a Job while a worker
+owns it detaches the Handle without cancelling execution. Unclaimed results
+and unrun finalizers are destroyed with their Job, before its lifetime lease is
+released. This fallback may close or finalize on the guest thread and block.
+The MoonBit wrapper uses explicit asynchronous discard to keep normal cleanup
+off the event loop. It checks cancellation and SQL-tail validity before taking
+the resource. Rejected results move directly into a discard Job, without
+publishing a Database or Statement Handle. The source result snapshot remains
+readable and the discard Job retains its lifetime lease.
+
+An ordinary finalizer constructor validates its Database and Statement before
+consuming the Statement Handle. Discard consumes only a completed Job's owned
+result. Discard returns the Runtime's null Handle when no unclaimed resource
+remains. There is no public cleanup reservation or later statement binding.
+Construction and pool insertion need no fallible OS-resource allocation;
+allocator exhaustion retains the existing Rust allocation-failure behavior.
+
+Cancellation keeps the existing finish-then-cancel contract. The wrapper shields
+the wait, checks cancellation outside that shield, and shields required discard
+before propagating cancellation. It does not request SIGUSR2 interruption or
+call `sqlite3_interrupt`. A connection remains in flight through disposal.
+
+The companion native implementation makes the same ownership decisions behind
+its dedicated executor. Open and prepare jobs embed a second private queue node
+and one-shot completion for discard. Their constructors initialize both pipe
+notifications before submitting work, so disposal needs no later allocation.
+The worker publishes result memory before closing its notifier; EOF wakes the
+waiter, which acquires that publication. Accepted results only release metadata
+and unused notification resources. Ordinary native finalization allocates and
+submits in one call and leaves the statement with the caller if submission
+fails. These details do not expose the async pool to native SQLite.
+
+Runtime teardown first releases guest mutex entries. Its field destruction
+order then joins and destroys Async Host workers and Jobs before destroying
+remaining SQLite Statements and Databases. This also handles a guest that
+traps or abandons Handles. Job leak accounting belongs to the Async Host.
+
+## Wasm representation
+
+[The shared import registry](../../src/sqlite/wasm/registry.rs) declares the same
+nine SQLite job imports for V8 and Wasmtime: constructors for open, prepare,
+step, finalize, and discard; result copying; handle transfer; and UTF-16 message
+length and copying. Job Handles use the existing async Job kind in the Runtime's
+shared namespace. Scheduling, return status, OS errors, completion, and release
+use the existing `moonbitlang/async` thread-pool imports.
+
+The pool's `ret` contains the SQLite status; its `err` remains the OS-error
+channel. `sqlite3_job_result` copies a 24-byte little-endian record:
+
+| Byte offset | Type | Value |
+| --- | --- | --- |
+| 0 | i32 | SQLite status |
+| 4 | i32 | Extended SQLite status |
+| 8 | i32 | Prepare tail, or -1 without a Statement |
+| 12 | i32 | Whether the affected-row count is present |
+| 16 | i64 | Affected-row count, or zero when absent |
+
+The async prepare tail is relative to the copied SQL view, matching native
+async prepare. Synchronous prepare instead returns an absolute offset in the
+backing String. Diagnostics use UTF-16 length-and-copy imports and are empty
+for successful Jobs. Invalid Handles, sequencing, and memory arguments trap;
+output buffers are validated before result copying.
+
+## Guest integration and coverage
+
+The upstream SQLite Wasm wrapper must enable its shared async code, represent
+its executor as an async Mutex, and lower its operation-specific Job wrappers
+to these imports. It also needs a companion `@async.perform_host_job` entry
+point that forwards a host Job Handle to the existing `perform_job_in_worker`.
+The caller retains ownership and frees the Job after taking or discarding owned
+results, or copying scalar results.
+The currently pinned async version does not expose that entry point.
+
+`tests/test_cases/test_sqlite_async.in/support` contains the companion async
+entry point and public re-export. The integration harness applies them to a
+disposable copy of the pinned async source. The MoonBit fixture uses async tests
+for SQL views, captured diagnostics, discard, cancellation, event-loop progress,
+and SQLite ordering alongside filesystem work. The test runner owns the event
+loop. The harness runs all cases through `moon test` with its moonrun override
+and leak checking enabled.
+
+`src/sqlite/jobs/tests.rs` covers worker reuse, pinned lifetimes, detached and
+unclaimed result cleanup, single-transfer results, discard without publishing
+handles, invalid finalizer inputs, and Runtime teardown.
+`src/sqlite/wasm/context.rs` checks invalid guest memory without consuming Job
+results.

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2305,6 +2305,26 @@ impl AsyncHost {
         Ok(handle_from_key(key))
     }
 
+    /// Domain adapters inspect their own payloads; the Async Host retains Job
+    /// identity and rejects access while a worker owns the payload.
+    pub(crate) fn with_job<T>(&self, handle: u64, f: impl FnOnce(&Job) -> T) -> AsyncHostResult<T> {
+        self.restore_completed_worker_jobs();
+        let key = self.handles.borrow().job(handle)?;
+        let jobs = self.jobs.borrow();
+        Ok(f(jobs.visible_job(key)?))
+    }
+
+    pub(crate) fn with_job_mut<T>(
+        &self,
+        handle: u64,
+        f: impl FnOnce(&mut Job) -> T,
+    ) -> AsyncHostResult<T> {
+        self.restore_completed_worker_jobs();
+        let key = self.handles.borrow().job(handle)?;
+        let mut jobs = self.jobs.borrow_mut();
+        Ok(f(jobs.visible_job_mut(key)?))
+    }
+
     pub(crate) fn free_job(&self, handle: u64) -> AsyncHostResult<()> {
         let mut handles = self.handles.borrow_mut();
         let key = handles.job(handle)?;

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -32,6 +32,7 @@ pub(crate) fn run_host_job(job: &mut Job) {
         JobPayload::Filesystem(job) => job.run(),
         JobPayload::Network(job) => job.run(),
         JobPayload::Process(job) => job.run(),
+        JobPayload::Sqlite(job) => job.run(),
         #[cfg(unix)]
         JobPayload::Signal(job) => job.run(),
     };

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -23,6 +23,7 @@ use crate::async_sys::signal::SigwaitJob;
 use crate::filesystem::Job as FilesystemJob;
 use crate::network::Job as NetworkJob;
 use crate::process::Job as ProcessJob;
+use crate::sqlite::Job as SqliteJob;
 #[cfg(unix)]
 use std::sync::Arc;
 
@@ -99,6 +100,20 @@ impl Job {
         }
     }
 
+    pub(crate) fn sqlite(&self) -> AsyncHostResult<&SqliteJob> {
+        match &self.payload {
+            JobPayload::Sqlite(job) => Ok(job),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    pub(crate) fn sqlite_mut(&mut self) -> AsyncHostResult<&mut SqliteJob> {
+        match &mut self.payload {
+            JobPayload::Sqlite(job) => Ok(job),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
     #[cfg(windows)]
     pub(crate) fn cancellation_resource(&self) -> Option<crate::resource::ResourceRef> {
         match &self.payload {
@@ -146,6 +161,12 @@ impl From<FilesystemJob> for Job {
     }
 }
 
+impl From<SqliteJob> for Job {
+    fn from(job: SqliteJob) -> Self {
+        Self::new(JobPayload::Sqlite(job))
+    }
+}
+
 impl From<ProcessJob> for Job {
     fn from(job: ProcessJob) -> Self {
         Self::new(JobPayload::Process(job))
@@ -170,6 +191,7 @@ pub(crate) enum JobPayload {
     Filesystem(FilesystemJob),
     Network(NetworkJob),
     Process(ProcessJob),
+    Sqlite(SqliteJob),
     #[cfg(unix)]
     Signal(SigwaitJob),
 }

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -115,6 +115,8 @@ pub(crate) struct Runtime {
     working_directory: Arc<WorkingDirectory>,
     stdio: Arc<Stdio>,
     filesystem: Arc<HostFs>,
+    // Field order is significant: join workers and drop their SQLite payloads
+    // before destroying the Database and Statement tables they refer to.
     async_host: AsyncHost,
     sqlite: SqliteHost,
 }
@@ -220,6 +222,9 @@ impl Runtime {
 
 impl Drop for Runtime {
     fn drop(&mut self) {
+        // Async Host is dropped first and joins workers that can use SQLite.
+        // Release guest-held recursive mutex entries before any worker join.
+        self.sqlite.release_entered_mutexes();
         // Keep the historical opt-in name for compatibility even though the
         // check now runs at the lifetime of the complete Runtime.
         if std::thread::panicking() || std::env::var_os("MOONBIT_ASYNC_CHECK_FD_LEAK").is_none() {

--- a/crates/moonrun/src/sqlite/column.rs
+++ b/crates/moonrun/src/sqlite/column.rs
@@ -32,6 +32,10 @@ unsafe extern "C" {
     fn sqlite3_column_bytes16(statement: *mut ffi::sqlite3_stmt, column: c_int) -> c_int;
 }
 
+// Statement lookup rejects every worker-owned Statement before these calls.
+// Guest host calls run serially, so the same Statement cannot be stepped,
+// reset, finalized, or converted while its column buffer is being copied.
+// Connection-wide error inspection is separate and needs its own exclusion.
 impl SqliteHost {
     pub(crate) fn column_count(&self, statement: u64) -> SqliteHostResult<i32> {
         let statement = self.statement(statement)?;
@@ -171,8 +175,9 @@ impl SqliteHost {
         let statement = self.current_column(statement, column)?;
         let pointer = unsafe { sqlite3_column_text16(statement.pointer.as_ptr(), column) };
         if pointer.is_null() {
-            // Do not make another SQLite call before the guest can inspect
-            // sqlite3_errcode() to distinguish SQL NULL from conversion OOM.
+            // Avoid replacing this error here. The guest must hold the
+            // connection mutex across conversion and error inspection if it
+            // needs to exclude intervening operations on other Statements.
             return Ok(None);
         }
         // SQLite requires this order so conversion cannot invalidate the
@@ -194,7 +199,7 @@ impl SqliteHost {
         let pointer = unsafe { ffi::sqlite3_column_blob(statement.pointer.as_ptr(), column) };
         if pointer.is_null() {
             // SQLite also uses NULL for SQL NULL, zero-length blobs, and OOM.
-            // Preserve the connection error until the guest inspects it.
+            // Avoid replacing the connection error within this host call.
             return Ok((None, 0));
         }
         // SQLite requires the value accessor before the matching byte count.

--- a/crates/moonrun/src/sqlite/connection.rs
+++ b/crates/moonrun/src/sqlite/connection.rs
@@ -32,7 +32,7 @@ unsafe extern "C" {
     fn sqlite3_errmsg16(database: *mut ffi::sqlite3) -> *const c_void;
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub(super) enum Database {
     /// The connection opened and the Host policy was installed.
     Ready {
@@ -45,7 +45,7 @@ pub(super) enum Database {
 }
 
 impl Database {
-    fn ready(pointer: NonNull<ffi::sqlite3>) -> Self {
+    pub(super) fn ready(pointer: NonNull<ffi::sqlite3>) -> Self {
         Self::Ready {
             pointer,
             mutex: None,
@@ -91,38 +91,10 @@ pub(crate) struct OpenOutcome {
 
 impl SqliteHost {
     pub(crate) fn open_v2(&self, filename: &CStr, flags: i32, vfs: u64) -> OpenOutcome {
-        let flags = normalize_open_flags(flags);
-        if let Err(code) = ensure_valid_database(&self.filesystem, filename, flags, vfs) {
-            return OpenOutcome {
-                code,
-                database: None,
-            };
-        }
-
-        let mut database = ptr::null_mut();
-        let code =
-            unsafe { ffi::sqlite3_open_v2(filename.as_ptr(), &mut database, flags, ptr::null()) };
-        let Some(database) = NonNull::new(database) else {
-            return OpenOutcome {
-                code,
-                database: None,
-            };
-        };
-
-        let code = if code == ffi::SQLITE_OK {
-            install_authorizer(database)
-        } else {
-            code
-        };
-
-        let database = if code == ffi::SQLITE_OK {
-            Database::ready(database)
-        } else {
-            Database::Failed(database)
-        };
+        let (code, database) = open_database(&self.filesystem, filename, flags, vfs);
         OpenOutcome {
             code,
-            database: Some(self.insert_database(database)),
+            database: database.map(|database| self.insert_database(database)),
         }
     }
 
@@ -130,19 +102,25 @@ impl SqliteHost {
     /// excluding its trailing NUL.
     pub(crate) fn errmsg16_length(&self, database: u64) -> SqliteHostResult<u32> {
         let database = self.database(database)?;
+        let _guard = database.lock();
         let message = unsafe { sqlite3_errmsg16(database.pointer().as_ptr()) };
-        // No other thread can access this run-local connection, and the scan
-        // finishes before another SQLite call can invalidate the pointer.
+        // The connection mutex keeps the borrowed error alive through this scan.
         Ok(unsafe { utf16_string_length(message) }?.unwrap_or(0))
     }
 
     pub(crate) fn errcode(&self, database: u64) -> SqliteHostResult<i32> {
         let database = self.database(database)?;
+        // SQLite's error-code getters read mutable connection fields without
+        // locking. Exclude worker writes for this read; separate guest calls
+        // still observe whichever operation most recently changed the error.
+        let _guard = database.lock();
         Ok(unsafe { ffi::sqlite3_errcode(database.pointer().as_ptr()) })
     }
 
     pub(crate) fn extended_errcode(&self, database: u64) -> SqliteHostResult<i32> {
         let database = self.database(database)?;
+        // Like errcode(), this SQLite getter does not lock internally.
+        let _guard = database.lock();
         Ok(unsafe { ffi::sqlite3_extended_errcode(database.pointer().as_ptr()) })
     }
 
@@ -151,6 +129,8 @@ impl SqliteHost {
         if !database.is_ready() {
             return Err(SqliteHostError::InvalidInput);
         }
+        // SQLite reads nChange without locking; a worker may be updating it.
+        let _guard = database.lock();
         Ok(unsafe { ffi::sqlite3_changes64(database.pointer().as_ptr()) })
     }
 
@@ -162,9 +142,9 @@ impl SqliteHost {
     /// the caller how much space to allocate.
     pub(crate) fn copy_errmsg16(&self, database: u64, output: &mut [u16]) -> SqliteHostResult<u32> {
         let database = self.database(database)?;
+        let _guard = database.lock();
         let message = unsafe { sqlite3_errmsg16(database.pointer().as_ptr()) };
-        // No other thread can access this run-local connection, and copying
-        // finishes before another SQLite call can invalidate the pointer.
+        // The connection mutex keeps the borrowed error alive through this copy.
         Ok(unsafe { copy_utf16_string(message, output) }?.unwrap_or(0))
     }
 
@@ -174,7 +154,9 @@ impl SqliteHost {
         }
         let database_handle = database;
         let database = self.database(database_handle)?;
-        if self.database_mutex_is_entered(database) {
+        if self.database_mutex_is_entered(database)
+            || self.job_uses_database(self.database_key(database_handle)?)
+        {
             return Err(SqliteHostError::InvalidInput);
         }
         let pointer = database.pointer();
@@ -186,7 +168,7 @@ impl SqliteHost {
         Ok(code)
     }
 
-    fn insert_database(&self, database: Database) -> u64 {
+    pub(super) fn insert_database(&self, database: Database) -> u64 {
         let key = self
             .keys
             .borrow_mut()
@@ -224,6 +206,36 @@ impl SqliteHost {
         debug_assert_eq!(removed, Some(HostResourceKind::SqliteDatabase));
         Ok(database)
     }
+}
+
+/// The same admission and raw open operation serves synchronous and worker calls.
+pub(super) fn open_database(
+    filesystem: &crate::filesystem::HostFs,
+    filename: &CStr,
+    flags: i32,
+    vfs: u64,
+) -> (i32, Option<Database>) {
+    let flags = normalize_open_flags(flags);
+    if let Err(code) = ensure_valid_database(filesystem, filename, flags, vfs) {
+        return (code, None);
+    }
+    let mut database = ptr::null_mut();
+    let code =
+        unsafe { ffi::sqlite3_open_v2(filename.as_ptr(), &mut database, flags, ptr::null()) };
+    let Some(database) = NonNull::new(database) else {
+        return (code, None);
+    };
+    let code = if code == ffi::SQLITE_OK {
+        install_authorizer(database)
+    } else {
+        code
+    };
+    let database = if code == ffi::SQLITE_OK {
+        Database::ready(database)
+    } else {
+        Database::Failed(database)
+    };
+    (code, Some(database))
 }
 
 /// Measure a native-endian, NUL-terminated SQLite UTF-16 string, excluding NUL.

--- a/crates/moonrun/src/sqlite/jobs/mod.rs
+++ b/crates/moonrun/src/sqlite/jobs/mod.rs
@@ -1,0 +1,262 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! SQLite payloads for the existing async Job lifecycle. The Async Host owns
+//! scheduling, completion, job Handles, and destruction; this module owns SQLite
+//! inputs, captured results, and the leases that keep native pointers valid.
+mod runner;
+
+use std::ffi::CString;
+use std::sync::{Arc, Weak};
+
+use libsqlite3_sys as ffi;
+use slotmap::Key;
+
+use super::statement::Statement;
+use super::{SqliteHost, SqliteHostError, SqliteHostResult};
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::runtime::HostKey;
+use runner::{DatabasePointer, Input, Outcome, Output, OwnedStatement, StatementPointer};
+
+/// A lease outlives both execution and unclaimed results, even when free_job
+/// detaches an in-flight Job. Weak references in SQLite Host track those actual
+/// lifetimes rather than the lifetime of the guest's async Job Handle.
+#[derive(Debug)]
+pub(super) struct Lease {
+    database: Option<HostKey>,
+    statement: Option<HostKey>,
+}
+
+pub(crate) struct Job {
+    input: Option<Input>,
+    result: Option<Outcome>,
+    // Drop native inputs/results before removing their lifetime protection.
+    lease: Arc<Lease>,
+}
+
+impl std::fmt::Debug for Job {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteJob")
+            .field("result", &self.result)
+            .field("lease", &self.lease)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Job {
+    pub(crate) fn run(&mut self) -> AsyncHostResult<i64> {
+        let result = self.input.take().ok_or(AsyncHostError::Inval)?.run();
+        let code = result.code;
+        self.result = Some(result);
+        // SQLite statuses belong in ret, not in the pool's OS-error channel.
+        Ok(i64::from(code))
+    }
+
+    pub(crate) fn copy_result(&self, output: &mut [u8; 24]) -> SqliteHostResult<()> {
+        let result = self.result.as_ref().ok_or(SqliteHostError::InvalidInput)?;
+        let tail = match result.output {
+            Output::Prepare { tail, .. } => tail,
+            _ => -1,
+        };
+        let changes = match result.output {
+            Output::Step(changes) => changes,
+            _ => None,
+        };
+        output[0..4].copy_from_slice(&result.code.to_le_bytes());
+        output[4..8].copy_from_slice(&result.extended.to_le_bytes());
+        output[8..12].copy_from_slice(&tail.to_le_bytes());
+        output[12..16].copy_from_slice(&i32::from(changes.is_some()).to_le_bytes());
+        output[16..24].copy_from_slice(&changes.unwrap_or(0).to_le_bytes());
+        Ok(())
+    }
+
+    pub(crate) fn message16_length(&self) -> SqliteHostResult<u32> {
+        let result = self.result.as_ref().ok_or(SqliteHostError::InvalidInput)?;
+        u32::try_from(result.message.len()).map_err(|_| SqliteHostError::Overflow)
+    }
+
+    pub(crate) fn copy_message16(&self, output: &mut [u16]) -> SqliteHostResult<u32> {
+        let length = self.message16_length()?;
+        let message = &self.result.as_ref().unwrap().message;
+        if output.len() >= message.len() {
+            output[..message.len()].copy_from_slice(message);
+        }
+        Ok(length)
+    }
+}
+
+impl SqliteHost {
+    pub(crate) fn make_open_job(&self, filename: CString, flags: i32) -> Job {
+        self.make_job(
+            None,
+            None,
+            Input::Open {
+                filesystem: Arc::clone(&self.filesystem),
+                filename,
+                flags,
+            },
+        )
+    }
+
+    pub(crate) fn make_prepare_job(&self, database: u64, sql: Vec<u16>) -> SqliteHostResult<Job> {
+        if sql.len() > i32::MAX as usize / 2 {
+            return Err(SqliteHostError::Overflow);
+        }
+        let key = self.database_key(database)?;
+        let database = self.database_for_job(database)?;
+        Ok(self.make_job(
+            Some(key),
+            None,
+            Input::Prepare {
+                database: DatabasePointer(database),
+                sql,
+            },
+        ))
+    }
+
+    pub(crate) fn make_step_job(&self, database: u64, statement: u64) -> SqliteHostResult<Job> {
+        let database_key = self.database_key(database)?;
+        let database = self.database_for_job(database)?;
+        let key = self.statement_key(statement)?;
+        if self.job_uses_statement(key) {
+            return Err(SqliteHostError::InvalidInput);
+        }
+        let statement = self.statements.borrow()[key];
+        if statement.database != database_key {
+            return Err(SqliteHostError::InvalidInput);
+        }
+        Ok(self.make_job(
+            Some(database_key),
+            Some(key),
+            Input::Step {
+                database: DatabasePointer(database),
+                statement: StatementPointer(statement.pointer),
+            },
+        ))
+    }
+
+    pub(crate) fn make_finalize_job(&self, database: u64, statement: u64) -> SqliteHostResult<Job> {
+        let database_key = self.database_key(database)?;
+        let database = self.database_for_job(database)?;
+        let key = self.statement_key(statement)?;
+        if self.job_uses_statement(key) || self.statements.borrow()[key].database != database_key {
+            return Err(SqliteHostError::InvalidInput);
+        }
+        // Validate everything before consuming the Statement. Job construction
+        // and pool insertion perform no fallible OS-resource allocation.
+        let statement = self.remove_statement(statement)?;
+        Ok(self.make_job(
+            Some(database_key),
+            None,
+            Input::Finalize {
+                database: DatabasePointer(database),
+                statement: OwnedStatement(Some(StatementPointer(statement.pointer))),
+            },
+        ))
+    }
+
+    /// Move an unclaimed result directly into cleanup work without publishing
+    /// a Database/Statement Handle. Releasing the source cannot release the
+    /// shared lease while the cleanup worker still owns the native pointer.
+    pub(crate) fn make_discard_job(&self, job: &mut Job) -> SqliteHostResult<Option<Job>> {
+        let result = job.result.as_mut().ok_or(SqliteHostError::InvalidInput)?;
+        let input = match &mut result.output {
+            Output::Open(database) if database.0.is_some() => {
+                Input::Close(runner::OwnedDatabase(database.0.take()))
+            }
+            Output::Prepare { statement, .. } if statement.0.is_some() => {
+                let key = job.lease.database.ok_or(SqliteHostError::InvalidInput)?;
+                let database = self.database_for_job(key.data().as_ffi())?;
+                Input::Finalize {
+                    database: DatabasePointer(database),
+                    statement: OwnedStatement(statement.0.take()),
+                }
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(Job {
+            input: Some(input),
+            result: None,
+            lease: Arc::clone(&job.lease),
+        }))
+    }
+
+    pub(crate) fn take_job_handle(&self, job: &mut Job) -> SqliteHostResult<u64> {
+        let result = job.result.as_mut().ok_or(SqliteHostError::InvalidInput)?;
+        if result.code != ffi::SQLITE_OK {
+            return Err(SqliteHostError::InvalidInput);
+        }
+        match &mut result.output {
+            Output::Open(database) => {
+                let database = database.0.take().ok_or(SqliteHostError::InvalidInput)?;
+                let handle = self.insert_database(database.0);
+                Ok(handle)
+            }
+            Output::Prepare { statement, .. } => {
+                let database = job.lease.database.ok_or(SqliteHostError::InvalidInput)?;
+                let pointer = statement.0.take().ok_or(SqliteHostError::InvalidInput)?.0;
+                Ok(self.insert_statement(Statement { pointer, database }))
+            }
+            _ => Err(SqliteHostError::InvalidInput),
+        }
+    }
+
+    pub(super) fn job_uses_database(&self, database: HostKey) -> bool {
+        let mut leases = self.job_leases.borrow_mut();
+        leases.retain(|lease| lease.strong_count() != 0);
+        leases
+            .iter()
+            .filter_map(Weak::upgrade)
+            .any(|lease| lease.database == Some(database))
+    }
+
+    pub(super) fn job_uses_statement(&self, statement: HostKey) -> bool {
+        let mut leases = self.job_leases.borrow_mut();
+        leases.retain(|lease| lease.strong_count() != 0);
+        leases
+            .iter()
+            .filter_map(Weak::upgrade)
+            .any(|lease| lease.statement == Some(statement))
+    }
+
+    fn database_for_job(&self, database: u64) -> SqliteHostResult<super::connection::Database> {
+        let database = self.database(database)?;
+        if !database.is_ready() || self.database_mutex_is_entered(database) {
+            return Err(SqliteHostError::InvalidInput);
+        }
+        Ok(database)
+    }
+
+    fn make_job(&self, database: Option<HostKey>, statement: Option<HostKey>, input: Input) -> Job {
+        let lease = Arc::new(Lease {
+            database,
+            statement,
+        });
+        let mut leases = self.job_leases.borrow_mut();
+        leases.retain(|lease| lease.strong_count() != 0);
+        leases.push(Arc::downgrade(&lease));
+        Job {
+            input: Some(input),
+            result: None,
+            lease,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/moonrun/src/sqlite/jobs/runner.rs
+++ b/crates/moonrun/src/sqlite/jobs/runner.rs
@@ -1,0 +1,231 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! One-shot native work. No guest Handles or Guest Memory cross this boundary.
+use std::ffi::CString;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use crate::filesystem::HostFs;
+use crate::sqlite::connection::{Database, open_database, utf16_string_length};
+use crate::sqlite::statement::prepare_statement;
+use libsqlite3_sys as ffi;
+
+/// The owning Job keeps its input lease alive, including after the guest frees
+/// an in-flight Job. Runtime destroys Async Host workers and Jobs before SQLite
+/// tables. FULLMUTEX connections serialize all native access.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct DatabasePointer(pub(super) Database);
+unsafe impl Send for DatabasePointer {}
+#[derive(Clone, Copy, Debug)]
+pub(super) struct StatementPointer(pub(super) NonNull<ffi::sqlite3_stmt>);
+unsafe impl Send for StatementPointer {}
+
+#[derive(Debug)]
+pub(super) struct OwnedDatabase(pub(super) Option<DatabasePointer>);
+impl Drop for OwnedDatabase {
+    fn drop(&mut self) {
+        if let Some(database) = self.0.take() {
+            unsafe { ffi::sqlite3_close(database.0.pointer().as_ptr()) };
+        }
+    }
+}
+#[derive(Debug)]
+pub(super) struct OwnedStatement(pub(super) Option<StatementPointer>);
+impl Drop for OwnedStatement {
+    fn drop(&mut self) {
+        if let Some(statement) = self.0.take() {
+            unsafe { ffi::sqlite3_finalize(statement.0.as_ptr()) };
+        }
+    }
+}
+
+pub(super) enum Input {
+    Close(OwnedDatabase),
+    Open {
+        filesystem: Arc<HostFs>,
+        filename: CString,
+        flags: i32,
+    },
+    Prepare {
+        database: DatabasePointer,
+        sql: Vec<u16>,
+    },
+    Step {
+        database: DatabasePointer,
+        statement: StatementPointer,
+    },
+    Finalize {
+        database: DatabasePointer,
+        statement: OwnedStatement,
+    },
+}
+
+#[derive(Debug)]
+pub(super) enum Output {
+    Open(OwnedDatabase),
+    Prepare {
+        statement: OwnedStatement,
+        tail: i32,
+    },
+    Step(Option<i64>),
+    Finalize,
+}
+
+#[derive(Debug)]
+pub(super) struct Outcome {
+    pub(super) code: i32,
+    pub(super) extended: i32,
+    pub(super) message: Vec<u16>,
+    pub(super) output: Output,
+}
+
+unsafe extern "C" {
+    fn sqlite3_errmsg16(database: *mut ffi::sqlite3) -> *const std::ffi::c_void;
+}
+
+impl Outcome {
+    fn new(code: i32, output: Output) -> Self {
+        Self {
+            code,
+            extended: code,
+            message: Vec::new(),
+            output,
+        }
+    }
+
+    /// Caller holds the connection mutex through the operation and this copy.
+    fn capture_error(&mut self, database: Database) {
+        self.extended = unsafe { ffi::sqlite3_extended_errcode(database.pointer().as_ptr()) };
+        let message = unsafe { sqlite3_errmsg16(database.pointer().as_ptr()) };
+        if let Ok(Some(length)) = unsafe { utf16_string_length(message) } {
+            self.message =
+                unsafe { std::slice::from_raw_parts(message.cast(), length as usize) }.to_vec();
+        }
+    }
+}
+
+impl Input {
+    pub(super) fn run(self) -> Outcome {
+        match self {
+            Self::Close(database) => {
+                // This Database was never exposed to guest code and has no
+                // Statements. Close on the worker; no mutex guard may outlive it.
+                drop(database);
+                Outcome::new(ffi::SQLITE_OK, Output::Finalize)
+            }
+            Self::Open {
+                filesystem,
+                filename,
+                flags,
+            } => {
+                let (code, database) =
+                    open_database(&filesystem, &filename, flags, crate::runtime::null_handle());
+                let mut outcome = Outcome::new(code, Output::Open(OwnedDatabase(None)));
+                if let Some(database) = database {
+                    if code == ffi::SQLITE_OK {
+                        outcome.output =
+                            Output::Open(OwnedDatabase(Some(DatabasePointer(database))));
+                    } else {
+                        {
+                            let _guard = database.lock();
+                            outcome.capture_error(database);
+                        }
+                        unsafe { ffi::sqlite3_close(database.pointer().as_ptr()) };
+                    }
+                }
+                outcome
+            }
+            Self::Prepare {
+                database: DatabasePointer(database),
+                sql,
+            } => {
+                let _guard = database.lock();
+                let (code, statement, tail) = match prepare_statement(database, &sql) {
+                    Ok(result) => result,
+                    Err(_) => {
+                        return Outcome::new(
+                            ffi::SQLITE_TOOBIG,
+                            Output::Prepare {
+                                statement: OwnedStatement(None),
+                                tail: -1,
+                            },
+                        );
+                    }
+                };
+                let tail = if statement.is_some() { tail as i32 } else { -1 };
+                let mut outcome = Outcome::new(
+                    code,
+                    Output::Prepare {
+                        statement: OwnedStatement(statement.map(StatementPointer)),
+                        tail,
+                    },
+                );
+                if code != ffi::SQLITE_OK {
+                    outcome.capture_error(database);
+                    outcome.output = Output::Prepare {
+                        statement: OwnedStatement(None),
+                        tail: -1,
+                    };
+                }
+                outcome
+            }
+            Self::Step {
+                database: DatabasePointer(database),
+                statement: StatementPointer(statement),
+            } => {
+                let _guard = database.lock();
+                let read_only = unsafe { ffi::sqlite3_stmt_readonly(statement.as_ptr()) } != 0;
+                let before = unsafe { ffi::sqlite3_total_changes64(database.pointer().as_ptr()) };
+                let code = unsafe { ffi::sqlite3_step(statement.as_ptr()) };
+                let changes = if code == ffi::SQLITE_DONE && !read_only {
+                    let after =
+                        unsafe { ffi::sqlite3_total_changes64(database.pointer().as_ptr()) };
+                    Some(if before == after {
+                        0
+                    } else {
+                        unsafe { ffi::sqlite3_changes64(database.pointer().as_ptr()) }
+                    })
+                } else {
+                    None
+                };
+                let mut outcome = Outcome::new(code, Output::Step(changes));
+                if code != ffi::SQLITE_ROW && code != ffi::SQLITE_DONE {
+                    outcome.capture_error(database);
+                }
+                outcome
+            }
+            Self::Finalize {
+                database: DatabasePointer(database),
+                mut statement,
+            } => {
+                let _guard = database.lock();
+                let pointer = statement
+                    .0
+                    .take()
+                    .expect("submitted finalizer owns a statement");
+                let code = unsafe { ffi::sqlite3_finalize(pointer.0.as_ptr()) };
+                let mut outcome = Outcome::new(code, Output::Finalize);
+                if code != ffi::SQLITE_OK {
+                    outcome.capture_error(database);
+                }
+                outcome
+            }
+        }
+    }
+}

--- a/crates/moonrun/src/sqlite/jobs/tests.rs
+++ b/crates/moonrun/src/sqlite/jobs/tests.rs
@@ -1,0 +1,462 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use super::*;
+use crate::runtime::Runtime;
+use crate::sqlite::tests::{open_memory, runtime, utf16le};
+
+fn take_handle(runtime: &Runtime, job: u64) -> SqliteHostResult<u64> {
+    runtime
+        .async_host()
+        .with_job_mut(job, |job| {
+            runtime.sqlite().take_job_handle(job.sqlite_mut().unwrap())
+        })
+        .unwrap()
+}
+
+#[test]
+fn shared_jobs_transfer_results_once_and_finalizers_consume_statements() {
+    let runtime = runtime();
+    let host = runtime.sqlite();
+    let pool = runtime.async_host();
+    let job = pool
+        .insert_job(host.make_open_job(
+            c":memory:".to_owned(),
+            ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE,
+        ))
+        .unwrap();
+    pool.run_job(job).unwrap();
+    assert_eq!(pool.job_get_ret(job), Ok(i64::from(ffi::SQLITE_OK)));
+    assert_eq!(pool.job_get_err(job), Ok(0));
+    let database = take_handle(&runtime, job).unwrap();
+    assert_eq!(
+        take_handle(&runtime, job),
+        Err(SqliteHostError::InvalidInput)
+    );
+    pool.free_job(job).unwrap();
+
+    let prepare = pool
+        .insert_job(
+            host.make_prepare_job(database, utf16le("SELECT 42; SELECT 43"))
+                .unwrap(),
+        )
+        .unwrap();
+    pool.run_job(prepare).unwrap();
+    let mut result = [0; 24];
+    pool.with_job(prepare, |job| {
+        job.sqlite().unwrap().copy_result(&mut result)
+    })
+    .unwrap()
+    .unwrap();
+    assert_eq!(i32::from_le_bytes(result[8..12].try_into().unwrap()), 10);
+    let statement = take_handle(&runtime, prepare).unwrap();
+    assert_eq!(
+        take_handle(&runtime, prepare),
+        Err(SqliteHostError::InvalidInput)
+    );
+    pool.free_job(prepare).unwrap();
+    let finalizer = pool
+        .insert_job(host.make_finalize_job(database, statement).unwrap())
+        .unwrap();
+    assert_eq!(host.step(statement), Err(SqliteHostError::InvalidHandle));
+    pool.run_job(finalizer).unwrap();
+    assert_eq!(pool.job_get_ret(finalizer), Ok(i64::from(ffi::SQLITE_OK)));
+    pool.free_job(finalizer).unwrap();
+    host.close(database).unwrap();
+    assert!(host.leak_summary().is_none());
+}
+
+#[test]
+fn detached_submitted_jobs_keep_their_sqlite_inputs_alive() {
+    let runtime = runtime();
+    let host = runtime.sqlite();
+    let pool = runtime.async_host();
+    let database = open_memory(host);
+    let statement = host
+        .prepare16_v2(database, &utf16le("SELECT 1"))
+        .unwrap()
+        .statement
+        .unwrap();
+    let poll = pool.poll_create().unwrap();
+    pool.init_thread_pool(poll).unwrap();
+    let guard = host.database(database).unwrap().lock();
+    let job = pool
+        .insert_job(host.make_step_job(database, statement).unwrap())
+        .unwrap();
+    let worker = pool.spawn_worker(42, job).unwrap();
+    pool.free_job(job).unwrap();
+    assert_eq!(pool.job_get_ret(job), Err(AsyncHostError::Badf));
+    assert_eq!(host.close(database), Err(SqliteHostError::InvalidInput));
+    assert_eq!(host.finalize(statement), Err(SqliteHostError::InvalidInput));
+    assert_eq!(host.reset(statement), Err(SqliteHostError::InvalidInput));
+    assert_eq!(
+        host.column_count(statement),
+        Err(SqliteHostError::InvalidInput)
+    );
+    assert_eq!(
+        host.bind_null(statement, 1),
+        Err(SqliteHostError::InvalidInput)
+    );
+    assert_eq!(
+        host.clear_bindings(statement),
+        Err(SqliteHostError::InvalidInput)
+    );
+    drop(guard);
+    pool.free_worker(worker).unwrap();
+    host.finalize(statement).unwrap();
+    host.close(database).unwrap();
+    pool.destroy_thread_pool();
+    pool.poll_destroy(poll).unwrap();
+}
+
+#[test]
+fn idle_statement_metadata_does_not_wait_for_the_connection_mutex() {
+    let host = crate::sqlite::tests::host();
+    let database = open_memory(&host);
+    let statement = host
+        .prepare16_v2(database, &utf16le("SELECT 1"))
+        .unwrap()
+        .statement
+        .unwrap();
+    let pointer = DatabasePointer(host.database(database).unwrap());
+    let (locked_tx, locked_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        let database = pointer;
+        let _guard = database.0.lock();
+        locked_tx.send(()).unwrap();
+        // Bound a regression's wait: a hidden lock in statement lookup would
+        // block column_count until this timeout releases the native mutex.
+        release_rx.recv_timeout(std::time::Duration::from_secs(5))
+    });
+    locked_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .unwrap();
+    let count = host.column_count(statement);
+    let _ = release_tx.send(());
+    assert_eq!(worker.join().unwrap(), Ok(()));
+    assert_eq!(count, Ok(1));
+    host.finalize(statement).unwrap();
+    host.close(database).unwrap();
+}
+
+#[test]
+fn connection_error_reads_observe_intervening_jobs() {
+    let runtime = runtime();
+    let host = runtime.sqlite();
+    let pool = runtime.async_host();
+    let database = open_memory(host);
+    assert_eq!(
+        host.prepare16_v2(database, &utf16le("SELECT missing_column"))
+            .unwrap()
+            .code,
+        ffi::SQLITE_ERROR
+    );
+    assert_eq!(host.errcode(database), Ok(ffi::SQLITE_ERROR));
+    let prepare = pool
+        .insert_job(
+            host.make_prepare_job(database, utf16le("SELECT 42"))
+                .unwrap(),
+        )
+        .unwrap();
+    pool.run_job(prepare).unwrap();
+    // A safe read is not a snapshot of the preceding guest operation.
+    assert_eq!(host.errcode(database), Ok(ffi::SQLITE_OK));
+    assert_eq!(host.extended_errcode(database), Ok(ffi::SQLITE_OK));
+    let statement = take_handle(&runtime, prepare).unwrap();
+    pool.free_job(prepare).unwrap();
+    host.finalize(statement).unwrap();
+    host.close(database).unwrap();
+}
+
+#[test]
+fn detached_preparing_jobs_destroy_unclaimed_results_before_releasing_the_database() {
+    let runtime = runtime();
+    let host = runtime.sqlite();
+    let pool = runtime.async_host();
+    let database = open_memory(host);
+    let poll = pool.poll_create().unwrap();
+    pool.init_thread_pool(poll).unwrap();
+    let guard = host.database(database).unwrap().lock();
+    let job = pool
+        .insert_job(
+            host.make_prepare_job(database, utf16le("SELECT 42"))
+                .unwrap(),
+        )
+        .unwrap();
+    let worker = pool.spawn_worker(1, job).unwrap();
+    pool.free_job(job).unwrap();
+    assert_eq!(pool.job_get_ret(job), Err(AsyncHostError::Badf));
+    assert_eq!(host.close(database), Err(SqliteHostError::InvalidInput));
+    let replacement = pool
+        .insert_job(crate::async_sys::internal::event_loop::thread_pool::make_sleep_job(0))
+        .unwrap();
+    drop(guard);
+    assert_eq!(pool.poll_wait(poll, 10_000), Ok(1));
+    pool.free_worker(worker).unwrap();
+    assert_eq!(pool.job_get_ret(job), Err(AsyncHostError::Badf));
+    pool.run_job(replacement).unwrap();
+    pool.free_job(replacement).unwrap();
+    // SQLITE_BUSY here would reveal an unclaimed native Statement leak.
+    assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+    pool.destroy_thread_pool();
+    pool.poll_destroy(poll).unwrap();
+}
+
+#[test]
+fn freeing_jobs_destroys_unclaimed_statements_and_unrun_finalizers() {
+    let runtime = runtime();
+    let host = runtime.sqlite();
+    let pool = runtime.async_host();
+    let database = open_memory(host);
+    let prepare = pool
+        .insert_job(
+            host.make_prepare_job(database, utf16le("SELECT 42"))
+                .unwrap(),
+        )
+        .unwrap();
+    pool.run_job(prepare).unwrap();
+    pool.free_job(prepare).unwrap();
+    assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+
+    let database = open_memory(host);
+    let statement = host
+        .prepare16_v2(database, &utf16le("SELECT 42"))
+        .unwrap()
+        .statement
+        .unwrap();
+    let finalizer = pool
+        .insert_job(host.make_finalize_job(database, statement).unwrap())
+        .unwrap();
+    assert_eq!(host.close(database), Err(SqliteHostError::InvalidInput));
+    pool.free_job(finalizer).unwrap();
+    assert_eq!(host.step(statement), Err(SqliteHostError::InvalidHandle));
+    assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+    assert!(host.leak_summary().is_none());
+}
+
+#[test]
+fn idle_async_workers_can_run_sqlite_and_existing_jobs() {
+    let runtime = runtime();
+    let pool = runtime.async_host();
+    let host = runtime.sqlite();
+    let poll = pool.poll_create().unwrap();
+    pool.init_thread_pool(poll).unwrap();
+    let sleep = pool
+        .insert_job(crate::async_sys::internal::event_loop::thread_pool::make_sleep_job(0))
+        .unwrap();
+    let worker = pool.spawn_worker(1, sleep).unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while pool.job_get_ret(sleep) != Ok(0) {
+        assert!(std::time::Instant::now() < deadline);
+        pool.poll_wait(poll, 10).unwrap();
+    }
+    pool.free_job(sleep).unwrap();
+    pool.worker_enter_idle(worker).unwrap();
+
+    let database = open_memory(host);
+    let job = pool
+        .insert_job(
+            host.make_prepare_job(database, utf16le("SELECT 42"))
+                .unwrap(),
+        )
+        .unwrap();
+    pool.wake_worker(worker, 2, job).unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !pool
+        .with_job(job, |job| job.sqlite().unwrap().result.is_some())
+        .unwrap_or(false)
+    {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "reused worker did not complete SQLite job"
+        );
+        pool.poll_wait(poll, 10).unwrap();
+        std::thread::yield_now();
+    }
+    pool.free_worker(worker).unwrap();
+    let statement = take_handle(&runtime, job).unwrap();
+    pool.free_job(job).unwrap();
+    host.finalize(statement).unwrap();
+    host.close(database).unwrap();
+    pool.destroy_thread_pool();
+    pool.poll_destroy(poll).unwrap();
+}
+
+#[test]
+fn captured_diagnostics_survive_other_operations_on_the_connection() {
+    let runtime = runtime();
+    let pool = runtime.async_host();
+    let host = runtime.sqlite();
+    let database = open_memory(host);
+    let failed = pool
+        .insert_job(
+            host.make_prepare_job(database, utf16le("SELECT missing_column"))
+                .unwrap(),
+        )
+        .unwrap();
+    pool.run_job(failed).unwrap();
+    assert_eq!(pool.job_get_ret(failed), Ok(i64::from(ffi::SQLITE_ERROR)));
+    assert_eq!(pool.job_get_err(failed), Ok(0));
+    let statement = host
+        .prepare16_v2(database, &utf16le("SELECT 42"))
+        .unwrap()
+        .statement
+        .unwrap();
+    host.step(statement).unwrap();
+    let message = pool
+        .with_job(failed, |job| {
+            let job = job.sqlite().unwrap();
+            let mut output = vec![0; job.message16_length().unwrap() as usize];
+            job.copy_message16(&mut output).unwrap();
+            String::from_utf16(&output).unwrap()
+        })
+        .unwrap();
+    assert!(message.contains("missing_column"));
+    pool.free_job(failed).unwrap();
+    host.finalize(statement).unwrap();
+    host.close(database).unwrap();
+}
+
+#[test]
+fn invalid_finalizer_input_preserves_the_statement() {
+    let runtime = runtime();
+    let host = runtime.sqlite();
+    let first = open_memory(host);
+    let other = open_memory(host);
+    let statement = host
+        .prepare16_v2(other, &utf16le("SELECT 42"))
+        .unwrap()
+        .statement
+        .unwrap();
+    assert!(matches!(
+        host.make_finalize_job(first, statement),
+        Err(SqliteHostError::InvalidInput)
+    ));
+    assert_eq!(host.step(statement), Ok(ffi::SQLITE_ROW));
+    host.finalize(statement).unwrap();
+    host.close(first).unwrap();
+    host.close(other).unwrap();
+}
+
+#[test]
+fn runtime_releases_guest_mutexes_before_joining_shared_sqlite_workers() {
+    let runtime = runtime();
+    let host = runtime.sqlite();
+    let pool = runtime.async_host();
+    let database = open_memory(host);
+    let poll = pool.poll_create().unwrap();
+    pool.init_thread_pool(poll).unwrap();
+    let job = pool
+        .insert_job(
+            host.make_prepare_job(database, utf16le("SELECT 1"))
+                .unwrap(),
+        )
+        .unwrap();
+    let mutex = host.db_mutex(database).unwrap();
+    host.mutex_enter(mutex).unwrap();
+    pool.spawn_worker(1, job).unwrap();
+    // Abandon the job, result, Database, poll, and guest mutex entry. Teardown
+    // must join the shared worker before destroying any SQLite pointers.
+    drop(runtime);
+}
+
+#[test]
+fn discard_keeps_an_unclaimed_statement_on_the_host_and_retains_its_database() {
+    let runtime = runtime();
+    let host = runtime.sqlite();
+    let pool = runtime.async_host();
+    let database = open_memory(host);
+    let prepare = pool
+        .insert_job(
+            host.make_prepare_job(database, utf16le("SELECT 1; SELECT 2"))
+                .unwrap(),
+        )
+        .unwrap();
+    assert!(matches!(
+        pool.with_job_mut(prepare, |job| host
+            .make_discard_job(job.sqlite_mut().unwrap()))
+            .unwrap(),
+        Err(SqliteHostError::InvalidInput)
+    ));
+    pool.run_job(prepare).unwrap();
+    let discard = pool
+        .with_job_mut(prepare, |job| {
+            host.make_discard_job(job.sqlite_mut().unwrap())
+        })
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(host.statements.borrow().is_empty());
+    assert_eq!(
+        take_handle(&runtime, prepare),
+        Err(SqliteHostError::InvalidInput)
+    );
+    assert!(
+        pool.with_job_mut(prepare, |job| host
+            .make_discard_job(job.sqlite_mut().unwrap()))
+            .unwrap()
+            .unwrap()
+            .is_none()
+    );
+    // Result snapshots survive disposal; only the owned pointer moves.
+    let mut result = [0; 24];
+    pool.with_job(prepare, |job| {
+        job.sqlite().unwrap().copy_result(&mut result)
+    })
+    .unwrap()
+    .unwrap();
+    assert_eq!(i32::from_le_bytes(result[8..12].try_into().unwrap()), 9);
+    pool.free_job(prepare).unwrap();
+    let discard = pool.insert_job(discard).unwrap();
+    assert_eq!(host.close(database), Err(SqliteHostError::InvalidInput));
+    pool.run_job(discard).unwrap();
+    pool.free_job(discard).unwrap();
+    host.close(database).unwrap();
+    assert!(host.leak_summary().is_none());
+}
+
+#[test]
+fn unclaimed_open_results_are_discarded_without_publishing_database_handles() {
+    let runtime = runtime();
+    let host = runtime.sqlite();
+    let pool = runtime.async_host();
+    let open = pool
+        .insert_job(host.make_open_job(
+            c":memory:".to_owned(),
+            ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE,
+        ))
+        .unwrap();
+    pool.run_job(open).unwrap();
+    let discard = pool
+        .with_job_mut(open, |job| host.make_discard_job(job.sqlite_mut().unwrap()))
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(host.databases.borrow().is_empty());
+    assert_eq!(
+        take_handle(&runtime, open),
+        Err(SqliteHostError::InvalidInput)
+    );
+    pool.free_job(open).unwrap();
+    let discard = pool.insert_job(discard).unwrap();
+    pool.run_job(discard).unwrap();
+    assert_eq!(pool.job_get_ret(discard), Ok(i64::from(ffi::SQLITE_OK)));
+    pool.free_job(discard).unwrap();
+    assert!(host.leak_summary().is_none());
+}

--- a/crates/moonrun/src/sqlite/mod.rs
+++ b/crates/moonrun/src/sqlite/mod.rs
@@ -23,6 +23,8 @@ pub(crate) mod wasm;
 mod bind;
 mod column;
 mod connection;
+mod jobs;
+pub(crate) use jobs::Job;
 mod mutex;
 mod policy;
 mod statement;
@@ -68,6 +70,7 @@ pub(crate) struct SqliteHost {
     databases: RefCell<SecondaryMap<HostKey, Database>>,
     mutexes: RefCell<SecondaryMap<HostKey, mutex::DatabaseMutex>>,
     statements: RefCell<SecondaryMap<HostKey, Statement>>,
+    job_leases: RefCell<Vec<std::sync::Weak<jobs::Lease>>>,
 }
 
 impl SqliteHost {
@@ -78,6 +81,7 @@ impl SqliteHost {
             databases: RefCell::new(SecondaryMap::new()),
             mutexes: RefCell::new(SecondaryMap::new()),
             statements: RefCell::new(SecondaryMap::new()),
+            job_leases: RefCell::new(Vec::new()),
         }
     }
 
@@ -101,6 +105,7 @@ impl Drop for SqliteHost {
         // A guest may terminate between a balanced enter/leave pair. Release
         // those recursive entries before SQLite destroys connection mutexes.
         self.release_entered_mutexes();
+        // Runtime destroys Async Host workers and Jobs before these tables.
         // Statements hold their connections open, so destroy them first.
         for statement in self.statements.get_mut().values() {
             unsafe { ffi::sqlite3_finalize(statement.pointer.as_ptr()) };
@@ -123,6 +128,25 @@ pub(super) mod tests {
             Arc::new(Env::ambient()),
             Arc::new(WorkingDirectory::Ambient),
         ))
+    }
+
+    pub(crate) fn runtime() -> crate::runtime::Runtime {
+        #[cfg(unix)]
+        let mask = {
+            let mut mask = unsafe { std::mem::zeroed() };
+            unsafe { libc::sigemptyset(&mut mask) };
+            mask
+        };
+        crate::runtime::Runtime::new(
+            None,
+            None,
+            None,
+            WorkingDirectory::Ambient,
+            crate::signal_channel().1,
+            #[cfg(unix)]
+            mask,
+        )
+        .unwrap()
     }
 
     pub(super) fn host() -> SqliteHost {

--- a/crates/moonrun/src/sqlite/mutex.rs
+++ b/crates/moonrun/src/sqlite/mutex.rs
@@ -113,7 +113,7 @@ impl SqliteHost {
         debug_assert_eq!(removed, Some(HostResourceKind::SqliteDatabaseMutex));
     }
 
-    pub(super) fn release_entered_mutexes(&mut self) {
+    pub(crate) fn release_entered_mutexes(&mut self) {
         // SqliteHost contains the Runtime's Rc-backed Host Keys and therefore
         // cannot move across threads; SQLite requires leave on the enter thread.
         for mutex in self.mutexes.get_mut().values_mut() {
@@ -173,5 +173,25 @@ impl SqliteHost {
             .ok_or(SqliteHostError::InvalidHandle)?;
         NonNull::new(unsafe { ffi::sqlite3_db_mutex(database.pointer().as_ptr()) })
             .ok_or(SqliteHostError::InvalidHandle)
+    }
+}
+
+/// Explicit protection for connection-field reads, borrowed error memory, and
+/// worker operation/result snapshots. This never spans separate guest calls;
+/// a guest that needs that exclusion uses the exposed Database Mutex itself.
+pub(super) struct DatabaseMutexGuard(*mut ffi::sqlite3_mutex);
+
+impl Database {
+    pub(super) fn lock(self) -> DatabaseMutexGuard {
+        // SAFETY: host Handles and outstanding jobs retain the connection.
+        let mutex = unsafe { ffi::sqlite3_db_mutex(self.pointer().as_ptr()) };
+        unsafe { ffi::sqlite3_mutex_enter(mutex) };
+        DatabaseMutexGuard(mutex)
+    }
+}
+
+impl Drop for DatabaseMutexGuard {
+    fn drop(&mut self) {
+        unsafe { ffi::sqlite3_mutex_leave(self.0) };
     }
 }

--- a/crates/moonrun/src/sqlite/statement.rs
+++ b/crates/moonrun/src/sqlite/statement.rs
@@ -23,7 +23,7 @@ use libsqlite3_sys as ffi;
 use slotmap::Key;
 
 use super::{SqliteHost, SqliteHostError, SqliteHostResult};
-use crate::runtime::{HostResourceKind, null_handle};
+use crate::runtime::{HostKey, HostResourceKind, null_handle};
 
 // `libsqlite3-sys` intentionally omits SQLite's UTF-16 convenience APIs from
 // its generated bindings. The bundled SQLite library still exports them.
@@ -40,6 +40,7 @@ unsafe extern "C" {
 #[derive(Clone, Copy)]
 pub(super) struct Statement {
     pub(super) pointer: NonNull<ffi::sqlite3_stmt>,
+    pub(super) database: HostKey,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -60,42 +61,17 @@ impl SqliteHost {
         database: u64,
         sql: &[u16],
     ) -> SqliteHostResult<PrepareOutcome> {
-        let byte_length = sql
-            .len()
-            .checked_mul(size_of::<u16>())
-            .ok_or(SqliteHostError::Overflow)?;
-        let native_length = i32::try_from(byte_length).map_err(|_| SqliteHostError::Overflow)?;
+        let database_key = self.database_key(database)?;
         let database = self.database(database)?;
-        if !database.is_ready() {
-            return Ok(PrepareOutcome {
-                code: ffi::SQLITE_MISUSE,
-                statement: None,
-                tail_offset: 0,
-            });
-        }
-
-        let native_start = sql.as_ptr().cast::<c_void>();
-        let mut statement = ptr::null_mut();
-        let mut native_tail = ptr::null();
-        let code = unsafe {
-            sqlite3_prepare16_v2(
-                database.pointer().as_ptr(),
-                native_start,
-                native_length,
-                &mut statement,
-                &mut native_tail,
-            )
-        };
-        // SAFETY: SQLite guarantees that `pzTail` points into the supplied SQL
-        // and UTF-16 input keeps both pointers aligned to code units.
-        let tail_offset = unsafe { native_tail.cast::<u16>().offset_from(sql.as_ptr()) };
-        let tail_offset = u32::try_from(tail_offset).map_err(|_| SqliteHostError::Overflow)?;
-        let statement =
-            NonNull::new(statement).map(|pointer| self.insert_statement(Statement { pointer }));
-
+        let (code, statement, tail_offset) = prepare_statement(database, sql)?;
         Ok(PrepareOutcome {
             code,
-            statement,
+            statement: statement.map(|pointer| {
+                self.insert_statement(Statement {
+                    pointer,
+                    database: database_key,
+                })
+            }),
             tail_offset,
         })
     }
@@ -114,6 +90,7 @@ impl SqliteHost {
         if statement == null_handle() {
             return Ok(ffi::SQLITE_OK);
         }
+        self.statement(statement)?;
         let statement = self.remove_statement(statement)?;
         // `sqlite3_finalize` always destroys the statement, even when it
         // reports an earlier execution error. Remove the guest handle before
@@ -121,7 +98,7 @@ impl SqliteHost {
         Ok(unsafe { ffi::sqlite3_finalize(statement.pointer.as_ptr()) })
     }
 
-    fn insert_statement(&self, statement: Statement) -> u64 {
+    pub(super) fn insert_statement(&self, statement: Statement) -> u64 {
         let key = self
             .keys
             .borrow_mut()
@@ -131,12 +108,14 @@ impl SqliteHost {
         key.data().as_ffi()
     }
 
+    /// Validate guest access without acquiring SQLite's connection mutex.
+    /// A worker cannot use this Statement while a synchronous host call does:
+    /// jobs pin it before submission, and guest calls do not overlap each other.
     pub(super) fn statement(&self, handle: u64) -> SqliteHostResult<Statement> {
-        let key = self
-            .keys
-            .borrow()
-            .key(handle, HostResourceKind::SqliteStatement)
-            .ok_or(SqliteHostError::InvalidHandle)?;
+        let key = self.statement_key(handle)?;
+        if self.job_uses_statement(key) {
+            return Err(SqliteHostError::InvalidInput);
+        }
         self.statements
             .borrow()
             .get(key)
@@ -144,7 +123,14 @@ impl SqliteHost {
             .ok_or(SqliteHostError::InvalidHandle)
     }
 
-    fn remove_statement(&self, handle: u64) -> SqliteHostResult<Statement> {
+    pub(super) fn statement_key(&self, handle: u64) -> SqliteHostResult<HostKey> {
+        self.keys
+            .borrow()
+            .key(handle, HostResourceKind::SqliteStatement)
+            .ok_or(SqliteHostError::InvalidHandle)
+    }
+
+    pub(super) fn remove_statement(&self, handle: u64) -> SqliteHostResult<Statement> {
         let key = self
             .keys
             .borrow()
@@ -159,6 +145,38 @@ impl SqliteHost {
         debug_assert_eq!(removed, Some(HostResourceKind::SqliteStatement));
         Ok(statement)
     }
+}
+
+pub(super) fn prepare_statement(
+    database: super::connection::Database,
+    sql: &[u16],
+) -> SqliteHostResult<(i32, Option<NonNull<ffi::sqlite3_stmt>>, u32)> {
+    let native_length = sql
+        .len()
+        .checked_mul(size_of::<u16>())
+        .and_then(|len| i32::try_from(len).ok())
+        .ok_or(SqliteHostError::Overflow)?;
+    if !database.is_ready() {
+        return Ok((ffi::SQLITE_MISUSE, None, 0));
+    }
+    let mut statement = ptr::null_mut();
+    let mut tail = ptr::null();
+    let code = unsafe {
+        sqlite3_prepare16_v2(
+            database.pointer().as_ptr(),
+            sql.as_ptr().cast(),
+            native_length,
+            &mut statement,
+            &mut tail,
+        )
+    };
+    // SQLite's tail belongs to this input; empty/error results may omit it.
+    let offset = if tail.is_null() {
+        0
+    } else {
+        (unsafe { tail.cast::<u16>().offset_from(sql.as_ptr()) }) as u32
+    };
+    Ok((code, NonNull::new(statement), offset))
 }
 
 #[cfg(test)]

--- a/crates/moonrun/src/sqlite/wasm/context.rs
+++ b/crates/moonrun/src/sqlite/wasm/context.rs
@@ -41,6 +41,7 @@ pub(super) fn with_memory_context<T>(
     context.memory_binding().with_memory_mut(scope, |memory| {
         f(&mut ImportContext {
             host: context.runtime().sqlite(),
+            resources: context.runtime().async_host(),
             memory,
         })
     })
@@ -59,6 +60,7 @@ pub(super) fn with_wasmtime_context<T>(
             let (memory, data) = memory.data_and_store_mut(&mut *caller);
             f(&mut ImportContext {
                 host: data.runtime().sqlite(),
+                resources: data.runtime().async_host(),
                 memory,
             })
         }
@@ -67,6 +69,7 @@ pub(super) fn with_wasmtime_context<T>(
             let mut empty = [];
             f(&mut ImportContext {
                 host: data.runtime().sqlite(),
+                resources: data.runtime().async_host(),
                 memory: &mut empty,
             })
         }
@@ -75,6 +78,7 @@ pub(super) fn with_wasmtime_context<T>(
 
 pub(super) struct ImportContext<'a> {
     pub(super) host: &'a SqliteHost,
+    pub(super) resources: &'a crate::async_host::AsyncHost,
     memory: &'a mut [u8],
 }
 
@@ -185,7 +189,7 @@ impl ImportContext<'_> {
         self.write_exact(pointer, &value.to_le_bytes())
     }
 
-    fn write_exact(&mut self, pointer: u32, value: &[u8]) -> SqliteResult<()> {
+    pub(super) fn write_exact(&mut self, pointer: u32, value: &[u8]) -> SqliteResult<()> {
         if pointer == 0 {
             return Err(SqliteError::Fault);
         }
@@ -207,6 +211,15 @@ impl From<V8ImportError> for SqliteError {
     }
 }
 
+impl From<crate::async_host::AsyncHostError> for SqliteError {
+    fn from(error: crate::async_host::AsyncHostError) -> Self {
+        match error {
+            crate::async_host::AsyncHostError::Badf => Self::InvalidHandle,
+            _ => Self::Fault,
+        }
+    }
+}
+
 impl From<SqliteHostError> for SqliteError {
     fn from(error: SqliteHostError) -> Self {
         match error {
@@ -220,25 +233,54 @@ impl From<SqliteHostError> for SqliteError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
-    use std::rc::Rc;
+    use crate::sqlite::tests::runtime;
 
-    use crate::policy::Policy;
-    use crate::runtime::HostKeys;
+    #[test]
+    fn invalid_job_memory_preserves_results_and_database_lifetimes() {
+        use crate::sqlite::wasm::jobs;
 
-    fn host() -> SqliteHost {
-        SqliteHost::new(
-            crate::sqlite::tests::ambient_filesystem(Policy::allow_all()),
-            Rc::new(RefCell::new(HostKeys::default())),
-        )
+        let runtime = runtime();
+        let mut memory = vec![0; 64];
+        memory[2..10].copy_from_slice(b":memory:");
+        let mut context = ImportContext {
+            host: runtime.sqlite(),
+            resources: runtime.async_host(),
+            memory: &mut memory,
+        };
+        let job = jobs::make_open_job(&mut context, 2, 8, 6).unwrap();
+        context.resources.run_job(job).unwrap();
+        assert_eq!(
+            jobs::job_result(&mut context, job, 0),
+            Err(SqliteError::Fault)
+        );
+        assert_eq!(
+            jobs::job_result(&mut context, job, 48),
+            Err(SqliteError::Fault)
+        );
+        jobs::job_result(&mut context, job, 16).unwrap();
+        let database = jobs::take_job_handle(&mut context, job).unwrap();
+        assert_eq!(
+            jobs::take_job_handle(&mut context, job),
+            Err(SqliteError::Fault)
+        );
+        assert_eq!(
+            jobs::make_prepare_job(&mut context, database, 62, 0, 2),
+            Err(SqliteError::Fault)
+        );
+        // Neither a transferred open result nor rejected SQL memory pins the
+        // connection. The still-readable open result contains no native pointer.
+        assert_eq!(context.host.close(database), Ok(libsqlite3_sys::SQLITE_OK));
+        jobs::job_result(&mut context, job, 16).unwrap();
+        context.resources.free_job(job).unwrap();
     }
 
     #[test]
     fn utf16_view_uses_code_unit_offsets_and_lengths() {
-        let host = host();
+        let runtime = runtime();
         let mut memory = (0_u8..16).collect::<Vec<_>>();
         let context = ImportContext {
-            host: &host,
+            host: runtime.sqlite(),
+            resources: runtime.async_host(),
             memory: &mut memory,
         };
 
@@ -255,10 +297,11 @@ mod tests {
 
     #[test]
     fn utf8_c_string_adds_termination_after_the_explicit_length() {
-        let host = host();
+        let runtime = runtime();
         let mut memory = b"x:memory:".to_vec();
         let context = ImportContext {
-            host: &host,
+            host: runtime.sqlite(),
+            resources: runtime.async_host(),
             memory: &mut memory,
         };
 
@@ -267,10 +310,11 @@ mod tests {
 
     #[test]
     fn utf8_c_string_rejects_interior_nul_and_invalid_utf8() {
-        let host = host();
+        let runtime = runtime();
         let mut memory = b"xabc\0def\xff".to_vec();
         let context = ImportContext {
-            host: &host,
+            host: runtime.sqlite(),
+            resources: runtime.async_host(),
             memory: &mut memory,
         };
 
@@ -280,10 +324,11 @@ mod tests {
 
     #[test]
     fn byte_view_uses_byte_offsets_and_lengths() {
-        let host = host();
+        let runtime = runtime();
         let mut memory = (0_u8..8).collect::<Vec<_>>();
         let context = ImportContext {
-            host: &host,
+            host: runtime.sqlite(),
+            resources: runtime.async_host(),
             memory: &mut memory,
         };
 

--- a/crates/moonrun/src/sqlite/wasm/jobs.rs
+++ b/crates/moonrun/src/sqlite/wasm/jobs.rs
@@ -1,0 +1,117 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! SQLite job construction and result copying. Scheduling, completion, status
+//! transport, and release use the existing moonbitlang/async thread-pool ABI.
+use super::context::{ImportContext, SqliteError, SqliteResult};
+
+pub(super) fn make_open_job(
+    context: &mut ImportContext<'_>,
+    filename: u32,
+    length: i32,
+    flags: i32,
+) -> SqliteResult<u64> {
+    let length = u32::try_from(length).map_err(|_| SqliteError::Fault)?;
+    let filename = context.read_utf8_c_string(filename, length)?;
+    Ok(context
+        .resources
+        .insert_job(context.host.make_open_job(filename, flags))?)
+}
+
+pub(super) fn make_prepare_job(
+    context: &mut ImportContext<'_>,
+    database: u64,
+    sql: u32,
+    offset: i32,
+    length: i32,
+) -> SqliteResult<u64> {
+    let offset = u32::try_from(offset).map_err(|_| SqliteError::Fault)?;
+    let length = u32::try_from(length).map_err(|_| SqliteError::Fault)?;
+    let sql = context.read_utf16_view(sql, offset, length)?.to_vec();
+    let job = context.host.make_prepare_job(database, sql)?;
+    Ok(context.resources.insert_job(job)?)
+}
+
+pub(super) fn make_step_job(
+    context: &mut ImportContext<'_>,
+    database: u64,
+    statement: u64,
+) -> SqliteResult<u64> {
+    let job = context.host.make_step_job(database, statement)?;
+    Ok(context.resources.insert_job(job)?)
+}
+
+pub(super) fn make_finalize_job(
+    context: &mut ImportContext<'_>,
+    database: u64,
+    statement: u64,
+) -> SqliteResult<u64> {
+    let job = context.host.make_finalize_job(database, statement)?;
+    Ok(context.resources.insert_job(job)?)
+}
+
+pub(super) fn make_discard_job(context: &mut ImportContext<'_>, job: u64) -> SqliteResult<u64> {
+    let cleanup = context
+        .resources
+        .with_job_mut(job, |job| -> SqliteResult<_> {
+            Ok(context.host.make_discard_job(job.sqlite_mut()?)?)
+        })??;
+    match cleanup {
+        Some(cleanup) => Ok(context.resources.insert_job(cleanup)?),
+        None => Ok(crate::runtime::null_handle()),
+    }
+}
+
+pub(super) fn job_result(
+    context: &mut ImportContext<'_>,
+    job: u64,
+    output: u32,
+) -> SqliteResult<()> {
+    context.validate_write(output, 24)?;
+    let mut result = [0; 24];
+    context
+        .resources
+        .with_job(job, |job| -> SqliteResult<()> {
+            Ok(job.sqlite()?.copy_result(&mut result)?)
+        })??;
+    context.write_exact(output, &result)
+}
+
+pub(super) fn take_job_handle(context: &mut ImportContext<'_>, job: u64) -> SqliteResult<u64> {
+    context.resources.with_job_mut(job, |job| {
+        Ok(context.host.take_job_handle(job.sqlite_mut()?)?)
+    })?
+}
+
+pub(super) fn job_message16_length(context: &mut ImportContext<'_>, job: u64) -> SqliteResult<u32> {
+    context
+        .resources
+        .with_job(job, |job| Ok(job.sqlite()?.message16_length()?))?
+}
+
+pub(super) fn job_message16(
+    context: &mut ImportContext<'_>,
+    job: u64,
+    output: u32,
+    capacity: u32,
+) -> SqliteResult<u32> {
+    let resources = context.resources;
+    context.with_utf16_output(output, capacity, |_, output| {
+        resources.with_job(job, |job| Ok(job.sqlite()?.copy_message16(output)?))?
+    })
+}

--- a/crates/moonrun/src/sqlite/wasm/mod.rs
+++ b/crates/moonrun/src/sqlite/wasm/mod.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Synchronous Wasm adapter for the SQLite Host interface.
+//! Wasm adapter for the SQLite Host interface.
 //!
 //! The `sqlite3_*` imports keep SQLite-shaped operations while adapting native
 //! pointers to a portable wasm ABI. Guest-memory pointers are unsigned wasm
@@ -34,13 +34,17 @@
 //! pointers. Column names follow the same length-and-copy convention. SQLite
 //! behavior and policy belong to the parent `sqlite` module; this adapter only
 //! lowers engine values and Guest Memory.
-//! Callback-bearing extension APIs, varargs, process-global configuration,
-//! custom VFSes, and file-backed databases are outside the MVP.
+//! One-shot jobs copy inputs before submission, capture owned results, and use
+//! the existing async pool for scheduling and completion. Prepare tails are relative
+//! to the copied SQL view. See `docs/dev/sqlite-jobs.md` for ownership rules.
+//! Callback-bearing extension APIs, varargs, process-global configuration, and
+//! custom VFSes are not supported.
 
 mod bind;
 mod column;
 mod connection;
 mod context;
+mod jobs;
 mod registry;
 mod registry_macros;
 mod statement;

--- a/crates/moonrun/src/sqlite/wasm/registry.rs
+++ b/crates/moonrun/src/sqlite/wasm/registry.rs
@@ -27,7 +27,7 @@ use super::registry_macros::{
     decode_wasmtime_arg, finish_wasmtime_sqlite_import, invoke_wasmtime_sqlite_import,
     wasmtime_arg_type, wasmtime_return_type,
 };
-use super::{bind, column, connection, statement};
+use super::{bind, column, connection, jobs, statement};
 #[cfg(feature = "v8")]
 use crate::v8::context::{ImportArgs, V8ImportError, V8RunContext};
 
@@ -39,6 +39,16 @@ pub(crate) const MOONBIT_SQLITE_MODULE: &str = "moonbitlang/sqlite";
 // target; the registry does not expose how the macro reaches that target.
 declare_sqlite_imports! {
     Runtime::null_handle() -> u64 => "sqlite3_null_handle";
+
+    jobs::make_open_job(filename: u32, length: i32, flags: i32) -> u64 => "sqlite3_make_open_job";
+    jobs::make_prepare_job(database: u64, sql: u32, offset: i32, length: i32) -> u64 => "sqlite3_make_prepare_job";
+    jobs::make_step_job(database: u64, statement: u64) -> u64 => "sqlite3_make_step_job";
+    jobs::make_finalize_job(database: u64, statement: u64) -> u64 => "sqlite3_make_finalize_job";
+    jobs::make_discard_job(job: u64) -> u64 => "sqlite3_make_discard_job";
+    jobs::job_result(job: u64, output: u32) -> void => "sqlite3_job_result";
+    jobs::take_job_handle(job: u64) -> u64 => "sqlite3_take_job_handle";
+    jobs::job_message16_length(job: u64) -> u32 => "sqlite3_job_message16_length";
+    jobs::job_message16(job: u64, output: u32, capacity: u32) -> u32 => "sqlite3_job_message16";
 
     connection::open_v2(
         filename: u32,

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -1074,6 +1074,37 @@ fn test_moon_run_with_async_host_imports() {
 }
 
 #[test]
+fn sqlite_jobs_share_the_async_pool_from_moonbit() {
+    let dir = TestDir::new("test_sqlite_async.in");
+    let upstream = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../third_party/moonbitlang_async");
+    // Exercise the small companion guest entry point against the pinned async
+    // implementation without modifying the submodule or its generated files.
+    moon_test_util::test_dir::copy_tree(&upstream.join("src"), &dir.join("async/src"), false)
+        .unwrap();
+    std::fs::copy(upstream.join("moon.mod"), dir.join("async/moon.mod")).unwrap();
+    std::fs::copy(
+        dir.join("support/host_job.wasm.mbt"),
+        dir.join("async/src/internal/event_loop/host_job.wasm.mbt"),
+    )
+    .unwrap();
+    std::fs::copy(
+        dir.join("support/host_job_export.wasm.mbt"),
+        dir.join("async/src/host_job_export.wasm.mbt"),
+    )
+    .unwrap();
+    moon_test_util::test_dir::copy_tree(&dir.join("test"), &dir.join("async/src/test"), false)
+        .unwrap();
+    moon_cmd()
+        .current_dir(dir.join("async"))
+        .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
+        .args(["test", "--target", "wasm", "src/test"])
+        .assert()
+        .success()
+        .stdout_eq("Total tests: 6, passed: 6, failed: 0.\n");
+}
+
+#[test]
 fn test_moon_run_with_sqlite_ffi_imports() {
     let dir = TestDir::new("test_sqlite_ffi.in");
 

--- a/crates/moonrun/tests/test_cases/test_sqlite_async.in/support/host_job.wasm.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_async.in/support/host_job.wasm.mbt
@@ -1,16 +1,20 @@
-// Copyright 2025 International Digital Economy Academy
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 // Companion entry point for moonbitlang/async. Kept outside the submodule so
 // the integration harness can apply it to a disposable copy of the pinned

--- a/crates/moonrun/tests/test_cases/test_sqlite_async.in/support/host_job.wasm.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_async.in/support/host_job.wasm.mbt
@@ -1,0 +1,25 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Companion entry point for moonbitlang/async. Kept outside the submodule so
+// the integration harness can apply it to a disposable copy of the pinned
+// upstream sources. It reuses the existing worker queue and completion path.
+
+///|
+#cfg(target="wasm")
+pub async fn perform_host_job(handle : UInt64, context~ : String) -> Int {
+  // The caller owns the host Job and releases it after copying/taking results.
+  // Default non-interrupting cancellation waits for submitted work to finish.
+  perform_job_in_worker(Job::Job(JobHandle(handle)), context~)
+}

--- a/crates/moonrun/tests/test_cases/test_sqlite_async.in/support/host_job_export.wasm.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_async.in/support/host_job_export.wasm.mbt
@@ -1,0 +1,17 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(target="wasm")
+pub using @event_loop {perform_host_job}

--- a/crates/moonrun/tests/test_cases/test_sqlite_async.in/support/host_job_export.wasm.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_async.in/support/host_job_export.wasm.mbt
@@ -1,16 +1,20 @@
-// Copyright 2025 International Digital Economy Academy
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 ///|
 #cfg(target="wasm")

--- a/crates/moonrun/tests/test_cases/test_sqlite_async.in/test/ffi.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_async.in/test/ffi.mbt
@@ -1,0 +1,179 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+///|
+#unsafe_skip_stub_check
+#borrow(filename)
+fn make_open_job(filename : Bytes, length : Int, flags : Int) -> UInt64 = "moonbitlang/sqlite" "sqlite3_make_open_job"
+
+///|
+#unsafe_skip_stub_check
+#borrow(sql)
+fn make_prepare_job(
+  database : UInt64,
+  sql : String,
+  offset : Int,
+  length : Int,
+) -> UInt64 = "moonbitlang/sqlite" "sqlite3_make_prepare_job"
+
+///|
+fn make_step_job(database : UInt64, statement : UInt64) -> UInt64 = "moonbitlang/sqlite" "sqlite3_make_step_job"
+
+///|
+fn make_finalize_job(database : UInt64, statement : UInt64) -> UInt64 = "moonbitlang/sqlite" "sqlite3_make_finalize_job"
+
+///|
+fn make_discard_job(job : UInt64) -> UInt64 = "moonbitlang/sqlite" "sqlite3_make_discard_job"
+
+///|
+fn null_handle() -> UInt64 = "moonbitlang/sqlite" "sqlite3_null_handle"
+
+///|
+#unsafe_skip_stub_check
+#borrow(output)
+fn copy_result(job : UInt64, output : FixedArray[Int]) -> Unit = "moonbitlang/sqlite" "sqlite3_job_result"
+
+///|
+fn take_handle(job : UInt64) -> UInt64 = "moonbitlang/sqlite" "sqlite3_take_job_handle"
+
+///|
+fn message_length(job : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_job_message16_length"
+
+///|
+#unsafe_skip_stub_check
+#borrow(output)
+fn copy_message(job : UInt64, output : String, capacity : Int) -> Int = "moonbitlang/sqlite" "sqlite3_job_message16"
+
+///|
+fn free_job(job : UInt64) -> Unit = "moonbitlang/async" "thread_pool/free_job"
+
+///|
+fn close(database : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_close"
+
+///|
+fn finalize(statement : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_finalize"
+
+///|
+fn column_int64(statement : UInt64, column : Int) -> Int64 = "moonbitlang/sqlite" "sqlite3_column_int64"
+
+///|
+struct Database {
+  handle : UInt64
+  mutex : @async.Mutex
+}
+
+///|
+fn job_message(job : UInt64) -> String raise {
+  let length = message_length(job)
+  let output = String::make(length, '\u0000')
+  assert_eq(copy_message(job, output, length), length)
+  output
+}
+
+///|
+fn job_result(job : UInt64) -> (Int, Int, Int, Int64?) {
+  let output = FixedArray::make(6, 0)
+  copy_result(job, output)
+  let changes = if output[3] == 0 {
+    None
+  } else {
+    Some(
+      output[4].reinterpret_as_uint().to_int64() | (output[5].to_int64() << 32),
+    )
+  }
+  (output[0], output[1], output[2], changes)
+}
+
+///|
+async fn Database::open() -> Database {
+  @async.protect_from_cancel() <| () => {
+    let job = make_open_job(b":memory:", 8, 6)
+    defer free_job(job)
+    assert_eq(@async.perform_host_job(job, context="sqlite open"), 0)
+    { handle: take_handle(job), mutex: @async.Mutex(), }
+  }
+}
+
+///|
+async fn Database::run(self : Database, job : UInt64) -> Int {
+  self.mutex.acquire()
+  defer self.mutex.release()
+  @async.perform_host_job(job, context="sqlite job")
+}
+
+///|
+suberror InvalidSql
+
+///|
+async fn Database::prepare(self : Database, sql : String) -> UInt64 {
+  let job = make_prepare_job(self.handle, sql, 0, sql.length())
+  defer free_job(job)
+  @async.protect_from_cancel(() => assert_eq(self.run(job), 0))
+  let (_, _, tail, _) = job_result(job)
+  if tail < 0 {
+    raise InvalidSql
+  }
+  if tail != sql.length() || @async.is_being_cancelled() {
+    @async.protect_from_cancel() <| () => {
+      let discard = make_discard_job(job)
+      assert_true(discard != null_handle())
+      defer free_job(discard)
+      assert_eq(self.run(discard), 0)
+    }
+    if tail != sql.length() {
+      raise InvalidSql
+    }
+    @async.pause()
+  }
+  take_handle(job)
+}
+
+///|
+async fn Database::finalize(self : Database, statement : UInt64) -> Unit {
+  @async.protect_from_cancel() <| () => {
+    let job = make_finalize_job(self.handle, statement)
+    defer free_job(job)
+    assert_eq(self.run(job), 0)
+  }
+}
+
+///|
+async fn Database::step(self : Database, statement : UInt64) -> (Int, Int64?) {
+  let result = @async.protect_from_cancel() <| () => {
+    let job = make_step_job(self.handle, statement)
+    defer free_job(job)
+    let status = self.run(job)
+    let (code, extended, _, changes) = job_result(job)
+    assert_eq(status, code)
+    assert_eq(code, extended)
+    (code, changes)
+  }
+  if @async.is_being_cancelled() {
+    @async.pause()
+  }
+  result
+}
+
+///|
+async fn Database::execute(self : Database, sql : String) -> Int64? {
+  let statement = self.prepare(sql)
+  defer self.finalize(statement)
+  let (code, changes) = self.step(statement)
+  assert_eq(code, 101)
+  changes
+}

--- a/crates/moonrun/tests/test_cases/test_sqlite_async.in/test/moon.pkg
+++ b/crates/moonrun/tests/test_cases/test_sqlite_async.in/test/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+}

--- a/crates/moonrun/tests/test_cases/test_sqlite_async.in/test/test.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_async.in/test/test.mbt
@@ -1,0 +1,135 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+///|
+async test "discard an unaccepted open without publishing a database handle" {
+  let unaccepted = make_open_job(b":memory:", 8, 6)
+  assert_eq(@async.perform_host_job(unaccepted, context="unaccepted open"), 0)
+  let discard = make_discard_job(unaccepted)
+  assert_true(discard != null_handle())
+  assert_eq(make_discard_job(unaccepted), null_handle())
+  free_job(unaccepted)
+  assert_eq(@async.perform_host_job(discard, context="discard open"), 0)
+  free_job(discard)
+}
+
+///|
+async test "SQLite jobs remain ordered alongside filesystem work" {
+  let database = Database::open()
+  defer assert_eq(close(database.handle), 0)
+  assert_eq(database.execute("CREATE TABLE entries(value INTEGER)"), Some(0L))
+  @async.with_task_group() <| group => {
+    for value in [1, 2, 3] {
+      group.spawn_bg() <| () => {
+        assert_eq(
+          database.execute("INSERT INTO entries VALUES (\{value})"),
+          Some(1L),
+        )
+      }
+    }
+    group.spawn_bg() <| () => { ignore(@fs.read_file("moon.mod")) }
+  }
+  let ordered = database.prepare(
+    "SELECT group_concat(value, '') + 0 FROM entries",
+  )
+  assert_eq(database.step(ordered), (100, None))
+  assert_eq(column_int64(ordered, 0), 123L)
+  assert_eq(database.step(ordered), (101, None))
+  database.finalize(ordered)
+  assert_eq(
+    database.execute("UPDATE entries SET value=9 WHERE value=99"),
+    Some(0L),
+  )
+}
+
+///|
+async test "prepare tail is relative to the SQL view" {
+  let database = Database::open()
+  defer assert_eq(close(database.handle), 0)
+  let view = make_prepare_job(database.handle, "xxSELECT 42;yy", 2, 10)
+  assert_eq(database.run(view), 0)
+  assert_eq(job_result(view), (0, 0, 10, None))
+  let statement = take_handle(view)
+  free_job(view)
+  assert_eq(database.step(statement), (100, None))
+  assert_eq(column_int64(statement, 0), 42L)
+  assert_eq(finalize(statement), 0)
+}
+
+///|
+async test "job error snapshots survive later operations" {
+  let database = Database::open()
+  defer assert_eq(close(database.handle), 0)
+  let failed = make_prepare_job(
+    database.handle,
+    "SELECT missing_column",
+    0,
+    21,
+  )
+  defer free_job(failed)
+  assert_eq(database.run(failed), 1)
+  assert_eq(database.execute("CREATE TABLE entries(value INTEGER)"), Some(0L))
+  assert_true(job_message(failed).contains("missing_column"))
+}
+
+///|
+async test "prepare discards rejected trailing statements" {
+  let database = Database::open()
+  defer assert_eq(close(database.handle), 0)
+  try database.prepare("SELECT 1; SELECT 2") catch {
+    InvalidSql => ()
+    error => raise error
+  } noraise {
+    _ => fail("expected rejected SQL")
+  }
+}
+
+///|
+async test "cancelled step preserves event loop progress and connection reuse" {
+  let database = Database::open()
+  defer assert_eq(close(database.handle), 0)
+  let slow = database.prepare(
+    "WITH RECURSIVE n(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM n WHERE x<2000000) SELECT sum(x) FROM n",
+  )
+  let ticks = Ref(0)
+  let finished = Ref(false)
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
+      while !finished.val {
+        @async.sleep(1)
+        if !finished.val {
+          ticks.val += 1
+        }
+      }
+    }
+    group.spawn_bg() <| () => {
+      defer {
+        finished.val = true
+      }
+      try @async.with_timeout(1, () => database.step(slow)) catch {
+        @async.TimeoutError => ()
+        error => raise error
+      } noraise {
+        _ => fail("expected cancellation")
+      }
+    }
+  }
+  assert_true(ticks.val > 0)
+  assert_eq(finalize(slow), 0)
+  assert_eq(database.execute("CREATE TABLE after_cancel(value INTEGER)"), Some(0L))
+}


### PR DESCRIPTION
- Related issues: [SQLite async API](https://github.com/moonbit-community/sqlite3.mbt/pull/23)
- PR kind: Feature

## Summary

SQLite calls on Wasm currently run synchronously and can block the event loop. Add host jobs for open, prepare, step, finalize, and unclaimed-result disposal, executed through the existing async worker pool on V8 and Wasmtime.

Jobs own their copied inputs and captured results. Lifetime leases keep databases and statements valid through execution, detachment, and disposal; workers capture diagnostics and change counts together with the operation. Open and prepare results transfer their native resource once, and runtime teardown joins workers before destroying SQLite state. The common job release lifecycle also disposes of abandoned resources.

The change reuses the existing scheduling, completion, and release ABI while keeping SQLite operation semantics in the SQLite host. MoonBit async tests exercise pool sharing, result ownership, SQL views, captured diagnostics, cancellation, and event-loop progress.

This PR supplies the moonrun host support. Package-level use also requires the companion `sqlite3.mbt` Wasm wrapper and a Wasm-only `moonbitlang/async.perform_host_job` bridge; the integration fixture applies that bridge to the pinned async source. Native SQLite retains its dedicated executor. A general typed resource abstraction is deferred to a separate refactor.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
