### PR TITLE
support -stacktrace

### DIFF
--- a/crates/moon/src/tests/planner/profile_planning.rs
+++ b/crates/moon/src/tests/planner/profile_planning.rs
@@ -396,6 +396,11 @@ fn native_run_cli_flags_match_requested_debug_info() {
                 );
                 assert!(tokens.iter().any(|token| token == "-O0"), "{tokens:?}");
                 assert_eq!(
+                    tokens.iter().any(|token| token == "-stacktrace"),
+                    label == "default" && !generates_c,
+                    "{case}: {label}: {tokens:?}"
+                );
+                assert_eq!(
                     tokens.iter().any(|token| token == "-g"),
                     expect_debug_info.unwrap_or(generates_c),
                     "{case}: {label}: {tokens:?}"

--- a/crates/moon/tests/test_cases/moon_prove/warn_suppression.in/lib/hello_test.mbt
+++ b/crates/moon/tests/test_cases/moon_prove/warn_suppression.in/lib/hello_test.mbt
@@ -1,3 +1,3 @@
 test "value" {
-  inspect!(value(), content="1")
+  inspect(value(), content="1")
 }

--- a/crates/moon/tests/test_cases/moon_test/doctest_without_bbtest/lib/hello.mbt
+++ b/crates/moon/tests/test_cases/moon_test/doctest_without_bbtest/lib/hello.mbt
@@ -1,5 +1,5 @@
 /// ```mbt test
-/// inspect!(add(1, 2), content="3")
+/// inspect(add(1, 2), content="3")
 /// ```
 pub fn add(a: Int, b: Int) -> Int {
   a + b

--- a/crates/moon/tests/test_cases/native_backend/test_filter/lib/hello.mbt
+++ b/crates/moon/tests/test_cases/native_backend/test_filter/lib/hello.mbt
@@ -21,6 +21,6 @@ test "C" {
 
 test "D" (it: @test.Test) {
   it.writeln("test D")
-  it.snapshot!(filename = "test.d")
+  it.snapshot(filename = "test.d")
 }
 

--- a/crates/moon/tests/test_cases/snapshot_testing.in/src/lib/hello.mbt
+++ b/crates/moon/tests/test_cases/snapshot_testing.in/src/lib/hello.mbt
@@ -11,7 +11,7 @@ test "test snapshot 1" (it : @test.Test) {
   it.writeln("hello")
   it.writeln("snapshot")
   it.writeln("testing")
-  it.snapshot!(filename="001.txt")
+  it.snapshot(filename="001.txt")
 }
 
 test "test inspect 2" {
@@ -23,5 +23,5 @@ test "test snapshot 2" (it : @test.Test) {
   it.writeln("should")
   it.writeln("be")
   it.writeln("work")
-  it.snapshot!(filename="002.txt")
+  it.snapshot(filename="002.txt")
 }

--- a/crates/moon/tests/test_cases/snapshot_testing.in/src/lib/hello_test.mbt
+++ b/crates/moon/tests/test_cases/snapshot_testing.in/src/lib/hello_test.mbt
@@ -6,5 +6,5 @@ test "hello" {
 
 test "snapshot in blackbox test" (it : @test.Test) {
   it.write(@lib.hello())
-  it.snapshot!(filename="003.txt")
+  it.snapshot(filename="003.txt")
 }

--- a/crates/moon/tests/test_cases/snapshot_testing/mod.rs
+++ b/crates/moon/tests/test_cases/snapshot_testing/mod.rs
@@ -111,7 +111,7 @@ fn test_snapshot_test_target_js() {
               it.writeln("hello")
               it.writeln("snapshot")
               it.writeln("testing")
-              it.snapshot!(filename="001.txt")
+              it.snapshot(filename="001.txt")
             }
 
             test "test inspect 2" {
@@ -125,7 +125,7 @@ fn test_snapshot_test_target_js() {
               it.writeln("should")
               it.writeln("be")
               it.writeln("work")
-              it.snapshot!(filename="002.txt")
+              it.snapshot(filename="002.txt")
             }
         "#]],
     );
@@ -280,7 +280,7 @@ fn test_snapshot_test() {
               it.writeln("hello")
               it.writeln("snapshot")
               it.writeln("testing")
-              it.snapshot!(filename="001.txt")
+              it.snapshot(filename="001.txt")
             }
 
             test "test inspect 2" {
@@ -294,7 +294,7 @@ fn test_snapshot_test() {
               it.writeln("should")
               it.writeln("be")
               it.writeln("work")
-              it.snapshot!(filename="002.txt")
+              it.snapshot(filename="002.txt")
             }
         "#]],
     );

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_package.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_package.rs
@@ -107,6 +107,9 @@ impl<'a> CmdlineAbstraction for MooncBuildPackage<'a> {
         if self.flags.no_opt {
             args.push("-O0".to_string());
         }
+        if self.flags.stacktrace {
+            args.push("-stacktrace".to_string());
+        }
 
         // Additional compilation flags
         if self.flags.source_map {

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/link_core.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/link_core.rs
@@ -202,6 +202,9 @@ impl CmdlineAbstraction for MooncLinkCore<'_> {
         if self.flags.no_opt {
             args.push("-O0".to_string());
         }
+        if self.flags.stacktrace {
+            args.push("-stacktrace".to_string());
+        }
 
         // Source map
         if self.flags.source_map {

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/mod.rs
@@ -197,6 +197,8 @@ pub(super) struct CompilationFlags {
     pub no_opt: bool,
     /// Include debug symbols (adds -g)
     pub symbols: bool,
+    /// Include lightweight direct-native backtrace metadata (adds -stacktrace)
+    pub stacktrace: bool,
     /// Emit source map file for supported backends (JS and WASM)
     pub source_map: bool,
     /// Enable code coverage instrumentation.

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -78,6 +78,7 @@ impl<'a> LoweringContext<'a> {
         compiler::CompilationFlags {
             no_opt: self.opt.opt_level == OptLevel::Debug,
             symbols: debug_info,
+            stacktrace: self.plan.backend_plan().moonc_stacktrace(),
             source_map: self.opt.backend.target_backend().supports_source_map() && debug_info,
             enable_coverage: false,
             self_coverage: false,

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -119,6 +119,9 @@ pub(crate) struct BackendPlan {
     /// Native compiler settings belong to their individual action metadata.
     moonc_debug_info: bool,
 
+    /// Lightweight source backtraces for direct MoonBit object output.
+    moonc_stacktrace: bool,
+
     /// Planned backend actions, in stable insertion order.
     actions: IndexSet<BuildPlanNode>,
 
@@ -156,6 +159,10 @@ pub(crate) struct BackendPlan {
 impl BackendPlan {
     pub(crate) fn moonc_debug_info(&self) -> bool {
         self.moonc_debug_info
+    }
+
+    pub(crate) fn moonc_stacktrace(&self) -> bool {
+        self.moonc_stacktrace
     }
 
     pub(crate) fn native_mode(&self) -> &NativeBackendMode {
@@ -820,10 +827,12 @@ pub fn build_plan(
     constructor.res.backend.moonc_debug_info = match config.debug_info.symbols {
         DebugSymbols::None => false,
         DebugSymbols::Full => true,
-        // Direct objects retain backtrace metadata with -O0 alone. Generated C
+        // Direct objects use -stacktrace for backtrace metadata. Generated C
         // needs moonc -g for accurate source locations in its #line directives.
         DebugSymbols::Backtrace => constructor.res.backend.direct_native_target().is_none(),
     };
+    constructor.res.backend.moonc_stacktrace = config.debug_info.symbols == DebugSymbols::Backtrace
+        && constructor.res.backend.direct_native_target().is_some();
     // Preserve the caller-requested executable scope for Native selection,
     // then drop test artifacts excluded by the standard-library special cases.
     constructor.build(input.into_iter().filter(|artifact| {

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -390,6 +390,11 @@ mod tests {
                         opt_level == OptLevel::Debug,
                         "{args:?}"
                     );
+                    assert_eq!(
+                        args.iter().any(|arg| arg == "-stacktrace"),
+                        !generated_c && symbols == DebugSymbols::Backtrace,
+                        "{args:?}"
+                    );
                     if command == "link-core" {
                         let output = args
                             .windows(2)

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -115,7 +115,8 @@ backend into `DebugInfoRequest`, selecting requested symbol detail and native
 runtime backtrace support separately. A default `moon run` for the Native target
 backend requests source backtraces. After selecting the Native Payload Form,
 backend planning retains MoonBit debug information for generated C and omits it
-for direct object output, which keeps `-O0` and stack-trace metadata alone.
+for direct object output, which uses `-O0 -stacktrace` for unoptimized code
+and lightweight stack-trace metadata.
 The generated-C compiler step separately retains the source locations emitted
 by MoonBit. This includes C output selected by
 `MOONBIT_NEW_NATIVE=0`, an unsupported direct-object host, or package C compiler

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -111,6 +111,8 @@ same spelling are not interchangeable across the build stages:
 - `moonc build-package` and `moonc link-core` receive `-g` for MoonBit debug
   information and `-O0` for the debug optimization profile. For generated C,
   `link-core -g` preserves accurate MoonBit locations in C `#line` directives.
+  Direct-object source-backtrace requests add `-stacktrace` separately from
+  `-O0`; full-debug requests continue to use `-g`.
 - Compiling that C requires native debug information as well, so the C compiler
   can retain those locations in the executable. GCC-like compilers use `-g`;
   MSVC uses `/Z7`.


### PR DESCRIPTION
machine后端的-O0原本会带一个轻量的调用栈，这个解耦了。

现在的moonc的machie native后端，-O0是不做优化，-g是完整调试信息，-stacktrace是生成轻量的调用栈（-g是完整调用栈）

moon run --target native(非C后端）,会使用-O0 -stacktrace