### PR TITLE
fix(moonrun): allow Windows spawn without standard handles

### DIFF
--- a/crates/moonrun/src/process/ambient.rs
+++ b/crates/moonrun/src/process/ambient.rs
@@ -508,12 +508,10 @@ fn spawn_process_windows(
 
     let mut inherited_handles =
         Vec::with_capacity(stdio.len() + usize::from(policy_transfer.is_some()));
-    for resource in &stdio {
-        let raw = match resource
-            .as_deref()
-            .ok_or(AsyncHostError::Badf)
-            .and_then(spawn_stdio_handle)
-        {
+    let mut stdio_handles = [std::ptr::null_mut(); 3];
+    for (slot, resource) in stdio_handles.iter_mut().zip(&stdio) {
+        let Some(resource) = resource else { continue };
+        let raw = match spawn_stdio_handle(resource) {
             Ok(raw) => raw,
             Err(error) => {
                 close_handles(&inherited_handles);
@@ -521,7 +519,10 @@ fn spawn_process_windows(
             }
         };
         match duplicate_inheritable_handle(raw) {
-            Ok(handle) => inherited_handles.push(handle),
+            Ok(handle) => {
+                *slot = handle;
+                inherited_handles.push(handle);
+            }
             Err(error) => {
                 close_handles(&inherited_handles);
                 return Err(error);
@@ -548,9 +549,9 @@ fn spawn_process_windows(
     let mut startup_info = unsafe { std::mem::zeroed::<STARTUPINFOEXW>() };
     startup_info.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
     startup_info.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
-    startup_info.StartupInfo.hStdInput = inherited_handles[0];
-    startup_info.StartupInfo.hStdOutput = inherited_handles[1];
-    startup_info.StartupInfo.hStdError = inherited_handles[2];
+    startup_info.StartupInfo.hStdInput = stdio_handles[0];
+    startup_info.StartupInfo.hStdOutput = stdio_handles[1];
+    startup_info.StartupInfo.hStdError = stdio_handles[2];
 
     let attr_count = if job_object.is_some() { 2 } else { 1 };
     let mut attrs_size = 0;
@@ -573,17 +574,19 @@ fn spawn_process_windows(
         return Err(error);
     }
 
-    if unsafe {
-        UpdateProcThreadAttribute(
-            startup_info.lpAttributeList,
-            0,
-            PROC_THREAD_ATTRIBUTE_HANDLE_LIST as usize,
-            inherited_handles.as_ptr().cast(),
-            inherited_handles.len() * std::mem::size_of::<HANDLE>(),
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-        )
-    } == 0
+    // Win32 rejects an empty explicit handle list with ERROR_BAD_LENGTH.
+    if !inherited_handles.is_empty()
+        && unsafe {
+            UpdateProcThreadAttribute(
+                startup_info.lpAttributeList,
+                0,
+                PROC_THREAD_ATTRIBUTE_HANDLE_LIST as usize,
+                inherited_handles.as_ptr().cast(),
+                inherited_handles.len() * std::mem::size_of::<HANDLE>(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        } == 0
     {
         let error = last_native_error();
         unsafe {
@@ -625,7 +628,7 @@ fn spawn_process_windows(
             command_line.as_mut_ptr(),
             std::ptr::null(),
             std::ptr::null(),
-            1,
+            i32::from(!inherited_handles.is_empty()),
             create_flags,
             env_block.as_ptr().cast(),
             cwd.as_ref().map_or(std::ptr::null(), |cwd| cwd.as_ptr()),
@@ -1045,6 +1048,83 @@ mod tests {
 #[cfg(all(test, windows))]
 mod windows_tests {
     use super::*;
+
+    #[test]
+    fn spawn_without_standard_handles() {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Foundation::{INVALID_HANDLE_VALUE, WAIT_OBJECT_0};
+        use windows_sys::Win32::System::Console::{
+            STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, SetStdHandle,
+        };
+        use windows_sys::Win32::System::Threading::{GetExitCodeProcess, WaitForSingleObject};
+
+        const CHILD: &str = "MOONRUN_TEST_ABSENT_STDIO";
+        if std::env::var_os(CHILD).is_none() {
+            // Changing process stdio must not affect other tests or libtest's
+            // own output. Exercise both Win32 representations in isolated runs.
+            for missing in ["null", "invalid"] {
+                assert!(
+                    std::process::Command::new(std::env::current_exe().unwrap())
+                        .args([
+                            "--exact",
+                            "process::ambient::windows_tests::spawn_without_standard_handles"
+                        ])
+                        .env(CHILD, missing)
+                        .status()
+                        .unwrap()
+                        .success()
+                );
+            }
+            return;
+        }
+        let missing = if std::env::var(CHILD).unwrap() == "null" {
+            std::ptr::null_mut()
+        } else {
+            INVALID_HANDLE_VALUE
+        };
+        for stream in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+            assert_ne!(unsafe { SetStdHandle(stream, missing) }, 0);
+        }
+
+        // Cover an empty inheritance list and a partial stdio set, with and
+        // without the child Job Object attribute.
+        for is_orphan in [false, true] {
+            for redirect_stdout in [false, true] {
+                let output = tempfile::tempfile().unwrap();
+                let stdout = redirect_stdout
+                    .then(|| std::sync::Arc::new(Resource::stdio_file(output.as_raw_handle())));
+                let command = std::env::var("COMSPEC").unwrap();
+                let mut job = super::super::Job::spawn_windows(
+                    format!("\"{command}\" /d /c exit 23").into(),
+                    vec![0, 0],
+                    None,
+                    stdout,
+                    None,
+                    None,
+                    SpawnOptions {
+                        no_console_window: true,
+                        is_orphan,
+                    },
+                );
+                job.configure_stdio(&crate::runtime::Stdio::Ambient)
+                    .unwrap();
+                assert!(job.run().unwrap() > 0);
+                let Some(ResourcePublication::Unpublished(process)) =
+                    job.take_spawn_result().unwrap()
+                else {
+                    panic!("spawn must publish its process handle");
+                };
+                let handle = process.as_file().unwrap().as_raw_handle();
+                assert_eq!(
+                    unsafe { WaitForSingleObject(handle, 10_000) },
+                    WAIT_OBJECT_0
+                );
+                let mut exit_code = 0;
+                assert_ne!(unsafe { GetExitCodeProcess(handle, &mut exit_code) }, 0);
+                assert_eq!(exit_code, 23);
+            }
+        }
+    }
 
     #[test]
     fn spawn_stdio_accepts_socket_resource() {

--- a/crates/moonrun/src/process/job/mod.rs
+++ b/crates/moonrun/src/process/job/mod.rs
@@ -332,12 +332,11 @@ impl Job {
             #[cfg(windows)]
             Kind::SpawnWindows { stdio, .. } => {
                 for (slot, stream) in stdio.iter_mut().zip(StdioStream::ALL) {
-                    if slot.is_none() {
-                        let raw = runtime_stdio.raw(stream).map_err(|error| {
-                            error
-                                .raw_os_error()
-                                .map_or(AsyncHostError::Io, AsyncHostError::Native)
-                        })?;
+                    // GUI processes may have no standard streams. Preserve
+                    // absence for CreateProcessW instead of rejecting spawn.
+                    if slot.is_none()
+                        && let Ok(raw) = runtime_stdio.raw(stream)
+                    {
                         *slot = Some(Arc::new(crate::resource::Resource::stdio_file(raw)));
                     }
                 }


### PR DESCRIPTION
- Related issues: moonbitlang/async#565
- PR kind: Bugfix (upstream backport)

## Summary

Windows applications launched without a console may have missing standard handles. Port async #565 and its empty-handle-list follow-up: preserve absent stdio slots, include only valid handles in the inheritance list, and omit the handle-list attribute when that list is empty.

The change is confined to Windows spawn setup and advances the async fixture through this port. Process policy and child cleanup retain their existing ownership. Later watcher, signal, and cancellation ports are separate PRs.

Keep the originating async request labeled required until this change reaches Moon's `main`.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS

