### PR TITLE
fix(moonrun): deliver run signals without worker jobs

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -240,7 +240,13 @@ The destination for signals injected into one Run. It owns that guest's
 cancellation-signal selection and its Completion target. A Signal Sender selects
 one Run by owning the sending half; it never raises an operating-system signal.
 The guest starts and stops delivery without consuming a Worker. On Unix the
-existing CLI signal broker forwards directly into the Run's Completion Queue.
+existing CLI signal broker coalesces pending signals in a bitset and wakes the
+poller through a separate nonblocking pipe. Its level-triggered read end reports
+the same guest Completion Source as the worker pipe; fetching completions drains
+pending signals before worker IDs. Partial signal fetches retain readiness.
+Acceptance and detachment share a lock, and detachment discards pending signals.
+The broker never waits for space in the worker pipe or falls back to process
+termination because that pipe closes during an accepted delivery.
 Older guests retain a virtual signal-wait Job with a nonblocking self-pipe and
 pending-signal mask. Its cancellation hook records cancellation before waking
 the same pipe, and remains isolated from the direct delivery path.

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -237,15 +237,15 @@ _Avoid_: Host exit, import-side exit, process-global termination state
 
 **Run Signals**:
 The destination for signals injected into one Run. It owns that guest's
-cancellation-signal selection and a channel shared with that Run's virtual
-signal-wait Job. A Signal Sender selects one Run by owning the sending half; it
-never raises an operating-system signal. On Unix the channel is a nonblocking
-self-pipe with a pending-signal mask: the pipe wakes the Job, the mask coalesces
-standard signals, and the Job publishes them to the Run's Completion target.
-The virtual Job supplies the thread pool's native-shaped optional cancellation
-hook, which records cancellation and wakes the same pipe without a timing race.
+cancellation-signal selection and its Completion target. A Signal Sender selects
+one Run by owning the sending half; it never raises an operating-system signal.
+The guest starts and stops delivery without consuming a Worker. On Unix the
+existing CLI signal broker forwards directly into the Run's Completion Queue.
+Older guests retain a virtual signal-wait Job with a nonblocking self-pipe and
+pending-signal mask. Its cancellation hook records cancellation before waking
+the same pipe, and remains isolated from the direct delivery path.
 Ordinary Unix Jobs retain the default `SIGUSR2` interruption path. Signals sent
-before the guest registration and virtual waiter are ready are not retained.
+before guest registration and delivery startup are ready are not retained.
 Forced interruption and broader Run lifecycle belong to a later control layer
 rather than this delivery seam.
 _Avoid_: process signal handler, global completion target, Run lifecycle
@@ -296,8 +296,8 @@ _Avoid_: Host state, native-stub implementation
 **Async Host**:
 Moonrun-owned async state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Runtime's shared Host Key namespace and materializes its reserved standard-stream Resources from the Runtime Stdio. It owns the common Job lifecycle for Filesystem, Network, Process, Run Signal, and SQLite payloads; domain semantics remain with their Host Domains.
 It owns one Run Signal receiver, translates guest cancellation registration
-into that receiver's interest, and constructs the Unix virtual signal-wait Job
-against the Run's Completion target.
+into that receiver's interest, starts and stops delivery to the Run's Completion
+target, and retains the Unix virtual signal-wait Job for older guests.
 _Avoid_: `moonbitlang/async` source mirror
 
 **SQLite API**:

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -94,11 +94,10 @@ cannot yet forcibly interrupt guest execution. The `moonrun` CLI owns a
 process-lifetime adapter and forwards accepted signals directly through such a
 channel. On Unix it blocks its managed signals before creating the Engine and
 receives them on a `sigwait` thread; spawned guest processes retain the signal
-mask from before that block. Each Run's guest signal-wait Job is virtual: it
-receives forwarded signals through the Run channel rather than competing for
-process-wide signals. It supplies the same optional cancellation hook supported
-by the native Job model, recording cancellation before waking its blocking pipe
-read. Ordinary Unix Jobs retain the thread pool's `pthread_kill(SIGUSR2)` path.
+mask from before that block. The guest starts and stops delivery directly to its
+Run's completion queue, so signal handling does not consume an async worker.
+Older Wasm guests retain a virtual signal-wait Job and its cancellation hook.
+Ordinary Unix Jobs retain the thread pool's `pthread_kill(SIGUSR2)` path.
 If the Run does not accept a signal, the adapter applies the process's existing
 signal behavior.
 

--- a/crates/moonrun/src/async_api/os_error.rs
+++ b/crates/moonrun/src/async_api/os_error.rs
@@ -28,7 +28,12 @@ pub(super) fn get_errno(context: &mut ImportContext<'_, '_>) -> i32 {
     stub::get_errno(context.host)
 }
 
-#[ported(source = "src/os_error/stub.c")]
+#[compat(
+    source = "src/os_error/stub.c",
+    original = "moonbitlang_async_is_nonblocking_io_error",
+    upstream_pr = 566,
+    replacement = "platform errno constants in src/os_error/error.mbt"
+)]
 pub(super) fn is_nonblocking_io_error(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_nonblocking_io_error(errno) {
         1
@@ -37,32 +42,62 @@ pub(super) fn is_nonblocking_io_error(_context: &mut ImportContext<'_, '_>, errn
     }
 }
 
-#[ported(source = "src/os_error/stub.c")]
+#[compat(
+    source = "src/os_error/stub.c",
+    original = "moonbitlang_async_is_EINTR",
+    upstream_pr = 566,
+    replacement = "platform errno constants in src/os_error/error.mbt"
+)]
 pub(super) fn is_eintr(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_eintr(errno) { 1 } else { 0 }
 }
 
-#[ported(source = "src/os_error/stub.c")]
+#[compat(
+    source = "src/os_error/stub.c",
+    original = "moonbitlang_async_is_ENOENT",
+    upstream_pr = 566,
+    replacement = "platform errno constants in src/os_error/error.mbt"
+)]
 pub(super) fn is_enoent(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_enoent(errno) { 1 } else { 0 }
 }
 
-#[ported(source = "src/os_error/stub.c")]
+#[compat(
+    source = "src/os_error/stub.c",
+    original = "moonbitlang_async_is_EEXIST",
+    upstream_pr = 566,
+    replacement = "platform errno constants in src/os_error/error.mbt"
+)]
 pub(super) fn is_eexist(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_eexist(errno) { 1 } else { 0 }
 }
 
-#[ported(source = "src/os_error/stub.c")]
+#[compat(
+    source = "src/os_error/stub.c",
+    original = "moonbitlang_async_is_EACCES",
+    upstream_pr = 566,
+    replacement = "platform errno constants in src/os_error/error.mbt"
+)]
 pub(super) fn is_eacces(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_eacces(errno) { 1 } else { 0 }
 }
 
-#[ported(source = "src/os_error/stub.c")]
+#[compat(
+    source = "src/os_error/stub.c",
+    original = "moonbitlang_async_is_ECONNREFUSED",
+    upstream_pr = 566,
+    replacement = "platform errno constants in src/os_error/error.mbt"
+)]
 pub(super) fn is_econnrefused(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_econnrefused(errno) { 1 } else { 0 }
 }
 
-#[ported(source = "src/os_error/stub.c")]
+#[compat(
+    source = "src/os_error/stub.c",
+    original = "moonbitlang_async_is_ERROR_NOTIFY_ENUM_DIR",
+    upstream_pr = 566,
+    replacement = "platform errno constants in src/os_error/error.mbt"
+)]
 pub(super) fn is_error_notify_enum_dir(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_error_notify_enum_dir(errno) {
         1
@@ -80,12 +115,22 @@ pub(super) fn free_errno_str(context: &mut ImportContext<'_, '_>, ptr: u64) -> A
     super::c_buffer::free(context, ptr)
 }
 
-#[ported(source = "src/os_error/stub.c")]
+#[compat(
+    source = "src/os_error/stub.c",
+    original = "moonbitlang_async_get_ENOTDIR",
+    upstream_pr = 566,
+    replacement = "platform errno constants in src/os_error/error.mbt"
+)]
 pub(super) fn get_enotdir(_context: &mut ImportContext<'_, '_>) -> i32 {
     stub::get_enotdir()
 }
 
-#[ported(source = "src/os_error/stub.c")]
+#[compat(
+    source = "src/os_error/stub.c",
+    original = "moonbitlang_async_get_ENOTSUP",
+    upstream_pr = 566,
+    replacement = "platform errno constants in src/os_error/error.mbt"
+)]
 pub(super) fn get_enotsup(_context: &mut ImportContext<'_, '_>) -> i32 {
     stub::get_enotsup()
 }

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -658,23 +658,23 @@ declare_async_imports! {
     // os_error/stub.c predicates, errno accessors, and string formatting.
     ported os_error::get_errno() -> i32 => "os_error/get_errno";
 
-    ported os_error::is_nonblocking_io_error(errno: i32) -> i32 => "os_error/is_nonblocking_io_error";
+    compat os_error::is_nonblocking_io_error(errno: i32) -> i32 => "os_error/is_nonblocking_io_error";
 
-    ported os_error::is_eintr(errno: i32) -> i32 => "os_error/is_EINTR";
+    compat os_error::is_eintr(errno: i32) -> i32 => "os_error/is_EINTR";
 
-    ported os_error::is_enoent(errno: i32) -> i32 => "os_error/is_ENOENT";
+    compat os_error::is_enoent(errno: i32) -> i32 => "os_error/is_ENOENT";
 
-    ported os_error::is_eexist(errno: i32) -> i32 => "os_error/is_EEXIST";
+    compat os_error::is_eexist(errno: i32) -> i32 => "os_error/is_EEXIST";
 
-    ported os_error::is_eacces(errno: i32) -> i32 => "os_error/is_EACCES";
+    compat os_error::is_eacces(errno: i32) -> i32 => "os_error/is_EACCES";
 
-    ported os_error::is_econnrefused(errno: i32) -> i32 => "os_error/is_ECONNREFUSED";
+    compat os_error::is_econnrefused(errno: i32) -> i32 => "os_error/is_ECONNREFUSED";
 
-    ported os_error::is_error_notify_enum_dir(errno: i32) -> i32 => "os_error/is_ERROR_NOTIFY_ENUM_DIR";
+    compat os_error::is_error_notify_enum_dir(errno: i32) -> i32 => "os_error/is_ERROR_NOTIFY_ENUM_DIR";
 
-    ported os_error::get_enotdir() -> i32 => "os_error/get_ENOTDIR";
+    compat os_error::get_enotdir() -> i32 => "os_error/get_ENOTDIR";
 
-    ported os_error::get_enotsup() -> i32 => "os_error/get_ENOTSUP";
+    compat os_error::get_enotsup() -> i32 => "os_error/get_ENOTSUP";
 
     ported os_error::errno_to_string(errno: i32) -> u64 => "os_error/errno_to_string";
 
@@ -702,6 +702,16 @@ declare_async_imports! {
 
     #[cfg(windows)]
     ported signal::set_console_control_handler(add: i32) -> i32 => "signal/set_console_control_handler";
+
+    #[cfg(unix)]
+    ported signal::start_signal_handler() -> void => "signal/start_signal_handler";
+    #[cfg(windows)]
+    fake signal::start_signal_handler() -> void => "signal/start_signal_handler";
+
+    #[cfg(unix)]
+    ported signal::terminate_signal_handler() -> void => "signal/terminate_signal_handler";
+    #[cfg(windows)]
+    fake signal::terminate_signal_handler() -> void => "signal/terminate_signal_handler";
 
     #[cfg(unix)]
     fake signal::set_console_control_handler(add: i32) -> i32 => "signal/set_console_control_handler";
@@ -1618,7 +1628,7 @@ declare_async_imports! {
     ported thread_pool::make_wait_for_process_job(handle: u64, pid: i32) -> u64 => "thread_pool/make_wait_for_process_job";
 
     #[cfg(unix)]
-    ported thread_pool::make_sigwait_job(signals: u32, signals_len: u32) -> u64 => "thread_pool/make_sigwait_job";
+    compat thread_pool::make_sigwait_job(signals: u32, signals_len: u32) -> u64 => "thread_pool/make_sigwait_job";
 
     #[cfg(windows)]
     fake thread_pool::make_sigwait_job(signals: u32, signals_len: u32) -> u64 => "thread_pool/make_sigwait_job";
@@ -1732,6 +1742,7 @@ fn async_api_compat_imports() -> Vec<super::provenance::CompatImport> {
     imports.extend_from_slice(thread_pool::COMPAT_IMPORTS);
     imports.extend_from_slice(fd_util::COMPAT_IMPORTS);
     imports.extend_from_slice(process::COMPAT_IMPORTS);
+    imports.extend_from_slice(os_error::COMPAT_IMPORTS);
     imports
 }
 
@@ -1953,6 +1964,29 @@ mod tests {
                 "removed native stat ABI {wasm_symbol} must remain available through a compatibility adapter"
             );
         }
+    }
+
+    #[test]
+    fn signal_handler_imports_coexist_with_the_legacy_job_abi() {
+        for symbol in [
+            "signal/start_signal_handler",
+            "signal/terminate_signal_handler",
+        ] {
+            let import = ASYNC_IMPORTS
+                .iter()
+                .find(|import| import.wasm_symbol == symbol)
+                .unwrap();
+            assert!(import.params.is_empty());
+            assert_eq!(import.result, None);
+        }
+        let legacy = ASYNC_IMPORTS
+            .iter()
+            .find(|import| import.wasm_symbol == "thread_pool/make_sigwait_job")
+            .unwrap();
+        assert_eq!(legacy.params, &[WasmType::I32, WasmType::I32]);
+        assert_eq!(legacy.result, Some(WasmType::I64));
+        #[cfg(unix)]
+        assert_eq!(legacy.kind, AsyncImportKind::Compat);
     }
 
     #[test]

--- a/crates/moonrun/src/async_api/signal.rs
+++ b/crates/moonrun/src/async_api/signal.rs
@@ -24,6 +24,18 @@ use super::context::ImportContext;
 use super::provenance::ported_imports;
 
 ported_imports! {
+#[ported(source = "src/internal/event_loop/signal.c")]
+#[cfg(unix)]
+pub(super) fn start_signal_handler(context: &mut ImportContext<'_, '_>) -> crate::async_host::AsyncHostResult<()> {
+    context.host.start_signal_handler()
+}
+
+#[ported(source = "src/internal/event_loop/signal.c")]
+#[cfg(unix)]
+pub(super) fn terminate_signal_handler(context: &mut ImportContext<'_, '_>) {
+    context.host.terminate_signal_handler();
+}
+
 pub(super) fn get_signal_by_index(
     _context: &mut ImportContext<'_, '_>,
     index: u32,

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -808,7 +808,13 @@ pub(super) fn make_wait_for_process_job(
     context.host.make_wait_for_process_job(handle, pid)
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_make_sigwait_job",
+    upstream_pr = 581,
+    replacement = "signal/start_signal_handler and signal/terminate_signal_handler",
+    api_only = true
+)]
 #[cfg(unix)]
 pub(super) fn make_sigwait_job(
     context: &mut ImportContext<'_, '_>,

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1183,6 +1183,8 @@ pub(crate) struct AsyncHost {
     polls: RefCell<PollTable>,
     thread_pool_completions: RefCell<ThreadPoolCompletions>,
     signals: SignalReceiver,
+    #[cfg(unix)]
+    signal_handler: RefCell<Option<crate::run_signal::SignalTargetGuard>>,
     handles: RefCell<HandleTable>,
     tls_connections: RefCell<SecondaryMap<HandleKey, tls::TlsHandle>>,
     tls_error: RefCell<Option<String>>,
@@ -1223,6 +1225,8 @@ impl AsyncHost {
             polls: RefCell::new(PollTable::default()),
             thread_pool_completions: RefCell::new(ThreadPoolCompletions::default()),
             signals,
+            #[cfg(unix)]
+            signal_handler: RefCell::new(None),
             handles: RefCell::new(HandleTable::with_keys(keys, stdio)),
             tls_connections: RefCell::new(SecondaryMap::new()),
             tls_error: RefCell::new(None),
@@ -1722,6 +1726,26 @@ impl AsyncHost {
     }
 
     #[cfg(unix)]
+    pub(crate) fn start_signal_handler(&self) -> AsyncHostResult<()> {
+        if self.signal_handler.borrow().is_none() {
+            let handler = crate::async_sys::signal::start_signal_handler(
+                &self.signals,
+                self.thread_pool_notifier()?,
+            )?;
+            *self.signal_handler.borrow_mut() = Some(handler);
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn terminate_signal_handler(&self) {
+        crate::async_sys::signal::terminate_signal_handler(
+            &self.signals,
+            self.signal_handler.borrow_mut().take(),
+        );
+    }
+
+    #[cfg(unix)]
     pub(crate) fn make_sigwait_job(&self, signals: Vec<i32>) -> AsyncHostResult<HostHandle> {
         let notifier = self.thread_pool_notifier()?;
         let job = crate::async_sys::signal::make_sigwait_job(&self.signals, &signals, notifier)?;
@@ -1805,6 +1829,8 @@ impl AsyncHost {
     }
 
     pub(crate) fn destroy_thread_pool(&self) {
+        #[cfg(unix)]
+        self.terminate_signal_handler();
         for worker in self.workers.destroy() {
             self.handles.borrow_mut().remove_worker_key(worker.key);
             if let Some(unrun_job) = worker.unrun_job {
@@ -5151,6 +5177,45 @@ mod tests {
 
         #[cfg(windows)]
         assert_eq!(crate::async_sys::internal::event_loop::io::cleanup_wsa(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_handler_reconfigures_restarts_and_detaches_with_the_pool() {
+        let (sender, receiver) = crate::signal_channel();
+        let mut host = default_host();
+        host.signals = receiver;
+        let poll = host.poll_create().unwrap();
+        host.init_thread_pool(poll).unwrap();
+        let notifier = host.thread_pool_notifier().unwrap();
+        let all = [libc::SIGINT, libc::SIGTERM];
+        host.set_cancellation_signals(&all, &[libc::SIGINT])
+            .unwrap();
+        assert_eq!(sender.send(libc::SIGINT), Ok(false));
+        host.start_signal_handler().unwrap();
+        host.start_signal_handler().unwrap();
+        assert_eq!(host.workers.len(), 0);
+        assert_eq!(sender.send(libc::SIGINT), Ok(true));
+        let mut event = [0; 4];
+        assert_eq!(notifier.fetch(&mut event), Ok(4));
+        assert_eq!(i32::from_ne_bytes(event), libc::SIGINT | i32::MIN);
+
+        host.set_cancellation_signals(&all, &[libc::SIGTERM])
+            .unwrap();
+        assert_eq!(sender.send(libc::SIGINT), Ok(false));
+        assert_eq!(sender.send(libc::SIGTERM), Ok(true));
+        assert_eq!(notifier.fetch(&mut event), Ok(4));
+        assert_eq!(i32::from_ne_bytes(event), libc::SIGTERM | i32::MIN);
+
+        host.terminate_signal_handler();
+        assert_eq!(sender.send(libc::SIGTERM), Ok(false));
+        host.set_cancellation_signals(&all, &all).unwrap();
+        host.start_signal_handler().unwrap();
+        assert_eq!(sender.send(libc::SIGINT), Ok(true));
+        assert_eq!(notifier.fetch(&mut event), Ok(4));
+        host.destroy_thread_pool();
+        assert_eq!(sender.send(libc::SIGINT), Ok(false));
+        assert!(host.signal_handler.borrow().is_none());
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -5220,6 +5220,134 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn signal_bursts_do_not_wait_for_worker_completions() {
+        let (sender, receiver) = crate::signal_channel();
+        let mut host = default_host();
+        host.signals = receiver;
+        let poll = host.poll_create().unwrap();
+        let source = host.init_thread_pool(poll).unwrap();
+        let signals = [libc::SIGINT, libc::SIGTERM];
+        host.set_cancellation_signals(&signals, &signals).unwrap();
+        host.start_signal_handler().unwrap();
+        host.thread_pool_notifier()
+            .unwrap()
+            .fill_with_completions(17);
+
+        let (finished, result) = std::sync::mpsc::channel();
+        let broker = std::thread::spawn(move || {
+            let delivered = (0..65536).try_for_each(|index| {
+                sender
+                    .send(signals[index % signals.len()])
+                    .map(|accepted| assert!(accepted))
+            });
+            finished.send(delivered).unwrap();
+        });
+        let delivered = result.recv_timeout(std::time::Duration::from_secs(2));
+        if delivered.is_err() {
+            // Release a blocked writer so the regression fails without leaking a thread.
+            host.destroy_thread_pool();
+        }
+        broker.join().unwrap();
+        assert_eq!(
+            delivered,
+            Ok(Ok(())),
+            "signal delivery blocked on the full worker pipe"
+        );
+
+        let mut memory = [0; 12];
+        assert_eq!(
+            host.fetch_completion(memory.as_mut_slice(), source, 0, 3)
+                .unwrap(),
+            12
+        );
+        let events: Vec<_> = memory
+            .chunks_exact(4)
+            .map(|bytes| i32::from_ne_bytes(bytes.try_into().unwrap()))
+            .collect();
+        assert_eq!(
+            events,
+            [libc::SIGINT | i32::MIN, libc::SIGTERM | i32::MIN, 17]
+        );
+        assert_eq!(host.workers.len(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_notifications_remain_ready_until_fetched_and_are_discarded_on_detach() {
+        let (sender, receiver) = crate::signal_channel();
+        let mut host = default_host();
+        host.signals = receiver;
+        let poll = host.poll_create().unwrap();
+        let source = host.init_thread_pool(poll).unwrap();
+        let signals = [libc::SIGINT, libc::SIGTERM];
+        host.set_cancellation_signals(&signals, &signals).unwrap();
+        host.start_signal_handler().unwrap();
+        for signal in signals {
+            assert_eq!(sender.send(signal), Ok(true));
+        }
+        let mut memory = [0; 4];
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        assert_eq!(
+            host.poll_event_fd(host.poll_get_event(poll, 0).unwrap())
+                .unwrap(),
+            source
+        );
+        assert_eq!(
+            host.fetch_completion(memory.as_mut_slice(), source, 0, 0)
+                .unwrap(),
+            0
+        );
+        for signal in signals {
+            assert_eq!(host.poll_wait(poll, 0).unwrap(), 1);
+            assert_eq!(
+                host.fetch_completion(memory.as_mut_slice(), source, 0, 1)
+                    .unwrap(),
+                4
+            );
+            assert_eq!(i32::from_ne_bytes(memory), signal | i32::MIN);
+        }
+        assert_eq!(host.poll_wait(poll, 0).unwrap(), 0);
+
+        assert_eq!(sender.send(libc::SIGTERM), Ok(true));
+        host.terminate_signal_handler();
+        assert_eq!(host.poll_wait(poll, 0).unwrap(), 0);
+        assert_eq!(sender.send(libc::SIGTERM), Ok(false));
+        host.set_cancellation_signals(&signals, &signals).unwrap();
+        host.start_signal_handler().unwrap();
+        assert_eq!(
+            host.fetch_completion(memory.as_mut_slice(), source, 0, 1)
+                .unwrap(),
+            0
+        );
+        assert_eq!(sender.send(libc::SIGINT), Ok(true));
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_delivery_detaches_when_its_poll_or_completion_source_closes() {
+        for close_poll in [false, true] {
+            let (sender, receiver) = crate::signal_channel();
+            let mut host = default_host();
+            host.signals = receiver;
+            let poll = host.poll_create().unwrap();
+            let source = host.init_thread_pool(poll).unwrap();
+            host.set_cancellation_signals(&[libc::SIGINT], &[libc::SIGINT])
+                .unwrap();
+            host.start_signal_handler().unwrap();
+            assert_eq!(sender.send(libc::SIGINT), Ok(true));
+            if close_poll {
+                host.poll_destroy(poll).unwrap();
+            } else {
+                host.close_fd(source).unwrap();
+            }
+            assert_eq!(sender.send(libc::SIGINT), Ok(false));
+            assert!(host.signal_handler.borrow().is_none());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn thread_pool_exposes_its_concrete_child_signal_mask_only_while_active() {
         let mut child_signal_mask = unsafe { std::mem::zeroed::<libc::sigset_t>() };
         assert_eq!(unsafe { libc::sigemptyset(&mut child_signal_mask) }, 0);

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1527,6 +1527,7 @@ impl AsyncHost {
         #[cfg(unix)]
         {
             if let Some(source) = completion_source {
+                self.terminate_signal_handler();
                 let _ = self.handles.borrow_mut().remove_resource(source);
             }
             if let Some(old_signal_mask) = old_signal_mask {
@@ -1792,10 +1793,20 @@ impl AsyncHost {
                 let _ = self.handles.borrow_mut().remove_resource(source);
                 return Err(error);
             }
+            let signal_fd = completion_notifier.signal_fd();
+            // Both sources use the same guest handle. fetch_completion merges
+            // pending Run signals with worker IDs without a forwarding thread.
+            if let Err(error) = poll::poll_register_signal_source(&poll.instance, signal_fd, source)
+            {
+                let _ = poll::poll_unregister(&poll.instance, event_fd);
+                let _ = self.handles.borrow_mut().remove_resource(source);
+                return Err(error);
+            }
             let source = {
                 let mut completions = self.thread_pool_completions.borrow_mut();
                 if completions.source.is_some() {
                     drop(completions);
+                    let _ = poll::poll_unregister(&poll.instance, signal_fd);
                     let _ = poll::poll_unregister(&poll.instance, event_fd);
                     let _ = self.handles.borrow_mut().remove_resource(source);
                     return Err(AsyncHostError::Inval);
@@ -1803,6 +1814,7 @@ impl AsyncHost {
                 // Publish the poll-side mapping before exposing the notifier:
                 // workers can notify as soon as completions.notifier is visible.
                 poll.registered_fds.insert(event_fd);
+                poll.registered_fds.insert(signal_fd);
                 poll.completion_notifier = Some(Arc::clone(&completion_notifier));
                 completions.notifier = Some(completion_notifier);
                 completions.source = Some(source);
@@ -1860,7 +1872,11 @@ impl AsyncHost {
                 }
             }
             for poll in polls.polls.values_mut() {
-                poll.completion_notifier = None;
+                if let Some(notifier) = poll.completion_notifier.take() {
+                    let signal_fd = notifier.signal_fd();
+                    let _ = poll::poll_unregister(&poll.instance, signal_fd);
+                    poll.registered_fds.remove(&signal_fd);
+                }
             }
             if let Some(old_signal_mask) = old_signal_mask {
                 let _ = crate::async_sys::signal::restore_thread_pool_signal_mask(&old_signal_mask);
@@ -2557,8 +2573,13 @@ impl AsyncHost {
                 }
             };
             if completion_source_closed {
+                self.terminate_signal_handler();
                 for poll in polls.polls.values_mut() {
-                    poll.completion_notifier = None;
+                    if let Some(notifier) = poll.completion_notifier.take() {
+                        let signal_fd = notifier.signal_fd();
+                        let _ = poll::poll_unregister(&poll.instance, signal_fd);
+                        poll.registered_fds.remove(&signal_fd);
+                    }
                 }
                 if let Some(old_signal_mask) = old_signal_mask {
                     let _ =

--- a/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
@@ -22,12 +22,22 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub as fd_util;
 #[cfg(unix)]
 use crate::async_sys::internal::fd_util::stub::RawFd;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+#[cfg(unix)]
+use std::sync::Mutex;
 
 #[cfg(unix)]
 #[derive(Debug)]
 pub(crate) struct ThreadPoolCompletionNotifier {
     notify_recv: RawFd,
     notify_send: RawFd,
+    // Run signals must not backpressure the process-wide signal broker. They
+    // coalesce separately from worker IDs, with one wake byte while nonempty.
+    // Both ends stay alive with the notifier, including during an in-flight send.
+    signal_recv: OwnedFd,
+    signal_send: OwnedFd,
+    pending_signals: Mutex<u32>,
 }
 
 #[cfg(unix)]
@@ -62,6 +72,9 @@ impl ThreadPoolCompletionNotifier {
     }
 
     pub(crate) fn new() -> AsyncHostResult<(Self, RawFd)> {
+        let signals = fd_util::pipe(true, true)?;
+        let signal_recv = unsafe { OwnedFd::from_raw_fd(signals[0]) };
+        let signal_send = unsafe { OwnedFd::from_raw_fd(signals[1]) };
         let fds = fd_util::pipe(true, false)?;
 
         // The read end is transferred to AsyncHost's file table so poll
@@ -70,6 +83,9 @@ impl ThreadPoolCompletionNotifier {
             Self {
                 notify_recv: fds[0],
                 notify_send: fds[1],
+                signal_recv,
+                signal_send,
+                pending_signals: Mutex::new(0),
             },
             fds[0],
         ))
@@ -104,24 +120,105 @@ impl ThreadPoolCompletionNotifier {
         }
     }
 
+    pub(crate) fn signal_fd(&self) -> RawFd {
+        self.signal_recv.as_raw_fd()
+    }
+
+    pub(crate) fn notify_signal(&self, signal_bit: u32) -> AsyncHostResult<()> {
+        let mut pending = self.pending_signals.lock().unwrap();
+        if *pending == 0 {
+            // Serialize the empty-to-nonempty transition with fetch/discard.
+            // This pipe contains only the wake byte, never individual events.
+            loop {
+                let written =
+                    unsafe { libc::write(self.signal_send.as_raw_fd(), b"x".as_ptr().cast(), 1) };
+                if written == 1 {
+                    break;
+                }
+                if written == 0 {
+                    return Err(AsyncHostError::Inval);
+                }
+                let errno = last_errno();
+                if errno == libc::EINTR {
+                    continue;
+                }
+                if would_block(errno) {
+                    // An existing wake byte already makes the poller readable.
+                    break;
+                }
+                return Err(AsyncHostError::Native(errno));
+            }
+        }
+        *pending |= signal_bit;
+        Ok(())
+    }
+
+    fn fetch_signals(&self, dst: &mut [u8]) -> AsyncHostResult<usize> {
+        let mut pending = self.pending_signals.lock().unwrap();
+        let mut bytes = 0;
+        for output in dst.chunks_exact_mut(4) {
+            if *pending == 0 {
+                break;
+            }
+            let signal = pending.trailing_zeros();
+            output.copy_from_slice(&((signal as i32) | i32::MIN).to_ne_bytes());
+            *pending &= !(1 << signal);
+            bytes += 4;
+        }
+        if bytes != 0 && *pending == 0 {
+            // Leave the byte untouched after a partial fetch: the poller must
+            // remain readable until every pending signal has been consumed.
+            loop {
+                let mut wake = 0_u8;
+                let read =
+                    unsafe { libc::read(self.signal_recv.as_raw_fd(), (&raw mut wake).cast(), 1) };
+                if read == 1 {
+                    break;
+                }
+                if read == 0 {
+                    return Err(AsyncHostError::Inval);
+                }
+                let errno = last_errno();
+                if errno == libc::EINTR {
+                    continue;
+                }
+                return Err(AsyncHostError::Native(errno));
+            }
+        }
+        Ok(bytes)
+    }
+
+    pub(crate) fn discard_signals(&self) {
+        // Detachment may abandon accepted signals. Drain all bits and their
+        // wake byte so restarting delivery cannot receive stale notifications.
+        let _ = self.fetch_signals(&mut [0; u32::BITS as usize * 4]);
+    }
+
     pub(crate) fn fetch(&self, dst: &mut [u8]) -> AsyncHostResult<usize> {
         if dst.is_empty() {
             return Ok(0);
         }
+        let signal_bytes = self.fetch_signals(dst)?;
+        let dst = &mut dst[signal_bytes..];
+        if dst.is_empty() {
+            return Ok(signal_bytes);
+        }
         loop {
             let n = unsafe { libc::read(self.notify_recv, dst.as_mut_ptr().cast(), dst.len()) };
             if n > 0 {
-                return usize::try_from(n).map_err(|_| AsyncHostError::Fault);
+                return usize::try_from(n)
+                    .map(|bytes| signal_bytes + bytes)
+                    .map_err(|_| AsyncHostError::Fault);
             }
             if n == 0 {
-                return Ok(0);
+                return Ok(signal_bytes);
             }
             let errno = last_errno();
             if errno == libc::EINTR {
                 continue;
             }
             if would_block(errno) {
-                return Ok(0);
+                return Ok(signal_bytes);
             }
             return Err(AsyncHostError::Native(errno));
         }
@@ -157,10 +254,24 @@ mod tests {
     fn completion_pipe_is_close_on_exec() {
         let (notifier, notify_recv) = ThreadPoolCompletionNotifier::new().unwrap();
 
-        for fd in [notify_recv, notifier.notify_send] {
+        for fd in [
+            notify_recv,
+            notifier.notify_send,
+            notifier.signal_recv.as_raw_fd(),
+            notifier.signal_send.as_raw_fd(),
+        ] {
             let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
             assert!(flags >= 0);
             assert_ne!(flags & libc::FD_CLOEXEC, 0);
+        }
+
+        for fd in [
+            notifier.signal_recv.as_raw_fd(),
+            notifier.signal_send.as_raw_fd(),
+        ] {
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+            assert!(flags >= 0);
+            assert_ne!(flags & libc::O_NONBLOCK, 0);
         }
 
         unsafe {

--- a/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
@@ -32,6 +32,35 @@ pub(crate) struct ThreadPoolCompletionNotifier {
 
 #[cfg(unix)]
 impl ThreadPoolCompletionNotifier {
+    #[cfg(test)]
+    pub(crate) fn fill_with_completions(&self, completion_id: i32) {
+        // Establish backpressure without depending on the platform's pipe capacity.
+        let flags = unsafe { libc::fcntl(self.notify_send, libc::F_GETFL) };
+        assert!(flags >= 0);
+        assert_eq!(
+            unsafe { libc::fcntl(self.notify_send, libc::F_SETFL, flags | libc::O_NONBLOCK) },
+            0
+        );
+        let bytes = completion_id.to_ne_bytes();
+        loop {
+            let written =
+                unsafe { libc::write(self.notify_send, bytes.as_ptr().cast(), bytes.len()) };
+            if written == bytes.len() as isize {
+                continue;
+            }
+            assert_eq!(written, -1);
+            if last_errno() == libc::EINTR {
+                continue;
+            }
+            assert!(would_block(last_errno()));
+            break;
+        }
+        assert_eq!(
+            unsafe { libc::fcntl(self.notify_send, libc::F_SETFL, flags) },
+            0
+        );
+    }
+
     pub(crate) fn new() -> AsyncHostResult<(Self, RawFd)> {
         let fds = fd_util::pipe(true, false)?;
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -173,6 +173,24 @@ ported_fns! {
     }
 }
 
+// Run signals coalesce behind a single wake byte. Level triggering preserves
+// readiness when the guest fetches only part of the pending signal set.
+pub(crate) fn poll_register_signal_source(
+    instance: &PollInstance,
+    fd: RawFd,
+    fd_handle: u64,
+) -> AsyncHostResult<()> {
+    let mut event = libc::epoll_event {
+        events: libc::EPOLLIN as u32,
+        u64: fd_handle,
+    };
+    if unsafe { libc::epoll_ctl(instance.raw_fd(), libc::EPOLL_CTL_ADD, fd, &mut event) } < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
 pub(crate) fn poll_unregister(instance: &PollInstance, fd: RawFd) -> AsyncHostResult<()> {
     if unsafe {
         libc::epoll_ctl(

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -276,6 +276,38 @@ pub(crate) fn event_get_pid(event: &PollEvent) -> RawFd {
     event.ident as RawFd
 }
 
+// Run signals coalesce behind a single wake byte. Omit EV_CLEAR so readiness
+// persists when the guest fetches only part of the pending signal set.
+pub(crate) fn poll_register_signal_source(
+    instance: &PollInstance,
+    fd: RawFd,
+    fd_handle: u64,
+) -> AsyncHostResult<()> {
+    let change = new_kevent(
+        fd as libc::uintptr_t,
+        libc::EVFILT_READ,
+        libc::EV_ADD,
+        0,
+        0,
+        Some(fd_handle),
+    )?;
+    if unsafe {
+        libc::kevent(
+            instance.raw_fd(),
+            &change,
+            1,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null(),
+        )
+    } < 0
+    {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
 pub(crate) fn poll_unregister(instance: &PollInstance, fd: RawFd) -> AsyncHostResult<()> {
     for filter in [libc::EVFILT_READ, libc::EVFILT_WRITE] {
         let event = new_kevent(fd as libc::uintptr_t, filter, libc::EV_DELETE, 0, 0, None)?;

--- a/crates/moonrun/src/async_sys/mod.rs
+++ b/crates/moonrun/src/async_sys/mod.rs
@@ -187,5 +187,6 @@ pub(crate) fn compat_symbols() -> Vec<CompatSymbol> {
     let mut symbols = Vec::new();
     symbols.extend(crate::filesystem::compat_symbols());
     symbols.extend_from_slice(internal::fd_util::stub::COMPAT_SYMBOLS);
+    symbols.extend_from_slice(os_error::stub::COMPAT_SYMBOLS);
     symbols
 }

--- a/crates/moonrun/src/async_sys/os_error/stub.rs
+++ b/crates/moonrun/src/async_sys/os_error/stub.rs
@@ -28,9 +28,11 @@ ported_fns! {
         host.get_errno()
     }
 
-    #[ported(
+    #[compat(
         source = "src/os_error/stub.c",
-        original = "moonbitlang_async_is_nonblocking_io_error"
+        original = "moonbitlang_async_is_nonblocking_io_error",
+        upstream_pr = 566,
+        replacement = "platform errno constants in src/os_error/error.mbt"
     )]
     pub(crate) fn is_nonblocking_io_error(errno: i32) -> bool {
         #[cfg(unix)]
@@ -44,9 +46,11 @@ ported_fns! {
         }
     }
 
-    #[ported(
+    #[compat(
         source = "src/os_error/stub.c",
-        original = "moonbitlang_async_is_EINTR"
+        original = "moonbitlang_async_is_EINTR",
+        upstream_pr = 566,
+        replacement = "platform errno constants in src/os_error/error.mbt"
     )]
     pub(crate) fn is_eintr(errno: i32) -> bool {
         #[cfg(unix)]
@@ -60,9 +64,11 @@ ported_fns! {
         }
     }
 
-    #[ported(
+    #[compat(
         source = "src/os_error/stub.c",
-        original = "moonbitlang_async_is_ENOENT"
+        original = "moonbitlang_async_is_ENOENT",
+        upstream_pr = 566,
+        replacement = "platform errno constants in src/os_error/error.mbt"
     )]
     pub(crate) fn is_enoent(errno: i32) -> bool {
         #[cfg(unix)]
@@ -76,9 +82,11 @@ ported_fns! {
         }
     }
 
-    #[ported(
+    #[compat(
         source = "src/os_error/stub.c",
-        original = "moonbitlang_async_is_EEXIST"
+        original = "moonbitlang_async_is_EEXIST",
+        upstream_pr = 566,
+        replacement = "platform errno constants in src/os_error/error.mbt"
     )]
     pub(crate) fn is_eexist(errno: i32) -> bool {
         #[cfg(unix)]
@@ -92,9 +100,11 @@ ported_fns! {
         }
     }
 
-    #[ported(
+    #[compat(
         source = "src/os_error/stub.c",
-        original = "moonbitlang_async_is_EACCES"
+        original = "moonbitlang_async_is_EACCES",
+        upstream_pr = 566,
+        replacement = "platform errno constants in src/os_error/error.mbt"
     )]
     pub(crate) fn is_eacces(errno: i32) -> bool {
         #[cfg(unix)]
@@ -108,9 +118,11 @@ ported_fns! {
         }
     }
 
-    #[ported(
+    #[compat(
         source = "src/os_error/stub.c",
-        original = "moonbitlang_async_is_ECONNREFUSED"
+        original = "moonbitlang_async_is_ECONNREFUSED",
+        upstream_pr = 566,
+        replacement = "platform errno constants in src/os_error/error.mbt"
     )]
     pub(crate) fn is_econnrefused(errno: i32) -> bool {
         #[cfg(unix)]
@@ -127,9 +139,11 @@ ported_fns! {
         }
     }
 
-    #[ported(
+    #[compat(
         source = "src/os_error/stub.c",
-        original = "moonbitlang_async_is_ERROR_NOTIFY_ENUM_DIR"
+        original = "moonbitlang_async_is_ERROR_NOTIFY_ENUM_DIR",
+        upstream_pr = 566,
+        replacement = "platform errno constants in src/os_error/error.mbt"
     )]
     pub(crate) fn is_error_notify_enum_dir(errno: i32) -> bool {
         #[cfg(windows)]
@@ -144,9 +158,11 @@ ported_fns! {
         }
     }
 
-    #[ported(
+    #[compat(
         source = "src/os_error/stub.c",
-        original = "moonbitlang_async_get_ENOTDIR"
+        original = "moonbitlang_async_get_ENOTDIR",
+        upstream_pr = 566,
+        replacement = "platform errno constants in src/os_error/error.mbt"
     )]
     pub(crate) fn get_enotdir() -> i32 {
         #[cfg(unix)]
@@ -160,9 +176,11 @@ ported_fns! {
         }
     }
 
-    #[ported(
+    #[compat(
         source = "src/os_error/stub.c",
-        original = "moonbitlang_async_get_ENOTSUP"
+        original = "moonbitlang_async_get_ENOTSUP",
+        upstream_pr = 566,
+        replacement = "platform errno constants in src/os_error/error.mbt"
     )]
     pub(crate) fn get_enotsup() -> i32 {
         #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/signal/mod.rs
+++ b/crates/moonrun/src/async_sys/signal/mod.rs
@@ -60,7 +60,8 @@ ported_fns! {
         notifier: Arc<ThreadPoolCompletionNotifier>,
     ) -> AsyncHostResult<SignalTargetGuard> {
         // The CLI's dedicated signal broker already owns sigwait. Attach this
-        // Run directly instead of consuming a worker for a forwarding Job.
+        // Run's nonblocking signal source instead of consuming a worker for a
+        // forwarding Job or blocking the broker on the worker completion pipe.
         receiver.attach_completion_target(notifier)
             .ok_or(crate::async_host::AsyncHostError::Inval)
     }

--- a/crates/moonrun/src/async_sys/signal/mod.rs
+++ b/crates/moonrun/src/async_sys/signal/mod.rs
@@ -22,10 +22,16 @@
 //! completion delivery belong to one Run.
 
 use crate::async_host::AsyncHostResult;
+#[cfg(unix)]
+use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 #[cfg(windows)]
 use crate::async_sys::internal::event_loop::poll::CompletionPort;
 use crate::async_sys::ported_fns;
 use crate::run_signal::SignalReceiver;
+#[cfg(unix)]
+use crate::run_signal::SignalTargetGuard;
+#[cfg(unix)]
+use std::sync::Arc;
 
 #[cfg(unix)]
 mod unix;
@@ -44,6 +50,34 @@ pub(crate) use unix::{
 };
 
 ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/signal.c",
+        original = "moonbitlang_async_start_signal_handler"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn start_signal_handler(
+        receiver: &SignalReceiver,
+        notifier: Arc<ThreadPoolCompletionNotifier>,
+    ) -> AsyncHostResult<SignalTargetGuard> {
+        // The CLI's dedicated signal broker already owns sigwait. Attach this
+        // Run directly instead of consuming a worker for a forwarding Job.
+        receiver.attach_completion_target(notifier)
+            .ok_or(crate::async_host::AsyncHostError::Inval)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/signal.c",
+        original = "moonbitlang_async_terminate_signal_handler"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn terminate_signal_handler(
+        receiver: &SignalReceiver,
+        handler: Option<SignalTargetGuard>,
+    ) {
+        drop(handler);
+        receiver.configure(&[], &[]);
+    }
+
     #[ported(
         source = "src/internal/event_loop/signal.c",
         original = "moonbitlang_async_set_global_cancellation_signals"

--- a/crates/moonrun/src/async_sys/signal/unix.rs
+++ b/crates/moonrun/src/async_sys/signal/unix.rs
@@ -25,7 +25,7 @@ use crate::async_sys::internal::event_loop::{
     thread_pool::{JobCancellation, JobCancellationOverride},
 };
 use crate::async_sys::internal::fd_util::stub as fd_util;
-use crate::run_signal::{SignalReceiver, SigwaitTargetGuard, signal_mask};
+use crate::run_signal::{SignalReceiver, SignalTargetGuard, signal_mask};
 
 #[derive(Clone, Debug)]
 pub(crate) struct SigwaitTarget {
@@ -96,7 +96,7 @@ impl JobCancellationOverride for SigwaitCancellation {
 }
 
 pub(crate) struct SigwaitJob {
-    _target: SigwaitTargetGuard,
+    _target: SignalTargetGuard,
     state: Arc<Mutex<SigwaitState>>,
     cancellation: JobCancellation,
     wake: OwnedFd,

--- a/crates/moonrun/src/run_signal.rs
+++ b/crates/moonrun/src/run_signal.rs
@@ -20,6 +20,8 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
+#[cfg(unix)]
+use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 #[cfg(windows)]
 use crate::async_sys::internal::event_loop::poll::{self, CompletionPort};
 #[cfg(unix)]
@@ -43,8 +45,16 @@ pub struct SignalReceiver {
 }
 
 #[cfg(unix)]
-pub(crate) struct SigwaitTargetGuard {
+pub(crate) struct SignalTargetGuard {
     shared: Arc<SignalState>,
+}
+
+#[cfg(unix)]
+#[derive(Clone)]
+enum SignalTarget {
+    // Older Wasm guests still submit a virtual sigwait Job.
+    CompatibilityWaiter(SigwaitTarget),
+    Completion(Arc<ThreadPoolCompletionNotifier>),
 }
 
 /// An error returned when a signal cannot be delivered to a Run.
@@ -106,11 +116,18 @@ impl SignalSender {
                 }
                 state.target.clone()
             };
-            target.map_or(Ok(false), |target| {
-                target
+            match target {
+                None => Ok(false),
+                Some(SignalTarget::CompatibilityWaiter(target)) => target
                     .send(bit)
-                    .map_err(|_| SignalSendError::DeliveryFailed)
-            })
+                    .map_err(|_| SignalSendError::DeliveryFailed),
+                Some(SignalTarget::Completion(target)) => {
+                    target
+                        .notify(encode_signal_event(signal))
+                        .map_err(|_| SignalSendError::DeliveryFailed)?;
+                    Ok(true)
+                }
+            }
         }
 
         #[cfg(windows)]
@@ -159,7 +176,20 @@ impl SignalReceiver {
     }
 
     #[cfg(unix)]
-    pub(crate) fn attach_target(&self, target: SigwaitTarget) -> Option<SigwaitTargetGuard> {
+    pub(crate) fn attach_target(&self, target: SigwaitTarget) -> Option<SignalTargetGuard> {
+        self.attach_unix_target(SignalTarget::CompatibilityWaiter(target))
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn attach_completion_target(
+        &self,
+        target: Arc<ThreadPoolCompletionNotifier>,
+    ) -> Option<SignalTargetGuard> {
+        self.attach_unix_target(SignalTarget::Completion(target))
+    }
+
+    #[cfg(unix)]
+    fn attach_unix_target(&self, target: SignalTarget) -> Option<SignalTargetGuard> {
         let Ok(mut state) = self.shared.inner.lock() else {
             return None;
         };
@@ -167,7 +197,7 @@ impl SignalReceiver {
             return None;
         }
         state.target = Some(target);
-        Some(SigwaitTargetGuard {
+        Some(SignalTargetGuard {
             shared: Arc::clone(&self.shared),
         })
     }
@@ -184,7 +214,7 @@ impl SignalReceiver {
 }
 
 #[cfg(unix)]
-impl Drop for SigwaitTargetGuard {
+impl Drop for SignalTargetGuard {
     fn drop(&mut self) {
         self.shared.inner.lock().unwrap().target = None;
     }
@@ -206,12 +236,11 @@ struct SignalStateInner {
     receiver_alive: bool,
     interested: u32,
     #[cfg(unix)]
-    target: Option<SigwaitTarget>,
+    target: Option<SignalTarget>,
     #[cfg(windows)]
     target: Option<CompletionPort>,
 }
 
-#[cfg(windows)]
 fn encode_signal_event(signal: i32) -> i32 {
     ((signal as u32) | (1_u32 << 31)) as i32
 }

--- a/crates/moonrun/src/run_signal.rs
+++ b/crates/moonrun/src/run_signal.rs
@@ -50,7 +50,6 @@ pub(crate) struct SignalTargetGuard {
 }
 
 #[cfg(unix)]
-#[derive(Clone)]
 enum SignalTarget {
     // Older Wasm guests still submit a virtual sigwait Job.
     CompatibilityWaiter(SigwaitTarget),
@@ -102,28 +101,28 @@ impl SignalSender {
 
         #[cfg(unix)]
         {
-            let target = {
-                let state = self
-                    .shared
-                    .inner
-                    .lock()
-                    .map_err(|_| SignalSendError::Disconnected)?;
-                if !state.receiver_alive {
-                    return Err(SignalSendError::Disconnected);
-                }
-                if state.interested & bit == 0 {
-                    return Ok(false);
-                }
-                state.target.clone()
-            };
-            match target {
+            let state = self
+                .shared
+                .inner
+                .lock()
+                .map_err(|_| SignalSendError::Disconnected)?;
+            if !state.receiver_alive {
+                return Err(SignalSendError::Disconnected);
+            }
+            if state.interested & bit == 0 {
+                return Ok(false);
+            }
+            // Both Unix targets use nonblocking, coalesced wakeups. Keep the
+            // registration lock until acceptance so detach cannot turn an
+            // in-flight delivery into an error and process-level fallback.
+            match &state.target {
                 None => Ok(false),
                 Some(SignalTarget::CompatibilityWaiter(target)) => target
                     .send(bit)
                     .map_err(|_| SignalSendError::DeliveryFailed),
                 Some(SignalTarget::Completion(target)) => {
                     target
-                        .notify(encode_signal_event(signal))
+                        .notify_signal(bit)
                         .map_err(|_| SignalSendError::DeliveryFailed)?;
                     Ok(true)
                 }
@@ -216,7 +215,10 @@ impl SignalReceiver {
 #[cfg(unix)]
 impl Drop for SignalTargetGuard {
     fn drop(&mut self) {
-        self.shared.inner.lock().unwrap().target = None;
+        let mut state = self.shared.inner.lock().unwrap();
+        if let Some(SignalTarget::Completion(target)) = state.target.take() {
+            target.discard_signals();
+        }
     }
 }
 
@@ -241,6 +243,7 @@ struct SignalStateInner {
     target: Option<CompletionPort>,
 }
 
+#[cfg(windows)]
 fn encode_signal_event(signal: i32) -> i32 {
     ((signal as u32) | (1_u32 << 31)) as i32
 }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -78,7 +78,9 @@ fn test_moonrun_against_upstream_async() {
         .env("PATH", path)
         .arg("--target-dir")
         .arg(target_dir.path())
-        .args(["test", "--target", "wasm"])
+        // Upstream process tests assert subsecond child-output ordering.
+        // Avoid competing test packages delaying child startup past those gaps.
+        .args(["test", "--target", "wasm", "--no-parallelize"])
         .assert()
         .success()
         .stdout_eq("Total tests: 531, passed: 531, failed: 0.\n");

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -81,7 +81,7 @@ fn test_moonrun_against_upstream_async() {
         .args(["test", "--target", "wasm"])
         .assert()
         .success()
-        .stdout_eq("Total tests: 452, passed: 452, failed: 0.\n");
+        .stdout_eq("Total tests: 531, passed: 531, failed: 0.\n");
 }
 
 struct TestDir(moon_test_util::test_dir::TestDir);


### PR DESCRIPTION
- Related issues: moonbitlang/async#581
- PR kind: Bugfix (upstream backport)

## Summary

Port async #581 so updated Wasm guests receive Run cancellation signals without a signal-wait worker job. Moonrun reuses its existing process signal broker and per-Run registration through explicit start and termination imports.

Run signals coalesce in a pending bitset and wake the poller through a dedicated nonblocking pipe. This keeps the process broker responsive when the worker completion pipe is full. Both sources report the same guest completion handle, and level-triggered signal readiness survives partial fetches. Acceptance and detachment share a lock, so teardown can discard accepted signals without turning a failed worker-pipe write into process-level termination. The worker completion transport is preserved.

Older Wasm guests retain the signal-wait job ABI. Errno classifier imports removed by async #566 remain compatibility adapters while updated guests own those constants. Worker cancellation is delivered separately.

The async fixture pins the coordinating Wasm signal wrapper from https://github.com/moonbitlang/async/pull/597. Merge this runtime PR before that guest PR. Keep async #581 labeled required until the runtime is on Moon's main and the coordinating guest work is complete.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
