### PR TITLE
feat(prebuild): expose script inputs through environment variables

### DIFF
--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -88,7 +88,10 @@ pub(crate) fn run_bench(
     super::validate_test_or_bench_invocation(&cli, &bench_cmd)?;
     let resolve_output =
         super::sync_and_resolve_test_or_bench_project(&cli, &bench_cmd, &dirs, output.user_log())?;
-    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    }
     super::run_test_or_bench_from_resolved(
         &cli,
         &bench_cmd,

--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -88,10 +88,7 @@ pub(crate) fn run_bench(
     super::validate_test_or_bench_invocation(&cli, &bench_cmd)?;
     let resolve_output =
         super::sync_and_resolve_test_or_bench_project(&cli, &bench_cmd, &dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
+    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
     super::run_test_or_bench_from_resolved(
         &cli,
         &bench_cmd,

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -205,6 +205,7 @@ fn run_build_for_single_file_rr(
             vec![UserIntent::Build(package)].into(),
             mooncake_bin_dir,
             resolved.clone(),
+            cmd.build_flags.jobs,
             cmd.auto_sync_flags.frozen,
         )?);
     }
@@ -437,6 +438,7 @@ pub(crate) fn plan_build_rr_from_resolved(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )
 }
@@ -473,6 +475,7 @@ fn plan_build_rr_from_resolved_with_scope(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )
 }
@@ -504,6 +507,7 @@ fn plan_build_rr_from_selection(
         selection.into_user_intent(),
         mooncake_bin_dir,
         resolve_output,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )
 }

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -125,10 +125,7 @@ pub(crate) fn run_build(
     }
 
     let resolve_output = sync_and_resolve_build_project(cli, &cmd, &dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
+    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
     let result =
         run_build_rr_from_resolved(cli, &cmd, &dirs, false, &targets, resolve_output, output)
             .with_context(|| match targets.as_slice() {
@@ -180,10 +177,7 @@ fn run_build_for_single_file_rr(
         selected_target_backends.iter().copied().map(Some).collect()
     };
 
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(target_dir, user_log)?;
-    }
+    let _lock = lock_directory(target_dir, user_log)?;
 
     let package = rr_build::local_packages(&resolved)
         .next()
@@ -290,10 +284,7 @@ fn run_build_rr(
     output: &CommandOutput,
 ) -> anyhow::Result<WatchOutput> {
     let resolve_output = sync_and_resolve_build_project(cli, cmd, dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
+    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
     run_build_rr_from_resolved(
         cli,
         cmd,
@@ -307,7 +298,7 @@ fn run_build_rr(
 
 /// Plans and executes a build from resolved project data.
 ///
-/// The caller must hold the target-directory lock for a non-dry-run build.
+/// The caller must hold the target-directory lock, including for dry runs.
 #[allow(clippy::too_many_arguments)]
 fn run_build_rr_from_resolved(
     cli: &UniversalFlags,

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -125,7 +125,10 @@ pub(crate) fn run_build(
     }
 
     let resolve_output = sync_and_resolve_build_project(cli, &cmd, &dirs, output.user_log())?;
-    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    }
     let result =
         run_build_rr_from_resolved(cli, &cmd, &dirs, false, &targets, resolve_output, output)
             .with_context(|| match targets.as_slice() {
@@ -177,7 +180,10 @@ fn run_build_for_single_file_rr(
         selected_target_backends.iter().copied().map(Some).collect()
     };
 
-    let _lock = lock_directory(target_dir, user_log)?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(target_dir, user_log)?;
+    }
 
     let package = rr_build::local_packages(&resolved)
         .next()
@@ -201,6 +207,7 @@ fn run_build_for_single_file_rr(
             resolved.clone(),
             cmd.build_flags.jobs,
             cmd.auto_sync_flags.frozen,
+            cli.dry_run,
         )?);
     }
 
@@ -284,7 +291,10 @@ fn run_build_rr(
     output: &CommandOutput,
 ) -> anyhow::Result<WatchOutput> {
     let resolve_output = sync_and_resolve_build_project(cli, cmd, dirs, output.user_log())?;
-    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    }
     run_build_rr_from_resolved(
         cli,
         cmd,
@@ -298,7 +308,7 @@ fn run_build_rr(
 
 /// Plans and executes a build from resolved project data.
 ///
-/// The caller must hold the target-directory lock, including for dry runs.
+/// The caller must hold the target-directory lock for a non-dry-run build.
 #[allow(clippy::too_many_arguments)]
 fn run_build_rr_from_resolved(
     cli: &UniversalFlags,
@@ -431,6 +441,7 @@ pub(crate) fn plan_build_rr_from_resolved(
         resolve_output,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )
 }
 
@@ -468,6 +479,7 @@ fn plan_build_rr_from_resolved_with_scope(
         resolve_output,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )
 }
 
@@ -500,6 +512,7 @@ fn plan_build_rr_from_selection(
         resolve_output,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )
 }
 

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -73,7 +73,10 @@ pub(crate) fn run_bundle(
 
     let targets = lower_surface_targets(&surface_targets);
     let resolve_output = sync_and_resolve_bundle_project(&cli, &cmd, &dirs, output.user_log())?;
-    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    }
     run_bundle_rr_from_resolved(&cli, &cmd, &dirs, &targets, resolve_output, output).with_context(
         || match targets.as_slice() {
             [target] => format!("failed to run bundle for target {target:?}"),
@@ -104,7 +107,10 @@ pub(crate) fn run_bundle_internal_rr(
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
     let resolve_output = sync_and_resolve_bundle_project(cli, cmd, dirs, output.user_log())?;
-    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    }
     run_bundle_rr_from_resolved(
         cli,
         cmd,
@@ -240,6 +246,7 @@ pub(crate) fn plan_bundle_rr_from_resolved(
         resolve_output,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )
 }
 

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -244,6 +244,7 @@ pub(crate) fn plan_bundle_rr_from_resolved(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )
 }

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -73,10 +73,7 @@ pub(crate) fn run_bundle(
 
     let targets = lower_surface_targets(&surface_targets);
     let resolve_output = sync_and_resolve_bundle_project(&cli, &cmd, &dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
+    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
     run_bundle_rr_from_resolved(&cli, &cmd, &dirs, &targets, resolve_output, output).with_context(
         || match targets.as_slice() {
             [target] => format!("failed to run bundle for target {target:?}"),
@@ -107,10 +104,7 @@ pub(crate) fn run_bundle_internal_rr(
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
     let resolve_output = sync_and_resolve_bundle_project(cli, cmd, dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
+    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
     run_bundle_rr_from_resolved(
         cli,
         cmd,

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -609,6 +609,7 @@ fn run_check_for_single_file_rr(
                 resolved.clone(),
                 cmd.build_flags.jobs,
                 cmd.auto_sync_flags.frozen,
+                cli.dry_run,
             )
             .context("Failed to calculate build plan")?,
         );
@@ -1026,6 +1027,7 @@ pub(crate) fn plan_check_rr_from_resolved(
         resolve_output,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )
 }
 
@@ -1058,6 +1060,7 @@ fn plan_check_rr_from_selection(
         resolve_output,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )
 }
 

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -607,6 +607,7 @@ fn run_check_for_single_file_rr(
                 intent,
                 mooncake_bin_dir,
                 resolved.clone(),
+                cmd.build_flags.jobs,
                 cmd.auto_sync_flags.frozen,
             )
             .context("Failed to calculate build plan")?,
@@ -1023,6 +1024,7 @@ pub(crate) fn plan_check_rr_from_resolved(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )
 }
@@ -1054,6 +1056,7 @@ fn plan_check_rr_from_selection(
         selection.into_user_intent()?,
         mooncake_bin_dir,
         resolve_output,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )
 }

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -152,7 +152,11 @@ fn run_cram_test(
         cli.workspace_env.clone(),
     );
     let resolve_output = rr_build::sync_and_resolve_project(&resolve_cfg, &dirs, user_log)?;
-    let lock = lock_directory(target_dir, user_log)?;
+    let lock = if cli.dry_run {
+        None
+    } else {
+        Some(lock_directory(target_dir, user_log)?)
+    };
 
     let planned_runs = crate::cli::plan_build_rr_from_resolved_all(
         cli,

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -151,9 +151,8 @@ fn run_cram_test(
         build_cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     );
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
-    let resolve_output =
-        moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
+    let resolve_output = rr_build::sync_and_resolve_project(&resolve_cfg, &dirs, user_log)?;
+    let lock = lock_directory(target_dir, user_log)?;
 
     let planned_runs = crate::cli::plan_build_rr_from_resolved_all(
         cli,
@@ -189,7 +188,6 @@ fn run_cram_test(
         return Ok(ProcessAction::Exit(0));
     }
 
-    let lock = lock_directory(target_dir, user_log)?;
     let cfg = BuildConfig::from_flags(&build_cmd.build_flags, &cli.unstable_feature, cli.verbose);
     for (build_meta, build_graph) in planned_runs {
         rr_build::generate_all_pkgs_json(&build_meta)?;

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -163,6 +163,7 @@ pub(crate) fn run_doc_rr(
         resolve_output,
         build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )?;
 
     // Early exit for dry-run

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -161,6 +161,7 @@ pub(crate) fn run_doc_rr(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )?;
 

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -399,6 +399,7 @@ fn plan_info_rr(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        None,
         cmd.auto_sync_flags.frozen,
     )
 }

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -401,5 +401,6 @@ fn plan_info_rr(
         resolve_output,
         None,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )
 }

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -602,6 +602,7 @@ fn build_selected_package(
         intent,
         &prepared.mooncake_bin_dir,
         prepared.resolve_output.clone(),
+        build_flags.jobs,
         false,
     )?;
 

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -605,6 +605,7 @@ fn build_selected_package(
         prepared.resolve_output.clone(),
         build_flags.jobs,
         false,
+        false,
     )?;
 
     rr_build::generate_all_pkgs_json(&build_meta)?;

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -580,6 +580,7 @@ fn build_selected_package(
 
     user_log.info(format!("Building `{}`...", pkg.full_pkg_name));
 
+    let _lock = lock_directory(&prepared.target_dir, user_log)?;
     let build_flags = BuildFlags {
         release: true,
         warn_list: Some("-a".to_string()),
@@ -606,7 +607,6 @@ fn build_selected_package(
         false,
     )?;
 
-    let _lock = lock_directory(&prepared.target_dir, user_log)?;
     rr_build::generate_all_pkgs_json(&build_meta)?;
 
     let result = rr_build::execute_build(

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -148,10 +148,6 @@ pub(crate) fn run_prove(
     let proof_prelude = resolve_proof_prelude()?;
     let generated_why3_config_path = verif_dir.join("why3.conf");
 
-    if !cli.dry_run && why3_config_path.is_none() {
-        ensure_why3_config(&generated_why3_config_path)?;
-    }
-
     let path_filter = cmd.path.as_deref();
     let prove_why3_config = why3_config_path.clone();
 
@@ -161,9 +157,12 @@ pub(crate) fn run_prove(
         build_flags.enable_coverage,
         cli.workspace_env.clone(),
     );
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
-    let resolve_output =
-        moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
+    let resolve_output = rr_build::sync_and_resolve_project(&resolve_cfg, &dirs, user_log)?;
+    let _lock = lock_directory(target_dir, user_log)?;
+
+    if !cli.dry_run && why3_config_path.is_none() {
+        ensure_why3_config(&generated_why3_config_path)?;
+    }
 
     let compile_config = rr_build::prepare_resolved_build(
         cli,
@@ -207,7 +206,6 @@ pub(crate) fn run_prove(
         return Ok(0);
     }
 
-    let _lock = lock_directory(target_dir, user_log)?;
     rr_build::generate_all_pkgs_json(&build_meta)?;
     let cfg = BuildConfig::from_flags(&build_flags, &cli.unstable_feature, cli.verbose);
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -189,6 +189,7 @@ pub(crate) fn run_prove(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )?;
     let proof_reports = planned_proof_reports(&build_meta);

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -158,7 +158,10 @@ pub(crate) fn run_prove(
         cli.workspace_env.clone(),
     );
     let resolve_output = rr_build::sync_and_resolve_project(&resolve_cfg, &dirs, user_log)?;
-    let _lock = lock_directory(target_dir, user_log)?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(target_dir, user_log)?;
+    }
 
     if !cli.dry_run && why3_config_path.is_none() {
         ensure_why3_config(&generated_why3_config_path)?;
@@ -190,6 +193,7 @@ pub(crate) fn run_prove(
         resolve_output,
         build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )?;
     let proof_reports = planned_proof_reports(&build_meta);
 

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -189,7 +189,7 @@ pub(crate) struct EmbeddedMbtxPolicy {
 
 /// A built executable plus the state needed to consume it.
 ///
-/// Planning and building keep the target-directory lock alive until the caller
+/// Normal builds keep the target-directory lock alive until the caller
 /// either runs the program or explicitly releases the lock. Other consumers can
 /// reuse the same build stage without releasing the lock between planning and
 /// compilation.
@@ -559,7 +559,11 @@ fn build_package_executable(
     )
     .with_sync_output(options.output.sync_output());
     let resolve_output = rr_build::sync_and_resolve_project(&resolve_cfg, &dirs, user_log)?;
-    let lock = lock_directory(target_dir, user_log)?;
+    let lock = if cli.dry_run {
+        None
+    } else {
+        Some(lock_directory(target_dir, user_log)?)
+    };
     let (build_meta, build_graph) = plan_run_rr_from_resolved(
         cli,
         cmd,
@@ -638,6 +642,7 @@ pub(crate) fn plan_run_rr_from_resolved(
         resolve_output,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )
 }
 
@@ -776,7 +781,11 @@ fn build_single_file_executable(
         .or(backend)
         .unwrap_or(options.default_target_backend);
 
-    let lock = lock_directory(target_dir, user_log)?;
+    let lock = if cli.dry_run {
+        None
+    } else {
+        Some(lock_directory(target_dir, user_log)?)
+    };
     let compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
@@ -803,6 +812,7 @@ fn build_single_file_executable(
         resolved,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )?;
 
     build_executable_from_plan(
@@ -825,7 +835,8 @@ fn build_single_file_executable(
 #[instrument(level = Level::DEBUG, skip_all)]
 /// Execute the build graph and return the resulting run artifact without
 /// launching it.
-/// The caller transfers the target-directory lock acquired before planning.
+/// Normal builds transfer the target-directory lock acquired before planning.
+/// Dry-run planning acquires and releases its own lock only if scripts run.
 #[allow(clippy::too_many_arguments)]
 fn build_executable_from_plan(
     cli: &UniversalFlags,
@@ -834,7 +845,7 @@ fn build_executable_from_plan(
     target_dir: &Path,
     build_meta: &rr_build::BuildMeta,
     build_graph: rr_build::BuildInput,
-    lock: std::fs::File,
+    lock: Option<std::fs::File>,
     options: BuildExecutableFromPlanOptions,
     output: &CommandOutput,
 ) -> Result<RunExecutable, anyhow::Error> {
@@ -891,7 +902,7 @@ fn build_executable_from_plan(
         embedded_mbtx_policy: options.embedded_mbtx_policy,
         source_dir: source_dir.to_path_buf(),
         build_exit_code: Some(build_result.return_code_for_success()),
-        lock: Some(lock),
+        lock,
     })
 }
 

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -636,6 +636,7 @@ pub(crate) fn plan_run_rr_from_resolved(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )
 }
@@ -799,6 +800,7 @@ fn build_single_file_executable(
         intent,
         mooncake_bin_dir,
         resolved,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )?;
 

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -189,10 +189,10 @@ pub(crate) struct EmbeddedMbtxPolicy {
 
 /// A built executable plus the state needed to consume it.
 ///
-/// The build step keeps the target-directory lock alive until the caller either
-/// runs the program or explicitly releases the lock. This preserves the previous
-/// `moon run` behavior while allowing other consumers to reuse the same build
-/// stage.
+/// Planning and building keep the target-directory lock alive until the caller
+/// either runs the program or explicitly releases the lock. Other consumers can
+/// reuse the same build stage without releasing the lock between planning and
+/// compilation.
 pub(crate) struct RunExecutable {
     /// Path to the executable-like artifact that should be launched or reported.
     pub(crate) executable: PathBuf,
@@ -558,9 +558,8 @@ fn build_package_executable(
         cli.workspace_env.clone(),
     )
     .with_sync_output(options.output.sync_output());
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
-    let resolve_output =
-        moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
+    let resolve_output = rr_build::sync_and_resolve_project(&resolve_cfg, &dirs, user_log)?;
+    let lock = lock_directory(target_dir, user_log)?;
     let (build_meta, build_graph) = plan_run_rr_from_resolved(
         cli,
         cmd,
@@ -577,6 +576,7 @@ fn build_package_executable(
         target_dir,
         &build_meta,
         build_graph,
+        lock,
         BuildExecutableFromPlanOptions {
             print_dry_run_run_command: options.print_dry_run_run_command,
             output: options.output,
@@ -776,6 +776,7 @@ fn build_single_file_executable(
         .or(backend)
         .unwrap_or(options.default_target_backend);
 
+    let lock = lock_directory(target_dir, user_log)?;
     let compile_config = rr_build::prepare_resolved_build(
         cli,
         &cmd.build_flags,
@@ -811,6 +812,7 @@ fn build_single_file_executable(
         target_dir,
         &build_meta,
         build_graph,
+        lock,
         BuildExecutableFromPlanOptions {
             print_dry_run_run_command: options.print_dry_run_run_command,
             output: options.output,
@@ -823,6 +825,7 @@ fn build_single_file_executable(
 #[instrument(level = Level::DEBUG, skip_all)]
 /// Execute the build graph and return the resulting run artifact without
 /// launching it.
+/// The caller transfers the target-directory lock acquired before planning.
 #[allow(clippy::too_many_arguments)]
 fn build_executable_from_plan(
     cli: &UniversalFlags,
@@ -831,6 +834,7 @@ fn build_executable_from_plan(
     target_dir: &Path,
     build_meta: &rr_build::BuildMeta,
     build_graph: rr_build::BuildInput,
+    lock: std::fs::File,
     options: BuildExecutableFromPlanOptions,
     output: &CommandOutput,
 ) -> Result<RunExecutable, anyhow::Error> {
@@ -871,7 +875,6 @@ fn build_executable_from_plan(
         });
     }
 
-    let lock = lock_directory(target_dir, user_log)?;
     // Generate all_pkgs.json for indirect dependency resolution
     rr_build::generate_all_pkgs_json(build_meta)?;
 

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -410,7 +410,10 @@ fn run_test_impl(
     validate_test_or_bench_invocation(cli, &test_cmd)?;
     let resolve_output =
         sync_and_resolve_test_or_bench_project(cli, &test_cmd, &dirs, output.user_log())?;
-    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    }
     let ret_value = run_test_or_bench_from_resolved(
         cli,
         &test_cmd,
@@ -545,7 +548,10 @@ fn run_test_in_single_file_rr(
         cmd.build_flags.resolve_single_target_backend()?.or(backend)
     };
 
-    let _lock = lock_directory(target_dir, user_log)?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(target_dir, user_log)?;
+    }
     let build_flags = effective_test_build_flags(&cmd.build_flags, cmd.profile);
 
     let compile_config = rr_build::prepare_resolved_build(
@@ -589,6 +595,7 @@ fn run_test_in_single_file_rr(
         resolved,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )?;
 
     let test_cmd: TestLikeSubcommand<'_> = cmd.into();
@@ -728,6 +735,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
         resolve_output,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )?;
     Ok((build_meta, build_graph, filter))
 }
@@ -867,6 +875,7 @@ fn plan_test_or_bench_rr_from_resolved_scoped(
         resolve_output,
         cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
+        cli.dry_run,
     )?;
     Ok((build_meta, build_graph, filter))
 }
@@ -970,7 +979,10 @@ fn run_test_rr(
     output: &CommandOutput,
 ) -> Result<i32, anyhow::Error> {
     let resolve_output = sync_and_resolve_test_or_bench_project(cli, cmd, dirs, output.user_log())?;
-    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
+    }
     run_test_or_bench_from_resolved(
         cli,
         cmd,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -410,10 +410,7 @@ fn run_test_impl(
     validate_test_or_bench_invocation(cli, &test_cmd)?;
     let resolve_output =
         sync_and_resolve_test_or_bench_project(cli, &test_cmd, &dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
+    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
     let ret_value = run_test_or_bench_from_resolved(
         cli,
         &test_cmd,
@@ -548,6 +545,7 @@ fn run_test_in_single_file_rr(
         cmd.build_flags.resolve_single_target_backend()?.or(backend)
     };
 
+    let _lock = lock_directory(target_dir, user_log)?;
     let build_flags = effective_test_build_flags(&cmd.build_flags, cmd.profile);
 
     let compile_config = rr_build::prepare_resolved_build(
@@ -594,10 +592,6 @@ fn run_test_in_single_file_rr(
     )?;
 
     let test_cmd: TestLikeSubcommand<'_> = cmd.into();
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(target_dir, output.user_log())?;
-    }
     rr_test_from_plan(
         cli,
         &test_cmd,
@@ -976,10 +970,7 @@ fn run_test_rr(
     output: &CommandOutput,
 ) -> Result<i32, anyhow::Error> {
     let resolve_output = sync_and_resolve_test_or_bench_project(cli, cmd, dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
+    let _lock = lock_directory(&dirs.target_dir, output.user_log())?;
     run_test_or_bench_from_resolved(
         cli,
         cmd,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -589,6 +589,7 @@ fn run_test_in_single_file_rr(
         intent,
         mooncake_bin_dir,
         resolved,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )?;
 
@@ -731,6 +732,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )?;
     Ok((build_meta, build_graph, filter))
@@ -869,6 +871,7 @@ fn plan_test_or_bench_rr_from_resolved_scoped(
         intent,
         mooncake_bin_dir,
         resolve_output,
+        cmd.build_flags.jobs,
         cmd.auto_sync_flags.frozen,
     )?;
     Ok((build_meta, build_graph, filter))

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -179,6 +179,7 @@ pub(crate) fn run_build_binary_dep(
             // FIXME: cloning is not the best way to do this, it takes in this
             // type only to be returned in build meta. We should refactor later.
             resolve_output.clone(),
+            build_flags.jobs,
             false,
         )?;
 

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -94,9 +94,7 @@ pub(crate) fn run_build_binary_dep(
     let resolve_cfg =
         ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone())
             .without_bin_deps();
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
-    let resolve_output =
-        moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
+    let resolve_output = rr_build::sync_and_resolve_project(&resolve_cfg, &dirs, user_log)?;
 
     // Note: There's a cyclic dependency!
     //
@@ -144,6 +142,7 @@ pub(crate) fn run_build_binary_dep(
     };
 
     // For each package we need to get its target backend and then we can build it
+    let _lock = lock_directory(target_dir, user_log)?;
     for (pkg, target) in pkgs {
         // Get package info
         let package = &*resolve_output.pkg_dirs.get_package(pkg).raw;
@@ -183,7 +182,6 @@ pub(crate) fn run_build_binary_dep(
             false,
         )?;
 
-        let _lock = lock_directory(target_dir, user_log)?;
         // Generate all_pkgs.json for indirect dependency resolution
         rr_build::generate_all_pkgs_json(&build_meta)?;
 

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -180,6 +180,7 @@ pub(crate) fn run_build_binary_dep(
             resolve_output.clone(),
             build_flags.jobs,
             false,
+            false,
         )?;
 
         // Generate all_pkgs.json for indirect dependency resolution

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -76,7 +76,7 @@ mod prebuild;
 pub use dry_run::{format_dry_run_command, write_dry_run, write_dry_run_all};
 
 /// Synchronize dependencies and return resolved project data.
-/// Target-directory lock ownership remains with the command layer.
+/// This step does not acquire the target-directory lock.
 pub(crate) fn sync_and_resolve_project(
     resolve_config: &ResolveConfig,
     dirs: &PackageDirs,
@@ -439,10 +439,12 @@ pub(crate) fn prepare_resolved_build(
 /// At this boundary, command adapters have already resolved user selectors and
 /// command-specific directives into `CalcUserIntentOutput`. RR consumes those
 /// identities plus precomputed build-context paths from the command adapter.
+/// For actual builds, callers hold the target-directory lock while prebuild
+/// scripts run and their outputs are consumed. Dry-run callers leave locking to
+/// this function: it locks only when the resolved backend and modules require
+/// scripts, and keeps the lock through planning.
 #[instrument(level = Level::DEBUG, skip_all)]
-/// Callers that request module prebuild configuration must hold the target-directory
-/// lock from before planning through execution: scripts can rewrite persistent
-/// inputs consumed by the build. Dry-run planning also executes these scripts.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn plan_resolved_build_from_intent(
     cx: CompileConfig,
     user_log: &UserLog,
@@ -451,17 +453,30 @@ pub(crate) fn plan_resolved_build_from_intent(
     resolve_output: ResolveOutput,
     jobs: Option<usize>,
     frozen: bool,
+    dry_run: bool,
 ) -> anyhow::Result<(BuildMeta, BuildInput)> {
     let target_dir = cx.target_dir.clone();
     info!("User intent calculated: {:?}", intent.intents);
 
-    // Module-level configuration discovers native toolchains and flags; other
-    // backends do not need to execute these scripts.
-    let prebuild_config = if cx.action == RunMode::Check || !cx.backend.target_backend().is_native()
-    {
-        info!("Skipping prebuild configuration for check or non-native backend");
-        None
+    // Decide once, after backend selection, whether planning will execute a
+    // script. Dry runs that only lower commands must not acquire a write lock.
+    let run_prebuild = cx.action != RunMode::Check
+        && cx.backend.target_backend().is_native()
+        && resolve_output
+            .module_rel
+            .all_modules_and_id()
+            .any(|(m, _)| {
+                resolve_output
+                    .module_info(m)
+                    .__moonbit_unstable_prebuild
+                    .is_some()
+            });
+    let _dry_run_lock = if dry_run && run_prebuild {
+        Some(moonutil::locks::lock_directory(&target_dir, user_log)?)
     } else {
+        None
+    };
+    let prebuild_config = if run_prebuild {
         info!("Running prebuild configuration");
         Some(prebuild::run_prebuild_config(
             &resolve_output,
@@ -469,6 +484,9 @@ pub(crate) fn plan_resolved_build_from_intent(
             resolve_parallelism(jobs),
             frozen,
         )?)
+    } else {
+        info!("Skipping prebuild configuration: no applicable scripts");
+        None
     };
 
     info!("Expanding user intents to requested artifacts");

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -440,6 +440,9 @@ pub(crate) fn prepare_resolved_build(
 /// command-specific directives into `CalcUserIntentOutput`. RR consumes those
 /// identities plus precomputed build-context paths from the command adapter.
 #[instrument(level = Level::DEBUG, skip_all)]
+/// Callers that request module prebuild configuration must hold the target-directory
+/// lock from before planning through execution: scripts can rewrite persistent
+/// inputs consumed by the build. Dry-run planning also executes these scripts.
 pub(crate) fn plan_resolved_build_from_intent(
     cx: CompileConfig,
     user_log: &UserLog,

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -32,7 +32,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     rc::Rc,
-    sync::mpsc,
+    sync::{LazyLock, mpsc},
 };
 
 use anyhow::Context;
@@ -446,6 +446,7 @@ pub(crate) fn plan_resolved_build_from_intent(
     intent: CalcUserIntentOutput,
     mooncake_bin_dir: &Path,
     resolve_output: ResolveOutput,
+    jobs: Option<usize>,
     frozen: bool,
 ) -> anyhow::Result<(BuildMeta, BuildInput)> {
     let target_dir = cx.target_dir.clone();
@@ -461,7 +462,8 @@ pub(crate) fn plan_resolved_build_from_intent(
         info!("Running prebuild configuration");
         Some(prebuild::run_prebuild_config(
             &resolve_output,
-            &target_dir,
+            &cx,
+            resolve_parallelism(jobs),
             frozen,
         )?)
     };
@@ -707,6 +709,14 @@ pub fn generate_all_pkgs_json(build_meta: &BuildMeta) -> anyhow::Result<()> {
         ))?;
     }
     Ok(())
+}
+
+/// Share the default observation between prebuild scripts and the executor so
+/// both see the same job limit throughout this Moon process.
+fn resolve_parallelism(jobs: Option<usize>) -> usize {
+    static DEFAULT_PARALLELISM: LazyLock<usize> =
+        LazyLock::new(|| std::thread::available_parallelism().map_or(1, usize::from));
+    jobs.unwrap_or_else(|| *DEFAULT_PARALLELISM)
 }
 
 #[derive(Clone)]
@@ -1141,10 +1151,7 @@ fn execute_n2_graph_capturing(
     let n2_db = n2::db::open(&db_path, &mut build_graph, &mut hashes)
         .with_context(|| format!("Failed to open build cache DB at {}", db_path.display()))?;
 
-    let parallelism = cfg
-        .parallelism
-        .or_else(|| std::thread::available_parallelism().ok().map(|x| x.into()))
-        .unwrap();
+    let parallelism = resolve_parallelism(cfg.parallelism);
 
     let (captured_output_sender, captured_output_receiver) = mpsc::channel();
     let mut prog_console: Box<dyn n2::progress::Progress> = create_progress_console(

--- a/crates/moon/src/rr_build/prebuild.rs
+++ b/crates/moon/src/rr_build/prebuild.rs
@@ -29,10 +29,13 @@ use anyhow::{Context, anyhow};
 use log::warn;
 use moonbuild_rupes_recta::{
     ResolveOutput,
+    compile::CompileConfig,
     prebuild::{ModulePrebuildOutput, PrebuildOutput},
 };
 use moonutil::{
     build_script::{BuildScriptEnvironment, BuildScriptOutput, Paths},
+    constants::{MOON_MOD, MOON_MOD_JSON},
+    manifest::preferred_manifest_in_dir,
     project::SourceTargetDirs,
     resolution::ModuleName,
 };
@@ -46,10 +49,16 @@ use crate::{
 #[instrument(skip_all)]
 pub(super) fn run_prebuild_config(
     resolve_output: &ResolveOutput,
-    target_dir: &Path,
+    cx: &CompileConfig,
+    jobs: usize,
     frozen: bool,
 ) -> anyhow::Result<PrebuildOutput> {
     let environment: HashMap<String, String> = std::env::vars().collect();
+    let build_dir = cx
+        .artifact_paths
+        .target_layout()
+        .run_mode_dir(cx.backend.target_backend())
+        .join("prebuild");
     let mut output = PrebuildOutput::default();
     for (m, ms) in resolve_output.module_rel.all_modules_and_id() {
         let m_info = resolve_output.module_info(m);
@@ -57,15 +66,25 @@ pub(super) fn run_prebuild_config(
         let Some(prebuild) = &m_info.__moonbit_unstable_prebuild else {
             continue;
         };
+        // Keep generated files in caller-owned storage, separated by module and
+        // the build configuration selected by the existing target layout.
+        let module_hash = blake3::hash(m_dir.as_os_str().as_encoded_bytes()).to_hex();
+        let out_dir = build_dir.join(module_hash.as_str());
+        std::fs::create_dir_all(&out_dir).with_context(|| {
+            format!(
+                "failed to create prebuild output directory `{}`",
+                out_dir.display()
+            )
+        })?;
         let input = BuildScriptEnvironment {
             env: environment.clone(),
             paths: Paths {
                 module_root: m_dir.to_string_lossy().into_owned(),
-                out_dir: "TODO".to_string(),
+                out_dir: out_dir.to_string_lossy().into_owned(),
             },
         };
         let script_output =
-            run_build_script_for_module(ms, m_dir, input, prebuild, target_dir, frozen)
+            run_build_script_for_module(ms, m_dir, input, prebuild, cx, jobs, frozen)
                 .with_context(|| {
                     format!("Failed to run prebuild script for module {}", m_info.name)
                 })?;
@@ -175,7 +194,8 @@ fn run_build_script_for_module(
     dir: &Path,
     input: BuildScriptEnvironment,
     prebuild: &str,
-    target_dir: &Path,
+    cx: &CompileConfig,
+    jobs: usize,
     frozen: bool,
 ) -> Result<BuildScriptOutput, anyhow::Error> {
     // TODO: This executes arbitrary scripts. It's essentially the same as
@@ -185,8 +205,18 @@ fn run_build_script_for_module(
         "Running external prebuild config at `{}`. The script can execute arbitrary code.",
         prebuild
     );
-    let mut cmd = run_script_cmd(prebuild, module.name(), dir, target_dir, frozen)?
+    let (manifest_path, _) = preferred_manifest_in_dir(dir, MOON_MOD, MOON_MOD_JSON)
+        .with_context(|| format!("failed to locate module manifest for `{module}`"))?;
+    let mut cmd = run_script_cmd(prebuild, module.name(), dir, &cx.target_dir, frozen)?
         .current_dir(dir)
+        .envs(&input.env)
+        .env("MOON_MOD", manifest_path)
+        .env("MOON_BUILD_DIR", &input.paths.out_dir)
+        .env("MOON_HOST_OS", std::env::consts::OS)
+        .env("MOON_HOST_ARCH", std::env::consts::ARCH)
+        .env("MOON_BACKEND", cx.backend.target_backend().to_flag())
+        .env("MOON_PROFILE", cx.opt_level.as_str())
+        .env("MOON_JOBS", jobs.to_string())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -194,6 +224,8 @@ fn run_build_script_for_module(
         .with_context(|| {
             format!("failed to spawn prebuild script `{prebuild}` for module `{module}`")
         })?;
+    // TODO: Remove this stdin transport once compatibility with scripts reading
+    // the legacy JSON input is no longer required.
     let stdin = cmd.stdin.take().expect("Didn't get stdin");
     let join = std::thread::spawn(move || {
         let mut stdin = stdin;

--- a/crates/moon/tests/test_cases/prebuild_config_script/js/build.js
+++ b/crates/moon/tests/test_cases/prebuild_config_script/js/build.js
@@ -1,3 +1,17 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+// Environment-only scripts do not need to read the compatibility stdin payload.
+assert.equal(process.env.MOON_MOD, path.join(process.cwd(), 'moon.mod.json'))
+assert.ok(path.isAbsolute(process.env.MOON_BUILD_DIR))
+assert.ok(fs.statSync(process.env.MOON_BUILD_DIR).isDirectory())
+fs.writeFileSync(path.join(process.env.MOON_BUILD_DIR, 'generated.txt'), 'ready')
+assert.ok(process.env.MOON_CC)
+assert.equal(process.env.MOON_BACKEND, 'native')
+assert.equal(process.env.MOON_PROFILE, 'debug')
+assert.equal(process.env.MOON_JOBS, '3')
+
 const output = {
   vars: {
     HELLO: '------this-is-added-by-config-script------',

--- a/crates/moon/tests/test_cases/prebuild_config_script/mbtx/build config.mbtx
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mbtx/build config.mbtx
@@ -10,7 +10,11 @@ async fn main {
   let input = @json.parse(@stdio.stdin.read_all().text())
   guard input is {
     "env": { "MOON_CC": String(cc), .. },
-    "paths": { "module_root": String(module_root), .. },
+    "paths": {
+      "module_root": String(module_root),
+      "out_dir": String(out_dir),
+      ..
+    },
     ..
   } else {
     abort("missing prebuild environment or paths")
@@ -20,6 +24,18 @@ async fn main {
   }
   guard Some(module_root) == @env.current_dir() else {
     abort("prebuild working directory is not the module root")
+  }
+  guard @env.get_env_var("MOON_MOD") is Some(manifest) &&
+    manifest.has_prefix(module_root) && manifest.has_suffix("moon.mod.json") else {
+    abort("prebuild module manifest was not passed through the environment")
+  }
+  guard out_dir != "TODO" && Some(out_dir) == @env.get_env_var("MOON_BUILD_DIR") else {
+    abort("prebuild output directory was not passed through the environment")
+  }
+  guard @env.get_env_var("MOON_BACKEND") == Some("native") &&
+    @env.get_env_var("MOON_PROFILE") == Some("debug") &&
+    @env.get_env_var("MOON_JOBS") == Some("3") else {
+    abort("prebuild did not receive the outer build settings")
   }
   let output : Json = {
     "vars": { "HELLO": "------this-is-added-by-config-script------" },

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -23,6 +23,86 @@ fn test_prebuild_config_mbtx() {
 }
 
 #[test]
+fn test_prebuild_config_holds_target_lock() {
+    let dir = TestDir::new_empty();
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        r#"{
+          "name": "testuser/locked",
+          "preferred-target": "native",
+          "--moonbit-unstable-prebuild": "build.js"
+        }"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("moon.pkg.json"), r#"{"is-main":true}"#).unwrap();
+    std::fs::write(dir.join("main.mbt"), "fn main { println(42) }").unwrap();
+    std::fs::write(dir.join("why3.conf"), "").unwrap();
+
+    // Probe from a separate process using the same cross-platform locking API
+    // as Moon. This detects unlocked prebuild execution without timing a race.
+    std::fs::write(
+        dir.join("lock_probe.rs"),
+        r#"fn main() {
+    let lock = std::fs::OpenOptions::new()
+        .read(true).write(true)
+        .open(std::env::args_os().nth(1).unwrap()).unwrap();
+    assert!(matches!(lock.try_lock(), Err(std::fs::TryLockError::WouldBlock)),
+        "prebuild ran without holding the target lock");
+}
+"#,
+    )
+    .unwrap();
+    let probe = dir.join(format!("lock_probe{}", std::env::consts::EXE_SUFFIX));
+    snapbox::cmd::Command::new("rustc")
+        .arg(dir.join("lock_probe.rs"))
+        .arg("-o")
+        .arg(&probe)
+        .assert()
+        .success();
+    std::fs::write(
+        dir.join("build.js"),
+        r#"const { execFileSync } = require('node:child_process')
+execFileSync(process.env.MOON_TEST_LOCK_PROBE, [process.env.MOON_TEST_TARGET_LOCK], { stdio: 'inherit' })
+console.error('prebuild target is locked')
+// Stop before compilation so this test does not need native or proof artifacts.
+process.exit(1)
+"#,
+    )
+    .unwrap();
+
+    let target = dir.join("custom build");
+    for args in [
+        ["run", "."].as_slice(),
+        ["prove", "--why3-config", "why3.conf"].as_slice(),
+        ["build"].as_slice(),
+        ["build", "--target", "native"].as_slice(),
+        ["test"].as_slice(),
+        ["test", "--target", "native"].as_slice(),
+        ["bench"].as_slice(),
+        ["bench", "--target", "native"].as_slice(),
+        ["bundle"].as_slice(),
+        ["bundle", "--target", "native"].as_slice(),
+    ] {
+        for dry_run in [false, true] {
+            moon_cmd(&dir)
+                .env("MOON_TEST_LOCK_PROBE", &probe)
+                .env("MOON_TEST_TARGET_LOCK", target.join(".moon-lock"))
+                .arg("--target-dir")
+                .arg(&target)
+                .args(args)
+                .args(dry_run.then_some("--dry-run"))
+                .assert()
+                .failure()
+                .stderr_eq(snapbox::str![[r#"
+...
+prebuild target is locked
+...
+"#]]);
+        }
+    }
+}
+
+#[test]
 fn test_prebuild_config_build_environment() {
     let dir = TestDir::new_empty();
     std::fs::write(

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -23,6 +23,74 @@ fn test_prebuild_config_mbtx() {
 }
 
 #[test]
+fn test_prebuild_config_skipped_dry_runs_do_not_lock() {
+    let dir = TestDir::new_empty();
+    let target = dir.join("custom build");
+    // A directory at the lock-file path makes any attempt to open the lock
+    // fail immediately, without hanging the test on an intentionally held lock.
+    std::fs::create_dir_all(target.join(".moon-lock")).unwrap();
+    std::fs::create_dir(dir.join("main")).unwrap();
+    std::fs::write(dir.join("main/moon.pkg.json"), r#"{"is-main":true}"#).unwrap();
+    std::fs::write(dir.join("main/main.mbt"), "fn main {}").unwrap();
+    std::fs::write(
+        dir.join("build.js"),
+        "throw new Error('prebuild must be skipped')",
+    )
+    .unwrap();
+
+    for (has_script, preferred, targets) in [
+        (true, "js", ["wasm", "wasm-gc", "js"].as_slice()),
+        (false, "native", ["native", "llvm"].as_slice()),
+    ] {
+        let mut manifest = serde_json::json!({
+            "name": "testuser/unlocked",
+            "preferred-target": preferred,
+        });
+        if has_script {
+            manifest["--moonbit-unstable-prebuild"] = "build.js".into();
+        }
+        std::fs::write(dir.join("moon.mod.json"), manifest.to_string()).unwrap();
+
+        for command in ["build", "run", "test", "bench", "bundle"] {
+            for target_backend in std::iter::once(None).chain(targets.iter().copied().map(Some)) {
+                moon_cmd(&dir)
+                    .arg("--target-dir")
+                    .arg(&target)
+                    .arg(command)
+                    .args((command == "run").then_some("main"))
+                    .args(
+                        target_backend
+                            .into_iter()
+                            .flat_map(|target| ["--target", target]),
+                    )
+                    .args(["--dry-run", "--nostd"])
+                    .assert()
+                    .success();
+            }
+        }
+    }
+
+    let standalone = TestDir::new_empty();
+    std::fs::write(standalone.join("standalone.mbtx"), "fn main {}").unwrap();
+    std::fs::create_dir_all(target.join("standalone.mbtx/.moon-lock")).unwrap();
+    for command in ["build", "run", "test"] {
+        moon_cmd(&standalone)
+            .arg("--target-dir")
+            .arg(&target)
+            .args([
+                command,
+                "standalone.mbtx",
+                "--target",
+                "wasm",
+                "--dry-run",
+                "--nostd",
+            ])
+            .assert()
+            .success();
+    }
+}
+
+#[test]
 fn test_prebuild_config_holds_target_lock() {
     let dir = TestDir::new_empty();
     std::fs::write(
@@ -76,6 +144,7 @@ process.exit(1)
         ["prove", "--why3-config", "why3.conf"].as_slice(),
         ["build"].as_slice(),
         ["build", "--target", "native"].as_slice(),
+        ["build", "--target", "wasm,native"].as_slice(),
         ["test"].as_slice(),
         ["test", "--target", "native"].as_slice(),
         ["bench"].as_slice(),

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -23,6 +23,161 @@ fn test_prebuild_config_mbtx() {
 }
 
 #[test]
+fn test_prebuild_config_build_environment() {
+    let dir = TestDir::new_empty();
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        r#"{
+          "name": "testuser/environment",
+          "preferred-target": "llvm",
+          "--moonbit-unstable-prebuild": "build.js"
+        }"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("moon.pkg.json"), r#"{"is-main":true}"#).unwrap();
+    std::fs::write(dir.join("main.mbt"), "fn main { println(42) }").unwrap();
+    std::fs::write(
+        dir.join("build.js"),
+        r#"const fs = require('node:fs')
+const names = ['MOON_HOST_OS', 'MOON_HOST_ARCH', 'MOON_BACKEND', 'MOON_PROFILE', 'MOON_JOBS']
+fs.writeFileSync('environment.json', JSON.stringify(Object.fromEntries(names.map(name => [name, process.env[name]]))))
+// Stop before compilation: this test does not require LLVM standard-library artifacts.
+process.exit(1)
+"#,
+    )
+    .unwrap();
+
+    for (args, backend, profile, jobs) in [
+        (
+            ["build", "--target", "native", "--debug", "--jobs", "2"].as_slice(),
+            "native",
+            "debug",
+            2,
+        ),
+        (
+            ["build", "--target", "llvm", "--release", "-j", "3"].as_slice(),
+            "llvm",
+            "release",
+            3,
+        ),
+        (
+            ["run", ".", "--target", "native", "-j", "4"].as_slice(),
+            "native",
+            "debug",
+            4,
+        ),
+        (
+            ["test", "--target", "native", "-j", "5"].as_slice(),
+            "native",
+            "debug",
+            5,
+        ),
+        (
+            ["bench", "--target", "native", "-j", "6"].as_slice(),
+            "native",
+            "release",
+            6,
+        ),
+        (
+            ["build"].as_slice(),
+            "llvm",
+            "debug",
+            std::thread::available_parallelism().map_or(1, usize::from),
+        ),
+    ] {
+        moon_cmd(&dir)
+            .env("MOON_HOST_OS", "inherited-host-os")
+            .env("MOON_HOST_ARCH", "inherited-host-arch")
+            .env("MOON_BACKEND", "inherited-backend")
+            .env("MOON_PROFILE", "inherited-profile")
+            .env("MOON_JOBS", "inherited-jobs")
+            .args(args)
+            .arg("--dry-run")
+            .assert()
+            .failure();
+        let environment: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.join("environment.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            environment,
+            serde_json::json!({
+                "MOON_HOST_OS": std::env::consts::OS,
+                "MOON_HOST_ARCH": std::env::consts::ARCH,
+                "MOON_BACKEND": backend,
+                "MOON_PROFILE": profile,
+                "MOON_JOBS": jobs.to_string(),
+            })
+        );
+        std::fs::remove_file(dir.join("environment.json")).unwrap();
+    }
+}
+
+#[test]
+fn test_prebuild_config_build_dirs() {
+    let dir = TestDir::new_empty();
+    let dependency = dir.join("dep");
+    let target = dir.join("custom build");
+    std::fs::create_dir(&dependency).unwrap();
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        r#"{
+          "name": "testuser/consumer",
+          "deps": { "testuser/config": { "path": "./dep" } },
+          "--moonbit-unstable-prebuild": "build.js"
+        }"#,
+    )
+    .unwrap();
+    // The preferred DSL manifest must be reported when both formats exist.
+    std::fs::write(
+        dependency.join("moon.mod"),
+        "name = \"testuser/config\"\nversion = \"0.1.0\"\noptions(\"--moonbit-unstable-prebuild\": \"build.js\")\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dependency.join("moon.mod.json"),
+        r#"{"name":"testuser/config","version":"0.1.0"}"#,
+    )
+    .unwrap();
+    for module_dir in [dir.as_ref(), dependency.as_path()] {
+        std::fs::write(module_dir.join("moon.pkg.json"), "{}").unwrap();
+        std::fs::write(module_dir.join("lib.mbt"), "pub fn value() -> Int { 42 }").unwrap();
+        std::fs::write(
+            module_dir.join("build.js"),
+            r#"const fs = require('node:fs')
+const path = require('node:path')
+fs.appendFileSync(path.join(process.env.MOON_BUILD_DIR, 'runs.txt'), process.env.MOON_MOD + '\n')
+console.log('{}')
+"#,
+        )
+        .unwrap();
+    }
+
+    for profile in ["--debug", "--debug", "--release"] {
+        moon_cmd(&dir)
+            .arg("--target-dir")
+            .arg(&target)
+            .args(["build", "--target", "native", "--dry-run", profile])
+            .assert()
+            .success();
+    }
+
+    for (profile, runs) in [("debug", 2), ("release", 1)] {
+        let outputs = std::fs::read_dir(target.join(format!("native/{profile}/build/prebuild")))
+            .unwrap()
+            .map(|entry| std::fs::read_to_string(entry.unwrap().path().join("runs.txt")).unwrap())
+            .collect::<std::collections::BTreeSet<_>>();
+        let expected = [dir.join("moon.mod.json"), dependency.join("moon.mod")]
+            .map(|manifest| {
+                format!("{}\n", dunce::canonicalize(manifest).unwrap().display()).repeat(runs)
+            })
+            .into_iter()
+            .collect();
+        assert_eq!(outputs, expected);
+    }
+    assert!(!dependency.join("_build").exists());
+}
+
+#[test]
 fn test_prebuild_config_mbtx_preserves_frozen_dependencies() {
     let dir = TestDir::new("prebuild_config_script/mbtx");
     let moon_home = tempfile::tempdir().unwrap();
@@ -190,8 +345,13 @@ fn test_prebuild_config_common(dir: TestDir) {
     let cc = if cfg!(windows) { "cl" } else { "cc" };
     let stdout = get_stdout_with_envs(
         &dir,
-        ["build", "--target", "native", "--dry-run"],
-        [("MOON_CC", cc)],
+        ["build", "--target", "native", "--dry-run", "--jobs", "3"],
+        [
+            ("MOON_CC", cc),
+            ("MOON_MOD", "inherited-module-manifest"),
+            ("MOON_BUILD_DIR", "inherited-build-dir"),
+            ("MOON_BACKEND", "inherited-backend"),
+        ],
     );
     println!("{}", &stdout);
     let lines = stdout.lines().collect::<Vec<_>>();

--- a/crates/moon/tests/test_cases/prebuild_config_script/py/build.py
+++ b/crates/moon/tests/test_cases/prebuild_config_script/py/build.py
@@ -1,4 +1,23 @@
 import json
+import os
+import sys
+from pathlib import Path
+
+build_input = json.load(sys.stdin)
+assert set(build_input) == {"env", "paths"}
+assert build_input["env"]["MOON_CC"] == os.environ["MOON_CC"]
+assert build_input["env"]["MOON_MOD"] == "inherited-module-manifest"
+assert build_input["env"]["MOON_BUILD_DIR"] == "inherited-build-dir"
+assert build_input["env"]["MOON_BACKEND"] == "inherited-backend"
+assert os.environ["MOON_BACKEND"] == "native"
+assert os.environ["MOON_PROFILE"] == "debug"
+assert os.environ["MOON_JOBS"] == "3"
+assert build_input["paths"]["module_root"] == os.getcwd()
+assert Path(os.environ["MOON_MOD"]) == Path.cwd() / "moon.mod.json"
+assert build_input["paths"]["out_dir"] == os.environ["MOON_BUILD_DIR"]
+build_dir = Path(os.environ["MOON_BUILD_DIR"])
+assert build_dir.is_absolute() and build_dir.is_dir()
+(build_dir / "generated.txt").write_text("ready")
 
 output = {
     "vars": {"HELLO": "------this-is-added-by-config-script------"},

--- a/crates/moonbuild/template/mod.schema.json
+++ b/crates/moonbuild/template/mod.schema.json
@@ -8,7 +8,7 @@
   ],
   "properties": {
     "--moonbit-unstable-prebuild": {
-      "description": "**Experimental:** A relative path to the pre-build configuration script.\n\nThe script may be JavaScript (`.js`, `.cjs`, `.mjs`), Python (`.py`), or MoonBit (`.mbtx`), executed with Node.js, Python, or Moonrun respectively. MoonBit scripts are compiled to Wasm. Each script receives JSON on stdin and returns build configuration JSON on stdout. Since this is experimental, the API may change at any time without warning.",
+      "description": "**Experimental:** A relative path to the pre-build configuration script.\n\nThe script may be JavaScript (`.js`, `.cjs`, `.mjs`), Python (`.py`), or MoonBit (`.mbtx`), executed with Node.js, Python, or Moonrun respectively. MoonBit scripts are compiled to Wasm. Each script receives the process environment plus `MOON_MOD` (the module manifest path) and `MOON_BUILD_DIR` (a writable prebuild output directory created by Moon). `MOON_HOST_OS` and `MOON_HOST_ARCH` describe the Moon process's platform. `MOON_BACKEND`, `MOON_PROFILE`, and `MOON_JOBS` describe the project build. The original JSON input shape is still supplied on stdin for compatibility, with `paths.out_dir` set to the same output directory. Scripts return build configuration JSON on stdout. Since this is experimental, the API may change at any time without warning.",
       "type": [
         "string",
         "null"

--- a/crates/moonutil/src/module.rs
+++ b/crates/moonutil/src/module.rs
@@ -240,9 +240,15 @@ pub struct MoonModJSON {
     ///
     /// The script may be JavaScript (`.js`, `.cjs`, `.mjs`), Python (`.py`), or
     /// MoonBit (`.mbtx`), executed with Node.js, Python, or Moonrun respectively.
-    /// MoonBit scripts are compiled to Wasm. Each script receives JSON on stdin
-    /// and returns build configuration JSON on stdout. Since this is experimental,
-    /// the API may change at any time without warning.
+    /// MoonBit scripts are compiled to Wasm. Each script receives the process
+    /// environment plus `MOON_MOD` (the module manifest path) and `MOON_BUILD_DIR`
+    /// (a writable prebuild output directory created by Moon).
+    /// `MOON_HOST_OS` and `MOON_HOST_ARCH` describe the Moon process's platform.
+    /// `MOON_BACKEND`, `MOON_PROFILE`, and `MOON_JOBS` describe the project build.
+    /// The original JSON input shape is still supplied on stdin for compatibility,
+    /// with `paths.out_dir` set to the same output directory. Scripts return build
+    /// configuration JSON on stdout.
+    /// Since this is experimental, the API may change at any time without warning.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub __moonbit_unstable_prebuild: Option<String>,
 }

--- a/docs/dev/design/moon-run-process-lifecycle.md
+++ b/docs/dev/design/moon-run-process-lifecycle.md
@@ -39,7 +39,9 @@ on every platform.
 
 The execution flow is:
 
-1. Build the selected artifact while holding the target-directory lock.
+1. Acquire the target-directory lock, then plan and build the selected artifact.
+   Planning includes module-level prebuild scripts, which may update persistent
+   build inputs. Dry runs also hold the lock while planning.
 2. Construct its runtime command as `std::process::Command`.
 3. Release the build lock.
 4. Install the platform's parent-side terminal-signal handling.

--- a/docs/dev/design/moon-run-process-lifecycle.md
+++ b/docs/dev/design/moon-run-process-lifecycle.md
@@ -41,7 +41,8 @@ The execution flow is:
 
 1. Acquire the target-directory lock, then plan and build the selected artifact.
    Planning includes module-level prebuild scripts, which may update persistent
-   build inputs. Dry runs also hold the lock while planning.
+   build inputs. A dry run holds the lock during planning only when it executes
+   a module-level prebuild script; otherwise it skips locking.
 2. Construct its runtime command as `std::process::Command`.
 3. Release the build lock.
 4. Install the platform's parent-side terminal-signal handling.

--- a/docs/dev/reference/dry-run.md
+++ b/docs/dev/reference/dry-run.md
@@ -12,4 +12,5 @@
 - **Stable command programs**. A command program directly under the selected toolchain's `bin` directory is shortened to its file name. The running `moon` executable uses its file name. Other command programs remain unchanged unless an explicit override applies. Other occurrences of the same paths, such as build graph inputs, retain their masked or original path form. Platform executable suffixes on toolchain programs are omitted for stable cross-platform output.
 - **Explicit binary overrides**. Only override environment variables that are set are resolved and masked with the corresponding variable name, such as `$MOONC_OVERRIDE`.
 - **`moon run --dry-run` extras**. After the build commands, the dry-run output also prints the command that would execute the produced binary (typically `moonrun`, `node`, or the final executable).
+- **Prebuild locking**. Dry runs that execute [module-level prebuild configuration](prebuild.md) hold the target-directory lock while planning, since these scripts can update persistent build inputs.
 - **`moon test --verbose` extras**. With `--verbose` set, `moon test` print the command that is executed for each test case.

--- a/docs/dev/reference/dry-run.md
+++ b/docs/dev/reference/dry-run.md
@@ -3,6 +3,11 @@
 > **This output is intentionally unstable and meant only for maintainers.**
 > Do not build tools or workflows that depend on the exact formatting or ordering.
 
+A dry run resolves configuration and prints the resulting build commands without
+executing the build graph. Applicable module-level prebuild configuration scripts
+still run to supply dynamic flags, so a dry run is not guaranteed to be free of
+side effects.
+
 - **Deterministic order**. Build commands are printed in a topologically sorted order; executing them sequentially produces the expected build artifacts.
 - **Unix-style command lines**. Every command line is rewritten using Unix shell quoting, even on Windows hosts.
 - **Backslash normalize**. Backslashes `\` in the commandline is normalized to forward slash `/`.
@@ -12,5 +17,5 @@
 - **Stable command programs**. A command program directly under the selected toolchain's `bin` directory is shortened to its file name. The running `moon` executable uses its file name. Other command programs remain unchanged unless an explicit override applies. Other occurrences of the same paths, such as build graph inputs, retain their masked or original path form. Platform executable suffixes on toolchain programs are omitted for stable cross-platform output.
 - **Explicit binary overrides**. Only override environment variables that are set are resolved and masked with the corresponding variable name, such as `$MOONC_OVERRIDE`.
 - **`moon run --dry-run` extras**. After the build commands, the dry-run output also prints the command that would execute the produced binary (typically `moonrun`, `node`, or the final executable).
-- **Prebuild locking**. Dry runs that execute [module-level prebuild configuration](prebuild.md) hold the target-directory lock while planning, since these scripts can update persistent build inputs.
+- **Prebuild locking**. A backend planning pass that executes [module-level prebuild configuration](prebuild.md) holds the target-directory lock while planning, since these scripts can update persistent build inputs. Passes that skip the scripts remain unlocked, including native/LLVM passes with no declared scripts.
 - **`moon test --verbose` extras**. With `--verbose` set, `moon test` print the command that is executed for each test case.

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -76,6 +76,11 @@ directories under the consumer's target directory, so generated files need not
 be written into dependency sources. The directory's internal layout is not part
 of the script API.
 
+The command layer acquires the target-directory lock before planning runs these
+scripts and keeps it until the build has finished consuming their generated
+files. Native and LLVM dry runs also acquire the lock: they execute the scripts
+to determine build commands and can update the same persistent files.
+
 Stdout must contain one build configuration JSON value with the optional fields
 `vars`, `link_configs`, and `rerun_if`; `rerun_if` currently has no effect. Stderr
 carries script diagnostics. A failed script or invalid JSON output fails the

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -82,11 +82,13 @@ Rewriting such a file at the same path may therefore fail to trigger relinking.
 Explicit generated-file dependency declarations and rerun controls remain
 future work for the experimental protocol.
 
-The command layer acquires the target-directory lock before planning runs these
-scripts and keeps it through build execution. This protects script writes and
-any build actions that read their outputs from concurrent invocations. Native
-and LLVM dry runs also acquire the lock: they execute the scripts to determine
-build commands and can update the same persistent files.
+For actual builds, the command layer acquires the target-directory lock before
+planning runs these scripts and keeps it through build execution. This protects
+script writes and any build actions that read their outputs from concurrent
+invocations. For dry runs, each backend planning pass acquires the lock only
+if it will execute a module-level prebuild script, and keeps it through planning.
+Passes that skip the scripts do not acquire the lock, including native and LLVM
+passes when no resolved module declares a script.
 
 Stdout must contain one build configuration JSON value with the optional fields
 `vars`, `link_configs`, and `rerun_if`; `rerun_if` currently has no effect. Stderr

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -76,10 +76,17 @@ directories under the consumer's target directory, so generated files need not
 be written into dependency sources. The directory's internal layout is not part
 of the script API.
 
+This MVP does not register files as build inputs merely because they are written
+to `MOON_BUILD_DIR` or referenced in `link_flags` or `link_search_paths`.
+Rewriting such a file at the same path may therefore fail to trigger relinking.
+Explicit generated-file dependency declarations and rerun controls remain
+future work for the experimental protocol.
+
 The command layer acquires the target-directory lock before planning runs these
-scripts and keeps it until the build has finished consuming their generated
-files. Native and LLVM dry runs also acquire the lock: they execute the scripts
-to determine build commands and can update the same persistent files.
+scripts and keeps it through build execution. This protects script writes and
+any build actions that read their outputs from concurrent invocations. Native
+and LLVM dry runs also acquire the lock: they execute the scripts to determine
+build commands and can update the same persistent files.
 
 Stdout must contain one build configuration JSON value with the optional fields
 `vars`, `link_configs`, and `rerun_if`; `rerun_if` currently has no effect. Stderr

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -32,12 +32,54 @@ For example:
 }
 ```
 
-Every runner uses the module root as its working directory and the same JSON
-protocol. Stdin supplies `env` (the captured environment) and `paths`, including
-`module_root`. Stdout must contain one build configuration JSON value with the
-optional fields `vars`, `link_configs`, and `rerun_if`; `rerun_if` currently has
-no effect. Stderr carries script diagnostics. A failed script or invalid JSON
-output fails the build.
+Every runner uses the module root as its working directory and receives the
+captured process environment with these additional variables:
+
+| Variable | Value |
+| --- | --- |
+| `MOON_MOD` | Absolute path to the module's selected `moon.mod` or `moon.mod.json` manifest |
+| `MOON_BUILD_DIR` | Absolute path to this module's writable prebuild output directory |
+| `MOON_HOST_OS` | OS of the Moon process: `linux`, `macos`, or `windows` |
+| `MOON_HOST_ARCH` | Architecture of the Moon process, using names such as `x86_64` and `aarch64` |
+| `MOON_BACKEND` | Resolved project backend: `native` or `llvm` |
+| `MOON_PROFILE` | Effective project profile: `debug` or `release` |
+| `MOON_JOBS` | Build job limit as a decimal integer, honoring `-j` / `--jobs` |
+
+These variables override any inherited values of the same names. Scripts can
+read their inputs entirely from the environment. For compatibility, stdin still
+supplies the original JSON shape: `env` contains the captured environment before
+these overrides, and `paths` contains `module_root` and `out_dir`. `module_root`
+remains the module directory; `out_dir` now contains the real directory provided
+as `MOON_BUILD_DIR`.
+
+Host OS and architecture describe the Moon process's platform. Backend and
+profile describe the project build, even when the prebuild script itself is
+compiled to Wasm. They reflect effective
+[command defaults](build.md#default-cli-profiles), manifest preferences, and
+explicit CLI overrides.
+
+When `--jobs` is omitted, prebuild scripts and the build executor share the same
+available-parallelism observation, captured once per Moon process. If that
+observation is unavailable, the limit defaults to one. `MOON_JOBS` is a build
+concurrency limit, not a physical CPU count or a jobserver protocol.
+
+`MOON_MOD` reports the manifest using the same preference as module discovery:
+`moon.mod` takes precedence over `moon.mod.json`. It is supplied to prebuild
+scripts as information, not read by Moon as a module-selection override.
+[`MOON_WORK`](workspace.md#moon_work) remains the workspace-selection switch.
+
+Moon creates `MOON_BUILD_DIR` before running the script. It resides under the
+caller's target directory (including `--target-dir`), scoped by backend, profile,
+command, and module. Files persist across repeated builds in that scope; scripts
+must not assume the directory is empty. Dependencies receive their own output
+directories under the consumer's target directory, so generated files need not
+be written into dependency sources. The directory's internal layout is not part
+of the script API.
+
+Stdout must contain one build configuration JSON value with the optional fields
+`vars`, `link_configs`, and `rerun_if`; `rerun_if` currently has no effect. Stderr
+carries script diagnostics. A failed script or invalid JSON output fails the
+build.
 
 MoonBit scripts use standalone `.mbtx` imports and incremental compilation.
 Their target is always linear-memory Wasm, independently of the project backend;
@@ -55,14 +97,17 @@ dependencies shared between consumers.
 
 The ordinary [embedded `.mbtx` policy](moonx.md#standalone-mbtx) applies. Policy
 filesystem roots are relative to the script directory, while the working
-directory remains the module root. An environment policy does not filter the
-environment values explicitly supplied in the JSON input.
+directory remains the module root. An environment policy filters the script's
+environment, including the variables above, but does not filter the values
+explicitly supplied in the compatibility JSON input.
 
 `--moonbit-unstable-prebuild` in `moon.mod.json` supplies dynamic native build
 configuration, such as toolchain selection and compiler or linker flags. It runs
 only for the Native and LLVM target backends. Wasm, WasmGC, and JS builds skip
 it, including `moon build --target wasm --release` and dry runs. This applies
 to both project and standalone-file builds, using the resolved target backend.
+Each backend planning pass runs the scripts separately, with `MOON_BACKEND`
+identifying that pass's backend.
 
 `moon check` skips this configuration for the checked project on every backend.
 Dependency installation can still invoke a separate native or LLVM build whose
@@ -215,8 +260,10 @@ Behavior:
 - Module-level prebuild configuration scripts receive a snapshot of the process
   environment captured by `rr_build` before prebuild execution.
 - Commands that skip prebuild configuration do not capture this environment.
-- The snapshot is passed to each module prebuild script as part of its prebuild
-  input; it is not rediscovered inside individual module execution.
+- The snapshot is passed to each module prebuild script through its environment
+  and the compatibility stdin input; it is not rediscovered inside individual
+  module execution. The module paths are added as environment variables after
+  applying the snapshot.
 
 ## Failure Conditions
 

--- a/docs/manual-zh/src/source/mod_json_schema.html
+++ b/docs/manual-zh/src/source/mod_json_schema.html
@@ -46,7 +46,7 @@
   ],
   "properties": {
     "--moonbit-unstable-prebuild": {
-      "description": "**Experimental:** A relative path to the pre-build configuration script.\n\nThe script may be JavaScript (`.js`, `.cjs`, `.mjs`), Python (`.py`), or MoonBit (`.mbtx`), executed with Node.js, Python, or Moonrun respectively. MoonBit scripts are compiled to Wasm. Each script receives JSON on stdin and returns build configuration JSON on stdout. Since this is experimental, the API may change at any time without warning.",
+      "description": "**Experimental:** A relative path to the pre-build configuration script.\n\nThe script may be JavaScript (`.js`, `.cjs`, `.mjs`), Python (`.py`), or MoonBit (`.mbtx`), executed with Node.js, Python, or Moonrun respectively. MoonBit scripts are compiled to Wasm. Each script receives the process environment plus `MOON_MOD` (the module manifest path) and `MOON_BUILD_DIR` (a writable prebuild output directory created by Moon). `MOON_HOST_OS` and `MOON_HOST_ARCH` describe the Moon process's platform. `MOON_BACKEND`, `MOON_PROFILE`, and `MOON_JOBS` describe the project build. The original JSON input shape is still supplied on stdin for compatibility, with `paths.out_dir` set to the same output directory. Scripts return build configuration JSON on stdout. Since this is experimental, the API may change at any time without warning.",
       "type": [
         "string",
         "null"

--- a/docs/manual/src/source/mod_json_schema.html
+++ b/docs/manual/src/source/mod_json_schema.html
@@ -46,7 +46,7 @@
   ],
   "properties": {
     "--moonbit-unstable-prebuild": {
-      "description": "**Experimental:** A relative path to the pre-build configuration script.\n\nThe script may be JavaScript (`.js`, `.cjs`, `.mjs`), Python (`.py`), or MoonBit (`.mbtx`), executed with Node.js, Python, or Moonrun respectively. MoonBit scripts are compiled to Wasm. Each script receives JSON on stdin and returns build configuration JSON on stdout. Since this is experimental, the API may change at any time without warning.",
+      "description": "**Experimental:** A relative path to the pre-build configuration script.\n\nThe script may be JavaScript (`.js`, `.cjs`, `.mjs`), Python (`.py`), or MoonBit (`.mbtx`), executed with Node.js, Python, or Moonrun respectively. MoonBit scripts are compiled to Wasm. Each script receives the process environment plus `MOON_MOD` (the module manifest path) and `MOON_BUILD_DIR` (a writable prebuild output directory created by Moon). `MOON_HOST_OS` and `MOON_HOST_ARCH` describe the Moon process's platform. `MOON_BACKEND`, `MOON_PROFILE`, and `MOON_JOBS` describe the project build. The original JSON input shape is still supplied on stdin for compatibility, with `paths.out_dir` set to the same output directory. Scripts return build configuration JSON on stdout. Since this is experimental, the API may change at any time without warning.",
       "type": [
         "string",
         "null"


### PR DESCRIPTION
- Related issues: None
- PR kind: Feature

## Summary

Module-level prebuild configuration scripts currently receive their inputs only as JSON on stdin, and `paths.out_dir` is a placeholder. Expose these inputs through environment variables while retaining the stdin protocol for existing scripts.

- Provide `MOON_MOD` as the selected `moon.mod` or `moon.mod.json` manifest and `MOON_BUILD_DIR` as a directory created before script execution. Output directories persist within each module, backend, profile, and command scope under the caller's target directory, including for dependencies.
- Provide `MOON_HOST_OS`, `MOON_HOST_ARCH`, `MOON_BACKEND`, `MOON_PROFILE`, and `MOON_JOBS`. Backend and profile come from the resolved project build, and the job limit uses the same resolution as the executor.
- Preserve the original stdin JSON shape and captured environment. Set `paths.out_dir` to the real output directory. Stdout remains the build configuration JSON protocol.
- Acquire the target-directory lock before prebuild planning and retain it through compilation, so concurrent commands cannot overwrite generated inputs in use by another build. Dry-run planning locks only when the resolved backend and modules require a prebuild script; other dry runs retain their unlocked behavior.

This is an MVP for environment inputs and writable storage. Files written to `MOON_BUILD_DIR` or referenced in linker flags are not automatically registered as build inputs, so rewriting them at the same path may not trigger relinking. Explicit generated-file dependency declarations and rerun controls remain future work; the existing `rerun_if` field still has no effect.

The change reuses the existing target layout, build configuration, and target-directory locks. The planner uses one resolved decision for both script execution and dry-run locking. Coverage includes all three script runners, environment overrides, stdin compatibility, manifest preference, persistent output directories, lock ownership during prebuild execution, and unlocked dry runs that skip scripts. The behavioral references and generated manifest documentation describe the new inputs, dry-run semantics, and locking requirements.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
