### PR TITLE
fix(moonrun): acknowledge cancellation before blocking calls

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -354,5 +354,8 @@ The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOC
 _Avoid_: Completion queue, worker wakeup
 
 **Thread-Pool Completion Source**:
-The host-side notify handle corresponding to `thread_pool.c`'s `pool.notify_send`. Worker threads write or post completed job ids through it so `poll/wait` reports the completion source key, after which MoonBit drains `thread_pool/fetch_completion`.
+The host-side notify handle corresponding to `thread_pool.c`'s `pool.notify_send`.
+On Unix, host memory retains completed Job IDs and coalesced cancellation
+retries; a nonblocking pipe wakes the Host Poller so MoonBit can drain them
+through `thread_pool/fetch_completion`. Windows posts IDs directly to IOCP.
 _Avoid_: Host Poller, Barrier, worker wakeup

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -21,7 +21,9 @@ The host-owned result of a finished job that is ready to wake or resume guest co
 _Avoid_: Callback, event
 
 **Completion Queue**:
-A host-owned queue of completed job identifiers that the guest event loop drains to resume waiting coroutines.
+A host-owned queue of job identifiers and signal notifications that the guest
+event loop drains. A job identifier may request a cancellation retry; only a
+finished Worker permits the guest to consume that Job's Completion.
 _Avoid_: Notify pipe, callback queue
 
 **Guest Memory**:

--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -14,7 +14,7 @@
 The cancellation protocol follows upstream async #595. Workers acknowledge a
 cancellation request before entering native's cancellable syscalls. A Unix
 signal arriving after that check may precede the syscall, so the signal handler
-writes the job ID into the same pipe used for normal completions. The MoonBit
+records the Job ID for a cancellation retry. The MoonBit
 event loop calls `cancel_worker_with_retry` both to start cancellation and to
 check each job notification. The host retries cancellation when needed and
 returns a distinct status once the Job result is ready.
@@ -33,6 +33,22 @@ that order using its existing result channel: send the host-owned Job, set
 it does not copy result buffers. Before accepting completion, the host restores
 the result to its Job table. The guest wrapper copies output into Wasm memory
 when it subsequently requests that output.
+
+Unix notification transport deliberately differs from native's pipe of IDs.
+Ordinary completion IDs stay in a host FIFO queue. Each Worker that enables
+retries gets a preallocated atomic slot, so repeated retries for its current
+Job coalesce without locking or allocating in the signal handler. A nonblocking
+pipe carries only wake bytes, shared by pending notifications. A full wake
+pipe already provides readiness; it cannot block a publisher or discard an ID.
+The notifier retains both pipe ends while publishers are alive, even if the
+guest closes its duplicate reader. Windows retains its existing IOCP delivery.
+
+`fetch_completion` returns the same Job IDs through the existing guest import.
+It clears the old wake before inspecting pending IDs, so a concurrent publisher
+either joins that fetch or creates a new wake. Partial fetches restore readiness
+on the level-triggered completion source. Only pending cancellation retries
+scan registered retry slots; normal completion delivery does not scan Workers.
+Run signals retain their separate coalesced source from the signal backport.
 
 The historical `thread_pool/cancel_worker` import returns `RetryLater` for a
 pending default Unix cancellation, so older guests retry after a timer. The new
@@ -55,12 +71,12 @@ with the notified Job. The host also preserves an early wake from direct
 callers, as tested by `wake_during_running_job_is_not_lost`, but after the Worker
 advances, its cancellation status no longer describes the previous Job.
 
-Worker freeing follows native's termination wakeup and join. Pipe capacity
-beyond the guest scheduler's worker bound, and cancellation/draining after a
-Run stops executing its guest event loop, remain correctness FIXMEs for a Run
-teardown follow-up: pending retries or full pipes can prevent Workers from
-exiting and make join hang. The backport does not add a separate notification
-transport or a retry loop to `free_worker`.
+Worker freeing follows native's termination wakeup and join. Notification
+publication no longer depends on guest consumption. Cancellation after a Run
+stops executing its guest event loop remains a correctness FIXME for teardown:
+a signal arriving before a blocking syscall may still require another attempt,
+and no guest remains to request it. The backport does not add a retry loop to
+`free_worker` or attempt to forcibly stop noncooperative computation.
 
 ## How to Build and Test
 

--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -12,12 +12,20 @@
 ## Worker cancellation
 
 The cancellation protocol follows upstream async #595. Workers acknowledge a
-cancellation request before entering potentially blocking syscalls. A Unix
+cancellation request before entering native's cancellable syscalls. A Unix
 signal arriving after that check may precede the syscall, so the signal handler
 writes the job ID into the same pipe used for normal completions. The MoonBit
 event loop calls `cancel_worker_with_retry` both to start cancellation and to
-check each job notification. The host retries cancellation while the Worker is
-not yet `Waiting`, and returns a distinct status once the Job result is ready.
+check each job notification. The host retries cancellation when needed and
+returns a distinct status once the Job result is ready.
+
+Cancellation eligibility also follows native. In async's
+`src/internal/event_loop/io.mbt`, positioned reads and writes are submitted with
+`cancellable=platform is Windows`. On Unix, cancellation can prevent assignment
+to a Worker, but once assigned the guest waits for the operation to finish.
+Accordingly, `pread` and `pwrite` have no cancellable region, as in native
+`thread_pool.c`.
+Windows positioned I/O is cancellable and has the corresponding region.
 
 Native writes its shared Job result before setting `Waiting`. Moonrun preserves
 that order using its existing result channel: send the host-owned Job, set
@@ -38,6 +46,14 @@ waits for the completion notification to retire the Worker, as native does.
 Older guests have no retry check and would treat retry notifications as
 completed Jobs. Both imports take one `i64` Worker handle and return an `i32`
 status; the historical import retains its original return values.
+
+The completion check describes the Worker's current Job; the import takes no
+Job ID. Async's `EventLoop::handle_completed_job` accepts the previous completion
+before calling `worker.wake` for the next Job. Pending Jobs stay in the guest's
+queue until then. This sequencing keeps the checked Worker state associated
+with the notified Job. The host also preserves an early wake from direct
+callers, as tested by `wake_during_running_job_is_not_lost`, but after the Worker
+advances, its cancellation status no longer describes the previous Job.
 
 Worker freeing follows native's termination wakeup and join. Pipe capacity
 beyond the guest scheduler's worker bound, and cancellation/draining after a

--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -15,8 +15,9 @@ The cancellation protocol follows upstream async #595. Workers acknowledge a
 cancellation request before entering potentially blocking syscalls. A Unix
 signal arriving after that check may precede the syscall, so the signal handler
 writes the job ID into the same pipe used for normal completions. The MoonBit
-event loop calls `worker_check_cancellation_retry` for each job notification;
-the host retries cancellation while the Worker is not yet `Waiting`.
+event loop calls `cancel_worker_with_retry` both to start cancellation and to
+check each job notification. The host retries cancellation while the Worker is
+not yet `Waiting`, and returns a distinct status once the Job result is ready.
 
 Native writes its shared Job result before setting `Waiting`. Moonrun preserves
 that order using its existing result channel: send the host-owned Job, set
@@ -27,11 +28,16 @@ when it subsequently requests that output.
 
 The historical `thread_pool/cancel_worker` import returns `RetryLater` for a
 pending default Unix cancellation, so older guests retry after a timer. The new
-`thread_pool/cancel_worker_with_retry` import opts into native's `NeedWait` and
-retry notifications. Older guests have no retry check and would treat those
-notifications as completed Jobs. Both imports take one `i64` Worker handle and
-return an `i32` status; `thread_pool/worker_check_cancellation_retry` has the same
-lowered types.
+`thread_pool/cancel_worker_with_retry` import opts into retry notifications and
+combines native's cancellation call and completion check in one Wasm import.
+It returns `0` for `RetryLater`, `1` for `NeedWait`, or `2` when the Worker is
+`Waiting` and its result has been restored to the Job table. A Worker that has
+acknowledged cancellation but not yet published its result still returns `1`.
+The guest uses `2` to accept completion; the initial cancellation path still
+waits for the completion notification to retire the Worker, as native does.
+Older guests have no retry check and would treat retry notifications as
+completed Jobs. Both imports take one `i64` Worker handle and return an `i32`
+status; the historical import retains its original return values.
 
 Worker freeing follows native's termination wakeup and join. Pipe capacity
 beyond the guest scheduler's worker bound, and cancellation/draining after a

--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -9,6 +9,37 @@
   deliver one upstream port at a time, and mark the originating async pull
   request completed after the Moon change lands.
 
+## Worker cancellation
+
+The cancellation protocol follows upstream async #595. Workers acknowledge a
+cancellation request before entering potentially blocking syscalls. A Unix
+signal arriving after that check may precede the syscall, so the signal handler
+writes the job ID into the same pipe used for normal completions. The MoonBit
+event loop calls `worker_check_cancellation_retry` for each job notification;
+the host retries cancellation while the Worker is not yet `Waiting`.
+
+Native writes its shared Job result before setting `Waiting`. Moonrun preserves
+that order using its existing result channel: send the host-owned Job, set
+`Waiting`, then notify. This transfers Rust ownership within the same process;
+it does not copy result buffers. Before accepting completion, the host restores
+the result to its Job table. The guest wrapper copies output into Wasm memory
+when it subsequently requests that output.
+
+The historical `thread_pool/cancel_worker` import returns `RetryLater` for a
+pending default Unix cancellation, so older guests retry after a timer. The new
+`thread_pool/cancel_worker_with_retry` import opts into native's `NeedWait` and
+retry notifications. Older guests have no retry check and would treat those
+notifications as completed Jobs. Both imports take one `i64` Worker handle and
+return an `i32` status; `thread_pool/worker_check_cancellation_retry` has the same
+lowered types.
+
+Worker freeing follows native's termination wakeup and join. Pipe capacity
+beyond the guest scheduler's worker bound, and cancellation/draining after a
+Run stops executing its guest event loop, remain correctness FIXMEs for a Run
+teardown follow-up: pending retries or full pipes can prevent Workers from
+exiting and make join hang. The backport does not add a separate notification
+transport or a retry loop to `free_worker`.
+
 ## How to Build and Test
 
 ```bash

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -638,8 +638,6 @@ declare_async_imports! {
 
     ported thread_pool::cancel_worker_with_retry(worker: u64) -> i32 => "thread_pool/cancel_worker_with_retry";
 
-    ported thread_pool::worker_check_cancellation_retry(worker: u64) -> i32 => "thread_pool/worker_check_cancellation_retry";
-
     helper thread_pool::init_thread_pool(poll: u64) -> u64 => "thread_pool/init_thread_pool";
 
     helper thread_pool::destroy_thread_pool() -> void => "thread_pool/destroy_thread_pool";
@@ -2000,10 +1998,6 @@ mod tests {
             ("thread_pool/cancel_worker", AsyncImportKind::Compat),
             (
                 "thread_pool/cancel_worker_with_retry",
-                AsyncImportKind::Ported,
-            ),
-            (
-                "thread_pool/worker_check_cancellation_retry",
                 AsyncImportKind::Ported,
             ),
         ] {

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -634,7 +634,11 @@ declare_async_imports! {
 
     ported thread_pool::worker_enter_idle(worker: u64) -> void => "thread_pool/worker_enter_idle";
 
-    ported thread_pool::cancel_worker(worker: u64) -> i32 => "thread_pool/cancel_worker";
+    compat thread_pool::cancel_worker(worker: u64) -> i32 => "thread_pool/cancel_worker";
+
+    ported thread_pool::cancel_worker_with_retry(worker: u64) -> i32 => "thread_pool/cancel_worker_with_retry";
+
+    ported thread_pool::worker_check_cancellation_retry(worker: u64) -> i32 => "thread_pool/worker_check_cancellation_retry";
 
     helper thread_pool::init_thread_pool(poll: u64) -> u64 => "thread_pool/init_thread_pool";
 
@@ -826,6 +830,7 @@ declare_async_imports! {
     ported socket::disable_nagle(fd: u64) -> i32 => "socket/disable_nagle";
 
     ported socket::allow_reuse_addr(fd: u64) -> i32 => "socket/allow_reuse_addr";
+    ported socket::allow_reuse_port(fd: u64) -> i32 => "socket/allow_reuse_port";
 
     ported socket::set_ipv6_only(fd: u64, ipv6_only: i32) -> i32 => "socket/set_ipv6_only";
 
@@ -1987,6 +1992,29 @@ mod tests {
         assert_eq!(legacy.result, Some(WasmType::I64));
         #[cfg(unix)]
         assert_eq!(legacy.kind, AsyncImportKind::Compat);
+    }
+
+    #[test]
+    fn cancellation_retry_imports_preserve_the_legacy_abi() {
+        for (symbol, kind) in [
+            ("thread_pool/cancel_worker", AsyncImportKind::Compat),
+            (
+                "thread_pool/cancel_worker_with_retry",
+                AsyncImportKind::Ported,
+            ),
+            (
+                "thread_pool/worker_check_cancellation_retry",
+                AsyncImportKind::Ported,
+            ),
+        ] {
+            let import = ASYNC_IMPORTS
+                .iter()
+                .find(|import| import.wasm_symbol == symbol)
+                .unwrap();
+            assert_eq!(import.kind, kind);
+            assert_eq!(import.params, &[WasmType::I64]);
+            assert_eq!(import.result, Some(WasmType::I32));
+        }
     }
 
     #[test]

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -364,6 +364,12 @@ pub(super) fn allow_reuse_addr(context: &mut ImportContext<'_, '_>, fd: u64) -> 
 }
 
 #[ported(source = "src/socket/socket.c")]
+pub(super) fn allow_reuse_port(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
+    let host = context.host;
+    zero_or_minus_one(context, host.with_raw_socket(fd, sys::allow_reuse_port))
+}
+
+#[ported(source = "src/socket/socket.c")]
 pub(super) fn set_ipv6_only(context: &mut ImportContext<'_, '_>, fd: u64, ipv6_only: i32) -> i32 {
     let host = context.host;
     zero_or_minus_one(

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -88,9 +88,25 @@ pub(super) fn worker_enter_idle(context: &mut ImportContext<'_, '_>, worker: u64
     context.host.worker_enter_idle(worker)
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.wasm.mbt",
+    original = "thread_pool/cancel_worker",
+    upstream_pr = 595,
+    replacement = "thread_pool/cancel_worker_with_retry with worker_check_cancellation_retry",
+    api_only = true
+)]
 pub(super) fn cancel_worker(context: &mut ImportContext<'_, '_>, worker: u64) -> AsyncHostResult<i32> {
     context.host.cancel_worker(worker)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c", original = "moonbitlang_async_cancel_worker")]
+pub(super) fn cancel_worker_with_retry(context: &mut ImportContext<'_, '_>, worker: u64) -> AsyncHostResult<i32> {
+    context.host.cancel_worker_with_retry(worker)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn worker_check_cancellation_retry(context: &mut ImportContext<'_, '_>, worker: u64) -> AsyncHostResult<i32> {
+    context.host.worker_check_cancellation_retry(worker).map(i32::from)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -92,7 +92,7 @@ pub(super) fn worker_enter_idle(context: &mut ImportContext<'_, '_>, worker: u64
     source = "src/internal/event_loop/thread_pool.wasm.mbt",
     original = "thread_pool/cancel_worker",
     upstream_pr = 595,
-    replacement = "thread_pool/cancel_worker_with_retry with worker_check_cancellation_retry",
+    replacement = "thread_pool/cancel_worker_with_retry",
     api_only = true
 )]
 pub(super) fn cancel_worker(context: &mut ImportContext<'_, '_>, worker: u64) -> AsyncHostResult<i32> {
@@ -102,11 +102,6 @@ pub(super) fn cancel_worker(context: &mut ImportContext<'_, '_>, worker: u64) ->
 #[ported(source = "src/internal/event_loop/thread_pool.c", original = "moonbitlang_async_cancel_worker")]
 pub(super) fn cancel_worker_with_retry(context: &mut ImportContext<'_, '_>, worker: u64) -> AsyncHostResult<i32> {
     context.host.cancel_worker_with_retry(worker)
-}
-
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn worker_check_cancellation_retry(context: &mut ImportContext<'_, '_>, worker: u64) -> AsyncHostResult<i32> {
-    context.host.worker_check_cancellation_retry(worker).map(i32::from)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1789,14 +1789,17 @@ impl AsyncHost {
                 .handles
                 .borrow_mut()
                 .insert_resource(Resource::new(event_fd));
-            if let Err(error) = poll::poll_register(&poll.instance, event_fd, true, source) {
+            if let Err(error) =
+                poll::poll_register_completion_source(&poll.instance, event_fd, source)
+            {
                 let _ = self.handles.borrow_mut().remove_resource(source);
                 return Err(error);
             }
             let signal_fd = completion_notifier.signal_fd();
             // Both sources use the same guest handle. fetch_completion merges
             // pending Run signals with worker IDs without a forwarding thread.
-            if let Err(error) = poll::poll_register_signal_source(&poll.instance, signal_fd, source)
+            if let Err(error) =
+                poll::poll_register_completion_source(&poll.instance, signal_fd, source)
             {
                 let _ = poll::poll_unregister(&poll.instance, event_fd);
                 let _ = self.handles.borrow_mut().remove_resource(source);
@@ -5664,7 +5667,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn fetch_completion_leaves_unfetched_completion_ids_in_os_source() {
+    fn completion_source_remains_ready_until_all_ids_are_fetched() {
         let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
@@ -5676,22 +5679,26 @@ mod tests {
         }
 
         let mut memory = vec![0; 8];
+        assert_eq!(host.poll_wait(poll, 0).unwrap(), 1);
         let bytes = host
             .fetch_completion(memory.as_mut_slice(), completion_notifier, 0, 0)
             .unwrap();
         assert_eq!(bytes, 0);
+        assert_eq!(host.poll_wait(poll, 0).unwrap(), 1);
 
         let bytes = host
             .fetch_completion(memory.as_mut_slice(), completion_notifier, 0, 1)
             .unwrap();
         assert_eq!(bytes, 4);
         assert_eq!(i32::from_le_bytes(memory[0..4].try_into().unwrap()), 41);
+        assert_eq!(host.poll_wait(poll, 0).unwrap(), 1);
 
         let bytes = host
             .fetch_completion(memory.as_mut_slice(), completion_notifier, 4, 1)
             .unwrap();
         assert_eq!(bytes, 4);
         assert_eq!(i32::from_le_bytes(memory[4..8].try_into().unwrap()), 42);
+        assert_eq!(host.poll_wait(poll, 0).unwrap(), 0);
     }
 
     #[test]
@@ -6407,6 +6414,57 @@ mod tests {
         host.free_worker(worker).unwrap();
         host.free_job(job).unwrap();
         host.destroy_thread_pool();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worker_teardown_does_not_require_guest_to_drain_completions() {
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        for destroy_pool in [false, true] {
+            let (notifier_tx, notifier_rx) = mpsc::channel();
+            let (finished_tx, finished_rx) = mpsc::channel();
+            let run = std::thread::spawn(move || {
+                let host = default_host();
+                let poll = host.poll_create().unwrap();
+                host.init_thread_pool(poll).unwrap();
+                let notifier = host.thread_pool_notifier().unwrap();
+                notifier.fill_with_completions(17);
+                let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
+                let worker = host.spawn_worker(23, job).unwrap();
+                notifier_tx.send(notifier).unwrap();
+                if destroy_pool {
+                    host.destroy_thread_pool();
+                } else {
+                    host.free_worker(worker).unwrap();
+                }
+                assert_eq!(host.job_get_ret(job), Ok(0));
+                host.free_job(job).unwrap();
+                host.destroy_thread_pool();
+                finished_tx.send(()).unwrap();
+            });
+            let notifier = notifier_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            let finished_without_fetch = finished_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+            if !finished_without_fetch {
+                // Keep a failing transport regression from hanging the test
+                // process while the host is inside free_worker/destroy_thread_pool.
+                let deadline = Instant::now() + Duration::from_secs(5);
+                while !run.is_finished() && Instant::now() < deadline {
+                    notifier.fetch(&mut [0; 4096]).unwrap();
+                    std::thread::yield_now();
+                }
+                assert!(
+                    run.is_finished(),
+                    "teardown did not finish even after draining"
+                );
+            }
+            run.join().unwrap();
+            assert!(
+                finished_without_fetch,
+                "teardown required guest consumption (destroy_pool={destroy_pool})"
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -3860,6 +3860,29 @@ impl AsyncHost {
         self.workers.cancel(worker_key)
     }
 
+    pub(crate) fn cancel_worker_with_retry(&self, worker_handle: u64) -> AsyncHostResult<i32> {
+        let worker_key = self.handles.borrow().worker(worker_handle)?;
+        self.workers.cancel_with_retry(
+            worker_key,
+            #[cfg(unix)]
+            self.thread_pool_notifier()?,
+        )
+    }
+
+    pub(crate) fn worker_check_cancellation_retry(
+        &self,
+        worker_handle: u64,
+    ) -> AsyncHostResult<bool> {
+        let worker_key = self.handles.borrow().worker(worker_handle)?;
+        let retry = self.workers.check_cancellation_retry(worker_key)?;
+        // Waiting is published only after the worker sends its owned result.
+        // Reacquire it even when this was originally a retry notification.
+        if !retry {
+            self.restore_completed_worker_jobs();
+        }
+        Ok(retry)
+    }
+
     #[cfg(unix)]
     pub(crate) fn thread_pool_child_signal_mask(&self) -> AsyncHostResult<libc::sigset_t> {
         self.thread_pool_completions

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -3862,25 +3862,17 @@ impl AsyncHost {
 
     pub(crate) fn cancel_worker_with_retry(&self, worker_handle: u64) -> AsyncHostResult<i32> {
         let worker_key = self.handles.borrow().worker(worker_handle)?;
-        self.workers.cancel_with_retry(
+        let status = self.workers.cancel_with_retry(
             worker_key,
             #[cfg(unix)]
             self.thread_pool_notifier()?,
-        )
-    }
-
-    pub(crate) fn worker_check_cancellation_retry(
-        &self,
-        worker_handle: u64,
-    ) -> AsyncHostResult<bool> {
-        let worker_key = self.handles.borrow().worker(worker_handle)?;
-        let retry = self.workers.check_cancellation_retry(worker_key)?;
+        )?;
         // Waiting is published only after the worker sends its owned result.
         // Reacquire it even when this was originally a retry notification.
-        if !retry {
+        if status == thread_pool::WORKER_JOB_FINISHED {
             self.restore_completed_worker_jobs();
         }
-        Ok(retry)
+        Ok(status)
     }
 
     #[cfg(unix)]
@@ -6391,6 +6383,8 @@ mod tests {
         let worker = host.spawn_worker(42, job).unwrap();
 
         assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        assert_eq!(host.cancel_worker_with_retry(worker), Ok(2));
+        assert_eq!(host.cancel_worker(worker), Ok(1));
         assert_eq!(host.job_get_ret(job).unwrap(), 0);
         assert_eq!(host.run_job(job), Err(AsyncHostError::Badf));
         assert_eq!(host.spawn_worker(43, job), Err(AsyncHostError::Badf));
@@ -6409,6 +6403,71 @@ mod tests {
             assert_eq!(host.poll_event_fd(event).unwrap(), completion_source);
             assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 42);
         }
+
+        host.free_worker(worker).unwrap();
+        host.free_job(job).unwrap();
+        host.destroy_thread_pool();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancellation_status_waits_for_job_result_after_acknowledgement() {
+        use std::time::Duration;
+
+        let host = default_host();
+        let poll = host.poll_create().unwrap();
+        host.init_thread_pool(poll).unwrap();
+        let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
+        let key = job_key(&host, job);
+        let worker_key = host.handles.borrow_mut().insert(HandleKind::Worker);
+        let worker = handle_from_key(worker_key);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+        let (finish_tx, finish_rx) = std::sync::mpsc::channel();
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+        host.workers
+            .spawn(
+                worker_key,
+                host.take_worker_job(WorkerCompletionId::from_abi(42), key)
+                    .unwrap(),
+                move |worker_job| {
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    assert!(thread_pool::CancellableRegion::enter().is_err());
+                    ack_tx.send(()).unwrap();
+                    finish_rx.recv().unwrap();
+                    worker_job.job.set_ret(73);
+                },
+                move |_| completed_tx.send(()).unwrap(),
+            )
+            .unwrap();
+
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(host.cancel_worker_with_retry(worker), Ok(1));
+        release_tx.send(()).unwrap();
+        ack_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(host.cancel_worker_with_retry(worker), Ok(1));
+        assert!(matches!(
+            host.jobs.borrow().jobs[key],
+            HostJobState::Reserved
+        ));
+
+        finish_tx.send(()).unwrap();
+        completed_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        // No poll or fetch call has restored the result: the combined ABI
+        // must make it available before reporting that the worker finished.
+        assert!(matches!(
+            host.jobs.borrow().jobs[key],
+            HostJobState::Reserved
+        ));
+        assert_eq!(host.cancel_worker_with_retry(worker), Ok(2));
+        assert!(matches!(
+            host.jobs.borrow().jobs[key],
+            HostJobState::ResultReady(_)
+        ));
+        assert_eq!(host.job_get_ret(job), Ok(73));
+        assert_eq!(host.cancel_worker(worker), Ok(1));
 
         host.free_worker(worker).unwrap();
         host.free_job(job).unwrap();

--- a/crates/moonrun/src/async_host/workers.rs
+++ b/crates/moonrun/src/async_host/workers.rs
@@ -155,9 +155,9 @@ impl InstanceWorkers {
 
         // Cancellation must fan out before any join: one slow Worker must not
         // prevent the remaining Workers from receiving their stop request.
-        // FIXME: after the guest stops polling, pending cancellation retries
-        // or full notify pipes can leave Workers stuck and make join hang.
-        // Define cancellation retry/drain ownership for Run teardown outside
+        // FIXME: after the guest stops polling, a cancellation signal arriving
+        // before a blocking syscall may still need a retry to let join finish.
+        // Define cancellation retry ownership for Run teardown outside
         // native free_worker; neither join nor repeated signals can forcibly
         // stop noncooperative computation.
         for (_, worker) in &workers {

--- a/crates/moonrun/src/async_host/workers.rs
+++ b/crates/moonrun/src/async_host/workers.rs
@@ -61,19 +61,21 @@ impl InstanceWorkers {
         worker: HandleKey,
         init_job: HostWorkerJob,
         run_job: impl FnMut(&mut HostWorkerJob) + Send + 'static,
-        mut notify_completion: impl FnMut(WorkerCompletionId) + Send + 'static,
+        notify_completion: impl FnMut(WorkerCompletionId) + Send + 'static,
     ) -> AsyncHostResult<()> {
         let mut workers = self.workers.borrow_mut();
         if workers.contains_key(worker) {
             return Err(AsyncHostError::Badf);
         }
         let completed = self.completed_sender.clone();
-        let handle = thread_pool::spawn_worker(init_job, run_job, move |result| {
-            let completion_id = result.completion_id;
-            if completed.send(result).is_ok() {
-                notify_completion(completion_id);
-            }
-        });
+        let handle = thread_pool::spawn_worker(
+            init_job,
+            run_job,
+            move |result| {
+                let _ = completed.send(result);
+            },
+            notify_completion,
+        );
         workers.insert(worker, handle);
         Ok(())
     }
@@ -98,6 +100,28 @@ impl InstanceWorkers {
         let workers = self.workers.borrow();
         let worker = workers.get(worker).ok_or(AsyncHostError::Badf)?;
         cancel_host_worker(worker)
+    }
+
+    pub(super) fn cancel_with_retry(
+        &self,
+        worker: HandleKey,
+        #[cfg(unix)] notifier: std::sync::Arc<
+            crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier,
+        >,
+    ) -> AsyncHostResult<i32> {
+        let workers = self.workers.borrow();
+        let worker = workers.get(worker).ok_or(AsyncHostError::Badf)?;
+        thread_pool::cancel_worker_with_retry(
+            worker,
+            #[cfg(unix)]
+            notifier,
+        )
+    }
+
+    pub(super) fn check_cancellation_retry(&self, worker: HandleKey) -> AsyncHostResult<bool> {
+        let workers = self.workers.borrow();
+        let worker = workers.get(worker).ok_or(AsyncHostError::Badf)?;
+        thread_pool::worker_check_cancellation_retry(worker)
     }
 
     pub(super) fn free(&self, worker: HandleKey) -> AsyncHostResult<Option<HostWorkerJob>> {
@@ -137,6 +161,11 @@ impl InstanceWorkers {
 
         // Cancellation must fan out before any join: one slow Worker must not
         // prevent the remaining Workers from receiving their stop request.
+        // FIXME: after the guest stops polling, pending cancellation retries
+        // or full notify pipes can leave Workers stuck and make join hang.
+        // Define cancellation retry/drain ownership for Run teardown outside
+        // native free_worker; neither join nor repeated signals can forcibly
+        // stop noncooperative computation.
         for (_, worker) in &workers {
             let _ = cancel_host_worker(worker);
         }
@@ -162,16 +191,6 @@ pub(super) struct StoppedWorker {
 }
 
 fn cancel_host_worker(worker: &HostWorkerHandle) -> AsyncHostResult<i32> {
-    #[cfg(windows)]
-    {
-        match thread_pool::worker_cancellation_target(worker) {
-            thread_pool::WorkerCancellationTarget::Resource(cancel) => {
-                crate::process::cancel_wait(&cancel)?;
-                return Ok(1);
-            }
-            thread_pool::WorkerCancellationTarget::Thread => {}
-        }
-    }
     thread_pool::cancel_worker(worker)
 }
 

--- a/crates/moonrun/src/async_host/workers.rs
+++ b/crates/moonrun/src/async_host/workers.rs
@@ -118,12 +118,6 @@ impl InstanceWorkers {
         )
     }
 
-    pub(super) fn check_cancellation_retry(&self, worker: HandleKey) -> AsyncHostResult<bool> {
-        let workers = self.workers.borrow();
-        let worker = workers.get(worker).ok_or(AsyncHostError::Badf)?;
-        thread_pool::worker_check_cancellation_retry(worker)
-    }
-
     pub(super) fn free(&self, worker: HandleKey) -> AsyncHostResult<Option<HostWorkerJob>> {
         let worker = self
             .workers

--- a/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
@@ -16,22 +16,61 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-#[cfg(unix)]
 use crate::async_host::{AsyncHostError, AsyncHostResult};
-#[cfg(unix)]
 use crate::async_sys::internal::fd_util::stub as fd_util;
-#[cfg(unix)]
 use crate::async_sys::internal::fd_util::stub::RawFd;
-#[cfg(unix)]
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
-#[cfg(unix)]
-use std::sync::Mutex;
+use std::collections::VecDeque;
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+use std::sync::{
+    Arc, Mutex, Weak,
+    atomic::{AtomicBool, AtomicI64, Ordering},
+};
 
-#[cfg(unix)]
+// Outside the i32 completion-ID range, including IDs supplied by direct guests.
+const NO_RETRY: i64 = i64::MIN;
+
+#[derive(Debug, Default)]
+struct PendingCompletions {
+    jobs: VecDeque<i32>,
+    // Register only Workers that enable retries. Each Worker owns its slot;
+    // fetch temporarily upgrades the Weak to keep it alive while reading.
+    // Expired registrations are removed during fetch or the next registration.
+    retries: Vec<Weak<AtomicI64>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CancellationRetryNotifier {
+    pending: Arc<AtomicI64>,
+    source: Arc<ThreadPoolCompletionNotifier>,
+}
+
+impl CancellationRetryNotifier {
+    pub(crate) fn notify_from_signal(&self, completion_id: i32) {
+        // Publish before waking. Repeated retries for the same current Job
+        // occupy one slot, even when the guest stops consuming notifications.
+        // The handler uses the existing Arc without changing reference counts.
+        self.pending
+            .store(i64::from(completion_id), Ordering::SeqCst);
+        self.source.retry_scan_needed.store(true, Ordering::SeqCst);
+        let _ = self.source.wake();
+    }
+
+    pub(crate) fn reset(&self) {
+        // The guest has accepted completion and is reusing the Worker.
+        self.pending.store(NO_RETRY, Ordering::SeqCst);
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct ThreadPoolCompletionNotifier {
-    notify_recv: RawFd,
-    notify_send: RawFd,
+    // Retain both ends until the last publisher exits. The guest receives a
+    // duplicate reader, so closing its handle cannot invalidate these fds.
+    notify_recv: OwnedFd,
+    notify_send: OwnedFd,
+    pending: Mutex<PendingCompletions>,
+    wake_pending: AtomicBool,
+    // A published retry needs inspection; its slot may since have been reset.
+    retry_scan_needed: AtomicBool,
     // Run signals must not backpressure the process-wide signal broker. They
     // coalesce separately from worker IDs, with one wake byte while nonempty.
     // Both ends stay alive with the notifier, including during an in-flight send.
@@ -40,22 +79,16 @@ pub(crate) struct ThreadPoolCompletionNotifier {
     pending_signals: Mutex<u32>,
 }
 
-#[cfg(unix)]
 impl ThreadPoolCompletionNotifier {
     #[cfg(test)]
     pub(crate) fn fill_with_completions(&self, completion_id: i32) {
-        // Establish backpressure without depending on the platform's pipe capacity.
-        let flags = unsafe { libc::fcntl(self.notify_send, libc::F_GETFL) };
-        assert!(flags >= 0);
-        assert_eq!(
-            unsafe { libc::fcntl(self.notify_send, libc::F_SETFL, flags | libc::O_NONBLOCK) },
-            0
-        );
-        let bytes = completion_id.to_ne_bytes();
+        self.notify(completion_id).unwrap();
+        // Fill the actual wake pipe too: publishing must handle EAGAIN without
+        // losing an ID or blocking. Do not depend on a platform's pipe capacity.
         loop {
             let written =
-                unsafe { libc::write(self.notify_send, bytes.as_ptr().cast(), bytes.len()) };
-            if written == bytes.len() as isize {
+                unsafe { libc::write(self.notify_send.as_raw_fd(), b"x".as_ptr().cast(), 1) };
+            if written == 1 {
                 continue;
             }
             assert_eq!(written, -1);
@@ -65,58 +98,77 @@ impl ThreadPoolCompletionNotifier {
             assert!(would_block(last_errno()));
             break;
         }
-        assert_eq!(
-            unsafe { libc::fcntl(self.notify_send, libc::F_SETFL, flags) },
-            0
-        );
+        // Force the next publication to attempt a write to the full pipe.
+        self.wake_pending.store(false, Ordering::SeqCst);
     }
 
     pub(crate) fn new() -> AsyncHostResult<(Self, RawFd)> {
         let signals = fd_util::pipe(true, true)?;
         let signal_recv = unsafe { OwnedFd::from_raw_fd(signals[0]) };
         let signal_send = unsafe { OwnedFd::from_raw_fd(signals[1]) };
-        let fds = fd_util::pipe(true, false)?;
+        let fds = fd_util::pipe(true, true)?;
+        let notify_recv = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        let notify_send = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+        let guest_recv = notify_recv
+            .try_clone()
+            .map_err(|error| AsyncHostError::Native(error.raw_os_error().unwrap_or(libc::EIO)))?;
 
-        // The read end is transferred to AsyncHost's file table so poll
-        // events report the same handle space as ordinary pipe/file fds.
         Ok((
             Self {
-                notify_recv: fds[0],
-                notify_send: fds[1],
+                notify_recv,
+                notify_send,
+                pending: Mutex::new(PendingCompletions::default()),
+                wake_pending: AtomicBool::new(false),
+                retry_scan_needed: AtomicBool::new(false),
                 signal_recv,
                 signal_send,
                 pending_signals: Mutex::new(0),
             },
-            fds[0],
+            guest_recv.into_raw_fd(),
         ))
     }
 
     pub(crate) fn notify(&self, completion_id: i32) -> AsyncHostResult<()> {
-        let bytes = completion_id.to_ne_bytes();
-        let mut offset = 0;
+        self.pending.lock().unwrap().jobs.push_back(completion_id);
+        self.wake()
+    }
+
+    pub(crate) fn cancellation_retry(self: &Arc<Self>) -> CancellationRetryNotifier {
+        let slot = Arc::new(AtomicI64::new(NO_RETRY));
+        let mut pending = self.pending.lock().unwrap();
+        pending.retries.retain(|slot| slot.strong_count() != 0);
+        pending.retries.push(Arc::downgrade(&slot));
+        CancellationRetryNotifier {
+            pending: slot,
+            source: Arc::clone(self),
+        }
+    }
+
+    // Also called by the cancellation signal handler: no locks, allocation,
+    // or blocking writes. An existing wake covers all subsequent publications.
+    fn wake(&self) -> AsyncHostResult<()> {
+        if self.wake_pending.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
         loop {
-            let n = unsafe {
-                libc::write(
-                    self.notify_send,
-                    bytes[offset..].as_ptr().cast(),
-                    bytes.len() - offset,
-                )
-            };
-            if n > 0 {
-                offset += n as usize;
-                if offset == bytes.len() {
-                    return Ok(());
-                }
-                continue;
-            }
-            if n == 0 {
-                return Err(AsyncHostError::Inval);
+            let written =
+                unsafe { libc::write(self.notify_send.as_raw_fd(), b"x".as_ptr().cast(), 1) };
+            if written == 1 {
+                return Ok(());
             }
             let errno = last_errno();
-            if errno == libc::EINTR {
+            if written < 0 && errno == libc::EINTR {
                 continue;
             }
-            return Err(AsyncHostError::Native(errno));
+            if written < 0 && would_block(errno) {
+                return Ok(());
+            }
+            self.wake_pending.store(false, Ordering::SeqCst);
+            return Err(AsyncHostError::Native(if written == 0 {
+                libc::EIO
+            } else {
+                errno
+            }));
         }
     }
 
@@ -194,89 +246,284 @@ impl ThreadPoolCompletionNotifier {
         let _ = self.fetch_signals(&mut [0; u32::BITS as usize * 4]);
     }
 
-    pub(crate) fn notify_from_signal(&self, completion_id: i32) {
-        // Match thread_pool.c: worker cancellation handlers write job IDs into
-        // the normal completion pipe, without locks or allocation. Native
-        // relies on its scheduler's worker bound to keep this write from
-        // blocking. FIXME: audit that bound for direct Wasm calls and Run
-        // teardown; a full pipe blocks this handler if nothing drains it.
-        unsafe {
-            libc::write(
-                self.notify_send,
-                (&raw const completion_id).cast(),
-                std::mem::size_of_val(&completion_id),
-            );
-        }
-    }
-
+    /// Called by the Run's single guest consumer. Publishers may run concurrently.
     pub(crate) fn fetch(&self, dst: &mut [u8]) -> AsyncHostResult<usize> {
-        if dst.is_empty() {
+        if dst.len() < 4 {
             return Ok(0);
         }
         let signal_bytes = self.fetch_signals(dst)?;
         let dst = &mut dst[signal_bytes..];
-        if dst.is_empty() {
+        if dst.len() < 4 {
             return Ok(signal_bytes);
         }
+
+        // Drain the old wake BEFORE clearing its flag, then inspect pending
+        // IDs. A publisher either joins this fetch or sets a new wake; clearing
+        // the flag after inspecting IDs could lose a concurrent publication.
         loop {
-            let n = unsafe { libc::read(self.notify_recv, dst.as_mut_ptr().cast(), dst.len()) };
-            if n > 0 {
-                return usize::try_from(n)
-                    .map(|bytes| signal_bytes + bytes)
-                    .map_err(|_| AsyncHostError::Fault);
-            }
-            if n == 0 {
-                return Ok(signal_bytes);
+            let mut wake_bytes = [0; 128];
+            let n = unsafe {
+                libc::read(
+                    self.notify_recv.as_raw_fd(),
+                    wake_bytes.as_mut_ptr().cast(),
+                    wake_bytes.len(),
+                )
+            };
+            if n >= 0 {
+                if n < wake_bytes.len() as isize {
+                    break;
+                }
+                continue;
             }
             let errno = last_errno();
             if errno == libc::EINTR {
                 continue;
             }
             if would_block(errno) {
-                return Ok(signal_bytes);
+                break;
             }
             return Err(AsyncHostError::Native(errno));
         }
-    }
-}
+        self.wake_pending.store(false, Ordering::SeqCst);
 
-#[cfg(unix)]
-impl Drop for ThreadPoolCompletionNotifier {
-    fn drop(&mut self) {
-        unsafe {
-            libc::close(self.notify_send);
+        let mut pending = self.pending.lock().unwrap();
+        let count = pending.jobs.len().min(dst.len() / 4);
+        for (output, id) in dst.chunks_exact_mut(4).zip(pending.jobs.drain(..count)) {
+            output.copy_from_slice(&id.to_ne_bytes());
         }
+        let mut bytes = count * 4;
+        // Scan retry slots only when there is room to return an ID. If normal
+        // completions filled the buffer, leave the flag set so the next fetch
+        // can inspect retries and the source stays ready in the meantime.
+        if dst.len() - bytes >= 4 && self.retry_scan_needed.swap(false, Ordering::SeqCst) {
+            pending.retries.retain(|slot| {
+                let Some(slot) = slot.upgrade() else {
+                    return false;
+                };
+                if bytes + 4 > dst.len() {
+                    if slot.load(Ordering::SeqCst) != NO_RETRY {
+                        self.retry_scan_needed.store(true, Ordering::SeqCst);
+                    }
+                } else {
+                    let id = slot.swap(NO_RETRY, Ordering::SeqCst);
+                    if id != NO_RETRY {
+                        dst[bytes..bytes + 4].copy_from_slice(&(id as i32).to_ne_bytes());
+                        bytes += 4;
+                    }
+                }
+                true
+            });
+        }
+        let remaining = !pending.jobs.is_empty() || self.retry_scan_needed.load(Ordering::SeqCst);
+        drop(pending);
+        if remaining {
+            // A short guest buffer must not consume the source's readiness.
+            self.wake()?;
+        }
+        Ok(signal_bytes + bytes)
     }
 }
 
-#[cfg(unix)]
 fn last_errno() -> i32 {
-    std::io::Error::last_os_error()
-        .raw_os_error()
-        .unwrap_or_else(|| AsyncHostError::Inval.errno())
+    // Keep the signal-handler path confined to atomics and libc calls.
+    #[cfg(target_os = "linux")]
+    unsafe {
+        *libc::__errno_location()
+    }
+    #[cfg(target_os = "macos")]
+    unsafe {
+        *libc::__error()
+    }
 }
 
-#[cfg(unix)]
 fn would_block(errno: i32) -> bool {
     errno == libc::EAGAIN || errno == libc::EWOULDBLOCK
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn retry_notifications_preserve_pipe_order_and_duplicates() {
+    fn completions_share_one_wakeup_and_survive_a_closed_guest_reader() {
+        let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
+        // Guest handle closure must not close the handler's reader or cause
+        // subsequent notification writes to generate SIGPIPE.
+        drop(unsafe { OwnedFd::from_raw_fd(recv) });
+        for id in 0..65536 {
+            notifier.notify(id).unwrap();
+        }
+        let mut readable = 0;
+        assert_eq!(
+            unsafe {
+                libc::ioctl(
+                    notifier.notify_recv.as_raw_fd(),
+                    libc::FIONREAD,
+                    &mut readable,
+                )
+            },
+            0
+        );
+        assert_eq!(readable, 1, "a burst shares one wake byte");
+
+        let mut bytes = [0; 128];
+        for first in (0_i32..65536).step_by(32) {
+            assert_eq!(notifier.fetch(&mut bytes).unwrap(), bytes.len());
+            for (offset, id) in bytes.chunks_exact(4).enumerate() {
+                assert_eq!(
+                    i32::from_ne_bytes(id.try_into().unwrap()),
+                    first + offset as i32
+                );
+            }
+        }
+        assert_eq!(notifier.fetch(&mut bytes).unwrap(), 0);
+    }
+
+    #[test]
+    fn retries_do_not_lock_and_remain_pending_after_partial_fetch() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
+        let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
+        let notifier = Arc::new(notifier);
+        let first = notifier.cancellation_retry();
+        let second = notifier.cancellation_retry();
+        let pending = notifier.pending.lock().unwrap();
+        let (sent_tx, sent_rx) = mpsc::channel();
+        let publisher = std::thread::spawn(move || {
+            for _ in 0..65536 {
+                first.notify_from_signal(i32::MIN);
+                second.notify_from_signal(i32::MAX);
+            }
+            sent_tx.send(()).unwrap();
+            (first, second)
+        });
+        let published_without_lock = sent_rx.recv_timeout(Duration::from_secs(2));
+        drop(pending);
+        let (first, second) = publisher.join().unwrap();
+        assert!(
+            published_without_lock.is_ok(),
+            "signal publication waited for the completion lock"
+        );
+        assert_eq!(notifier.pending.lock().unwrap().jobs.len(), 0);
+        assert_eq!(notifier.pending.lock().unwrap().retries.len(), 2);
+
+        let mut bytes = [0; 4];
+        for expected in [i32::MIN, i32::MAX] {
+            let mut poll = libc::pollfd {
+                fd: recv,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            assert_eq!(unsafe { libc::poll(&mut poll, 1, 0) }, 1);
+            assert_eq!(notifier.fetch(&mut bytes).unwrap(), 4);
+            assert_eq!(i32::from_ne_bytes(bytes), expected);
+        }
+        assert_eq!(notifier.fetch(&mut bytes).unwrap(), 0);
+
+        first.notify_from_signal(17);
+        first.reset();
+        second.notify_from_signal(19);
+        drop(second);
+        assert_eq!(
+            notifier.fetch(&mut bytes).unwrap(),
+            0,
+            "reused and freed Workers leave no stale retries"
+        );
+        assert_eq!(notifier.pending.lock().unwrap().retries.len(), 1);
+    }
+
+    #[test]
+    fn concurrent_publication_and_fetch_do_not_lose_wakeups() {
+        use std::sync::{Barrier, mpsc};
+        use std::time::{Duration, Instant};
+
+        let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
+        let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
+        let notifier = Arc::new(notifier);
+        let start = Arc::new(Barrier::new(6));
+        let producers: Vec<_> = (0..4)
+            .map(|producer| {
+                let notifier = Arc::clone(&notifier);
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    for id in 0..1024 {
+                        notifier.notify(producer * 1024 + id).unwrap();
+                        std::thread::yield_now();
+                    }
+                })
+            })
+            .collect();
+        let retry = notifier.cancellation_retry();
+        let (ack_tx, ack_rx) = mpsc::channel();
+        let retry_start = Arc::clone(&start);
+        let retry_producer = std::thread::spawn(move || {
+            retry_start.wait();
+            for id in 4096..4224 {
+                retry.notify_from_signal(id);
+                // A new Job ID is published only after the old one is fetched;
+                // duplicates for the same Job may otherwise legitimately coalesce.
+                assert_eq!(ack_rx.recv_timeout(Duration::from_secs(5)).unwrap(), id);
+            }
+        });
+        start.wait();
+        let mut seen = [false; 4224];
+        let mut received = 0;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while received < seen.len() && Instant::now() < deadline {
+            let mut poll = libc::pollfd {
+                fd: recv,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            assert!(unsafe { libc::poll(&mut poll, 1, 100) } >= 0);
+            if poll.revents == 0 {
+                continue;
+            }
+            let mut bytes = [0; 28];
+            let fetched = notifier.fetch(&mut bytes).unwrap();
+            for bytes in bytes[..fetched].chunks_exact(4) {
+                let id = i32::from_ne_bytes(bytes.try_into().unwrap());
+                assert!(!seen[id as usize], "duplicate notification {id}");
+                seen[id as usize] = true;
+                received += 1;
+                if id >= 4096 {
+                    ack_tx.send(id).unwrap();
+                }
+            }
+        }
+        for producer in producers {
+            producer.join().unwrap();
+        }
+        retry_producer.join().unwrap();
+        assert!(
+            seen.into_iter().all(|seen| seen),
+            "a publication lost its wakeup"
+        );
+    }
+
+    #[test]
+    fn full_pipe_retains_completions_and_coalesces_retries() {
         use std::os::fd::{FromRawFd, OwnedFd};
 
         let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
         let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
-        notifier.notify(17).unwrap();
-        notifier.notify_from_signal(19);
-        notifier.notify_from_signal(19);
+        let notifier = Arc::new(notifier);
+        let retry = notifier.cancellation_retry();
+        notifier.fill_with_completions(17);
         notifier.notify(23).unwrap();
+        retry.notify_from_signal(19);
+        retry.notify_from_signal(19);
 
-        for expected in [17, 19, 19, 23] {
+        let mut poll = libc::pollfd {
+            fd: recv,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        for expected in [17, 23, 19] {
+            assert_eq!(unsafe { libc::poll(&mut poll, 1, 0) }, 1);
             let mut bytes = [0u8; 4];
             assert_eq!(notifier.fetch(&mut bytes).unwrap(), 4);
             assert_eq!(i32::from_ne_bytes(bytes), expected);
@@ -290,7 +537,8 @@ mod tests {
 
         for fd in [
             notify_recv,
-            notifier.notify_send,
+            notifier.notify_recv.as_raw_fd(),
+            notifier.notify_send.as_raw_fd(),
             notifier.signal_recv.as_raw_fd(),
             notifier.signal_send.as_raw_fd(),
         ] {
@@ -300,6 +548,8 @@ mod tests {
         }
 
         for fd in [
+            notify_recv,
+            notifier.notify_send.as_raw_fd(),
             notifier.signal_recv.as_raw_fd(),
             notifier.signal_send.as_raw_fd(),
         ] {

--- a/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
@@ -194,6 +194,21 @@ impl ThreadPoolCompletionNotifier {
         let _ = self.fetch_signals(&mut [0; u32::BITS as usize * 4]);
     }
 
+    pub(crate) fn notify_from_signal(&self, completion_id: i32) {
+        // Match thread_pool.c: worker cancellation handlers write job IDs into
+        // the normal completion pipe, without locks or allocation. Native
+        // relies on its scheduler's worker bound to keep this write from
+        // blocking. FIXME: audit that bound for direct Wasm calls and Run
+        // teardown; a full pipe blocks this handler if nothing drains it.
+        unsafe {
+            libc::write(
+                self.notify_send,
+                (&raw const completion_id).cast(),
+                std::mem::size_of_val(&completion_id),
+            );
+        }
+    }
+
     pub(crate) fn fetch(&self, dst: &mut [u8]) -> AsyncHostResult<usize> {
         if dst.is_empty() {
             return Ok(0);
@@ -249,6 +264,25 @@ fn would_block(errno: i32) -> bool {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retry_notifications_preserve_pipe_order_and_duplicates() {
+        use std::os::fd::{FromRawFd, OwnedFd};
+
+        let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
+        let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
+        notifier.notify(17).unwrap();
+        notifier.notify_from_signal(19);
+        notifier.notify_from_signal(19);
+        notifier.notify(23).unwrap();
+
+        for expected in [17, 19, 19, 23] {
+            let mut bytes = [0u8; 4];
+            assert_eq!(notifier.fetch(&mut bytes).unwrap(), 4);
+            assert_eq!(i32::from_ne_bytes(bytes), expected);
+        }
+        assert_eq!(notifier.fetch(&mut [0; 4]).unwrap(), 0);
+    }
 
     #[test]
     fn completion_pipe_is_close_on_exec() {

--- a/crates/moonrun/src/async_sys/internal/event_loop/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/mod.rs
@@ -16,10 +16,11 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+#[cfg(unix)]
 mod completion;
 pub(crate) mod io;
 pub(crate) mod poll;
 pub(crate) mod thread_pool;
 
 #[cfg(unix)]
-pub(crate) use completion::ThreadPoolCompletionNotifier;
+pub(crate) use completion::{CancellationRetryNotifier, ThreadPoolCompletionNotifier};

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -173,9 +173,9 @@ ported_fns! {
     }
 }
 
-// Run signals coalesce behind a single wake byte. Level triggering preserves
-// readiness when the guest fetches only part of the pending signal set.
-pub(crate) fn poll_register_signal_source(
+// Host completion sources coalesce wakeups. Level triggering preserves
+// readiness when the guest fetches only part of the pending notifications.
+pub(crate) fn poll_register_completion_source(
     instance: &PollInstance,
     fd: RawFd,
     fd_handle: u64,

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -276,9 +276,9 @@ pub(crate) fn event_get_pid(event: &PollEvent) -> RawFd {
     event.ident as RawFd
 }
 
-// Run signals coalesce behind a single wake byte. Omit EV_CLEAR so readiness
-// persists when the guest fetches only part of the pending signal set.
-pub(crate) fn poll_register_signal_source(
+// Host completion sources coalesce wakeups. Omit EV_CLEAR so readiness
+// persists when the guest fetches only part of the pending notifications.
+pub(crate) fn poll_register_completion_source(
     instance: &PollInstance,
     fd: RawFd,
     fd_handle: u64,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
@@ -20,7 +20,9 @@
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 #[cfg(unix)]
-use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
+use crate::async_sys::internal::event_loop::{
+    CancellationRetryNotifier, ThreadPoolCompletionNotifier,
+};
 use std::sync::{
     Arc, OnceLock,
     atomic::{AtomicBool, AtomicI32, Ordering},
@@ -40,7 +42,7 @@ pub(super) struct WorkerCancellation {
     #[cfg(unix)]
     retry_enabled: AtomicBool,
     #[cfg(unix)]
-    notifier: OnceLock<Arc<ThreadPoolCompletionNotifier>>,
+    notifier: OnceLock<CancellationRetryNotifier>,
 }
 
 impl WorkerCancellation {
@@ -66,6 +68,9 @@ impl WorkerCancellation {
         #[cfg(unix)]
         {
             self.retry_enabled.store(false, Ordering::SeqCst);
+            if let Some(notifier) = self.notifier.get() {
+                notifier.reset();
+            }
             self.job_id.store(id, Ordering::SeqCst);
         }
         self.state.store(RUNNING, Ordering::SeqCst);
@@ -93,7 +98,7 @@ impl WorkerCancellation {
 
     #[cfg(unix)]
     pub(super) fn enable_retry(&self, notifier: &Arc<ThreadPoolCompletionNotifier>) {
-        self.notifier.get_or_init(|| Arc::clone(notifier));
+        self.notifier.get_or_init(|| notifier.cancellation_retry());
         self.retry_enabled.store(true, Ordering::SeqCst);
     }
 
@@ -242,8 +247,9 @@ pub(super) extern "C" fn cancellation_signal_handler(_: i32) {
         && worker.retry_enabled()
         && let Some(notifier) = worker.notifier.get()
     {
-        // The signal may arrive before the syscall begins, so ask the guest
-        // loop to retry until the worker acknowledges or publishes completion.
+        // The signal may arrive before the syscall begins. Record a retry in
+        // this Worker's preallocated slot; publication never locks or waits
+        // for the guest to drain the notification source.
         notifier.notify_from_signal(worker.job_id.load(Ordering::SeqCst));
     }
     unsafe {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
@@ -1,0 +1,283 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Native-shaped cancellation acknowledgement around potentially blocking calls.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+#[cfg(unix)]
+use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicBool, AtomicI32, Ordering},
+};
+
+const RUNNING: i32 = 0;
+const CANCELLING: i32 = 1;
+const CANCELLED: i32 = 2;
+const WAITING: i32 = 3;
+
+#[derive(Debug)]
+pub(super) struct WorkerCancellation {
+    state: AtomicI32,
+    inside: AtomicBool,
+    #[cfg(unix)]
+    job_id: AtomicI32,
+    #[cfg(unix)]
+    retry_enabled: AtomicBool,
+    #[cfg(unix)]
+    notifier: OnceLock<Arc<ThreadPoolCompletionNotifier>>,
+}
+
+impl WorkerCancellation {
+    pub(super) fn new(id: i32) -> Self {
+        #[cfg(windows)]
+        let _ = id;
+        Self {
+            state: AtomicI32::new(RUNNING),
+            inside: AtomicBool::new(false),
+            #[cfg(unix)]
+            job_id: AtomicI32::new(id),
+            #[cfg(unix)]
+            retry_enabled: AtomicBool::new(false),
+            #[cfg(unix)]
+            notifier: OnceLock::new(),
+        }
+    }
+
+    pub(super) fn start(&self, id: i32) {
+        #[cfg(windows)]
+        let _ = id;
+        self.inside.store(false, Ordering::SeqCst);
+        #[cfg(unix)]
+        {
+            self.retry_enabled.store(false, Ordering::SeqCst);
+            self.job_id.store(id, Ordering::SeqCst);
+        }
+        self.state.store(RUNNING, Ordering::SeqCst);
+    }
+
+    pub(super) fn finish(&self) {
+        self.inside.store(false, Ordering::SeqCst);
+        self.state.store(WAITING, Ordering::SeqCst);
+    }
+
+    pub(super) fn is_waiting(&self) -> bool {
+        self.state.load(Ordering::SeqCst) == WAITING
+    }
+
+    /// False means the operation acknowledged cancellation or already finished.
+    pub(super) fn request(&self) -> bool {
+        match self
+            .state
+            .compare_exchange(RUNNING, CANCELLING, Ordering::SeqCst, Ordering::SeqCst)
+        {
+            Ok(_) | Err(CANCELLING) => true,
+            Err(_) => false,
+        }
+    }
+
+    #[cfg(unix)]
+    pub(super) fn enable_retry(&self, notifier: &Arc<ThreadPoolCompletionNotifier>) {
+        self.notifier.get_or_init(|| Arc::clone(notifier));
+        self.retry_enabled.store(true, Ordering::SeqCst);
+    }
+
+    #[cfg(unix)]
+    pub(super) fn disable_retry(&self) {
+        self.retry_enabled.store(false, Ordering::SeqCst);
+    }
+
+    #[cfg(unix)]
+    pub(super) fn retry_enabled(&self) -> bool {
+        self.retry_enabled.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(unix)]
+static WORKER_KEY: OnceLock<libc::pthread_key_t> = OnceLock::new();
+#[cfg(windows)]
+static WORKER_KEY: OnceLock<u32> = OnceLock::new();
+
+pub(super) struct CurrentWorker(Arc<WorkerCancellation>);
+
+impl CurrentWorker {
+    pub(super) fn enter(worker: Arc<WorkerCancellation>) -> Self {
+        #[cfg(unix)]
+        {
+            let key = WORKER_KEY.get_or_init(|| {
+                let mut key = 0;
+                assert_eq!(unsafe { libc::pthread_key_create(&mut key, None) }, 0);
+                key
+            });
+            assert_eq!(
+                unsafe { libc::pthread_setspecific(*key, Arc::as_ptr(&worker).cast()) },
+                0
+            );
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::System::Threading::{
+                TLS_OUT_OF_INDEXES, TlsAlloc, TlsSetValue,
+            };
+            let key = WORKER_KEY.get_or_init(|| {
+                let key = unsafe { TlsAlloc() };
+                assert_ne!(key, TLS_OUT_OF_INDEXES);
+                key
+            });
+            assert_ne!(unsafe { TlsSetValue(*key, Arc::as_ptr(&worker).cast()) }, 0);
+        }
+        Self(worker)
+    }
+}
+
+impl Drop for CurrentWorker {
+    fn drop(&mut self) {
+        // Clear the TLS pointer before releasing the Arc that keeps it alive.
+        #[cfg(unix)]
+        unsafe {
+            libc::pthread_setspecific(*WORKER_KEY.get().unwrap(), std::ptr::null());
+        }
+        #[cfg(windows)]
+        unsafe {
+            windows_sys::Win32::System::Threading::TlsSetValue(
+                *WORKER_KEY.get().unwrap(),
+                std::ptr::null(),
+            );
+        }
+        let _ = &self.0;
+    }
+}
+
+fn current_worker() -> *const WorkerCancellation {
+    let Some(key) = WORKER_KEY.get() else {
+        return std::ptr::null();
+    };
+    #[cfg(unix)]
+    unsafe {
+        libc::pthread_getspecific(*key).cast()
+    }
+    #[cfg(windows)]
+    unsafe {
+        windows_sys::Win32::System::Threading::TlsGetValue(*key).cast()
+    }
+}
+
+/// Own the cancellation mark only for one cancellable syscall. Synchronous
+/// callers outside a Worker keep their existing behavior.
+pub(crate) struct CancellableRegion {
+    worker: Option<Arc<WorkerCancellation>>,
+    _same_thread: std::marker::PhantomData<*const ()>,
+}
+
+impl CancellableRegion {
+    pub(crate) fn enter() -> AsyncHostResult<Self> {
+        let raw = current_worker();
+        let worker = if raw.is_null() {
+            None
+        } else {
+            // CurrentWorker owns a strong reference until this thread leaves
+            // its loop. Incrementing it keeps the region valid independently.
+            Some(unsafe {
+                Arc::increment_strong_count(raw);
+                Arc::from_raw(raw)
+            })
+        };
+        if let Some(worker) = &worker {
+            worker.inside.store(true, Ordering::SeqCst);
+            if worker.state.load(Ordering::SeqCst) == CANCELLING {
+                worker.state.store(CANCELLED, Ordering::SeqCst);
+                worker.inside.store(false, Ordering::SeqCst);
+                #[cfg(unix)]
+                return Err(AsyncHostError::Native(libc::EINTR));
+                #[cfg(windows)]
+                return Err(AsyncHostError::Native(
+                    windows_sys::Win32::Foundation::ERROR_OPERATION_ABORTED as i32,
+                ));
+            }
+        }
+        Ok(Self {
+            worker,
+            _same_thread: std::marker::PhantomData,
+        })
+    }
+}
+
+impl Drop for CancellableRegion {
+    fn drop(&mut self) {
+        if let Some(worker) = &self.worker {
+            worker.inside.store(false, Ordering::SeqCst);
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(super) extern "C" fn cancellation_signal_handler(_: i32) {
+    // As in upstream #595, pthread_getspecific is signal-safe on the supported
+    // glibc, musl, and macOS implementations, although POSIX does not require
+    // it. Keep that platform dependency confined to this handler.
+    #[cfg(target_os = "linux")]
+    let errno = unsafe { libc::__errno_location() };
+    #[cfg(target_os = "macos")]
+    let errno = unsafe { libc::__error() };
+    let saved_errno = unsafe { *errno };
+    let worker = current_worker();
+    if let Some(worker) = unsafe { worker.as_ref() }
+        && worker.state.load(Ordering::SeqCst) == CANCELLING
+        && worker.inside.load(Ordering::SeqCst)
+        && worker.retry_enabled()
+        && let Some(notifier) = worker.notifier.get()
+    {
+        // The signal may arrive before the syscall begins, so ask the guest
+        // loop to retry until the worker acknowledges or publishes completion.
+        notifier.notify_from_signal(worker.job_id.load(Ordering::SeqCst));
+    }
+    unsafe {
+        *errno = saved_errno;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancellation_before_syscall_is_acknowledged_and_reset_for_next_job() {
+        let worker = Arc::new(WorkerCancellation::new(1));
+        let current = CurrentWorker::enter(Arc::clone(&worker));
+        assert!(worker.request());
+        assert!(CancellableRegion::enter().is_err());
+        assert!(
+            !worker.request(),
+            "acknowledgement stops further cancellation attempts"
+        );
+        assert!(!worker.inside.load(Ordering::SeqCst));
+
+        worker.finish();
+        worker.start(2);
+        let region = CancellableRegion::enter().unwrap();
+        assert!(worker.inside.load(Ordering::SeqCst));
+        drop(region);
+        assert!(!worker.inside.load(Ordering::SeqCst));
+        drop(current);
+        assert!(current_worker().is_null());
+        assert!(
+            CancellableRegion::enter().is_ok(),
+            "synchronous callers have no worker cancellation state"
+        );
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -16,12 +16,14 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+mod cancellation;
 mod jobs;
 mod runner;
 mod sleep;
 mod types;
 mod worker;
 
+pub(crate) use cancellation::CancellableRegion;
 #[cfg(any(feature = "v8", feature = "wasmtime", test))]
 pub(crate) use jobs::make_sleep_job;
 #[cfg(any(feature = "v8", feature = "wasmtime"))]
@@ -33,10 +35,9 @@ pub(crate) use types::{HostHandle, Job, JobPayload, ResourceTable};
 pub(crate) use types::{JobCancellation, JobCancellationOverride};
 pub(crate) use worker::{
     HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WorkerCompletionId, cancel_worker,
-    free_worker, spawn_worker, wake_worker, worker_enter_idle,
+    cancel_worker_with_retry, free_worker, spawn_worker, wake_worker,
+    worker_check_cancellation_retry, worker_enter_idle,
 };
-#[cfg(windows)]
-pub(crate) use worker::{WorkerCancellationTarget, worker_cancellation_target};
 
 #[cfg(test)]
 pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -34,9 +34,9 @@ pub(crate) use types::{HostHandle, Job, JobPayload, ResourceTable};
 #[cfg(unix)]
 pub(crate) use types::{JobCancellation, JobCancellationOverride};
 pub(crate) use worker::{
-    HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WorkerCompletionId, cancel_worker,
-    cancel_worker_with_retry, free_worker, spawn_worker, wake_worker,
-    worker_check_cancellation_retry, worker_enter_idle,
+    HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WORKER_JOB_FINISHED, WorkerCompletionId,
+    cancel_worker, cancel_worker_with_retry, free_worker, spawn_worker, wake_worker,
+    worker_enter_idle,
 };
 
 #[cfg(test)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -31,6 +31,9 @@ use std::os::unix::thread::JoinHandleExt;
 use super::Job;
 #[cfg(unix)]
 use super::JobCancellation;
+use super::cancellation::{CurrentWorker, WorkerCancellation};
+#[cfg(unix)]
+use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WorkerCompletionId(i32);
@@ -70,7 +73,6 @@ impl HostWorkerJob {
 
 #[derive(Debug)]
 pub(crate) struct HostWorkerJobResult {
-    pub(crate) completion_id: WorkerCompletionId,
     pub(crate) job_key: HandleKey,
     pub(crate) job: Job,
 }
@@ -104,12 +106,12 @@ struct HostWorkerState {
     running_cancel: RunningCancellation,
     #[cfg(unix)]
     running: bool,
-    waiting: bool,
     terminating: bool,
 }
 
 #[derive(Debug)]
 struct HostWorkerShared {
+    cancellation: Arc<WorkerCancellation>,
     state: Mutex<HostWorkerState>,
     wakeup: Condvar,
 }
@@ -141,12 +143,10 @@ impl std::fmt::Debug for HostWorkerHandle {
 fn init_worker_signal_handler() {
     static INIT: std::sync::Once = std::sync::Once::new();
 
-    extern "C" fn nop_signal_handler(_: i32) {}
-
     INIT.call_once(|| unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
         let mut action = std::mem::zeroed::<libc::sigaction>();
-        let signal_handler: extern "C" fn(i32) = nop_signal_handler;
+        let signal_handler: extern "C" fn(i32) = super::cancellation::cancellation_signal_handler;
         action.sa_sigaction = signal_handler as usize;
         libc::sigemptyset(&mut action.sa_mask);
         action.sa_flags = 0;
@@ -159,6 +159,7 @@ impl HostWorkerHandle {
         init_job: HostWorkerJob,
         mut run_job: impl FnMut(&mut HostWorkerJob) + Send + 'static,
         mut complete_job: impl FnMut(HostWorkerJobResult) + Send + 'static,
+        mut notify_completion: impl FnMut(WorkerCompletionId) + Send + 'static,
     ) -> Self {
         #[cfg(unix)]
         init_worker_signal_handler();
@@ -166,6 +167,7 @@ impl HostWorkerHandle {
         let init_cancel = init_job.job.cancellation_override();
 
         let shared = Arc::new(HostWorkerShared {
+            cancellation: Arc::new(WorkerCancellation::new(init_job.completion_id.as_i32())),
             state: Mutex::new(HostWorkerState {
                 job: Some(init_job),
                 #[cfg(unix)]
@@ -174,25 +176,24 @@ impl HostWorkerHandle {
                 running_cancel: RunningCancellation::Idle,
                 #[cfg(unix)]
                 running: false,
-                waiting: false,
                 terminating: false,
             }),
             wakeup: Condvar::new(),
         });
         let worker_shared = Arc::clone(&shared);
         #[cfg(unix)]
-        let parent_signal_mask = crate::async_sys::signal::set_worker_thread_signal_mask().ok();
+        let parent_signal_mask = crate::async_sys::signal::block_worker_thread_signals().ok();
         let thread = std::thread::spawn(move || {
+            let _current = CurrentWorker::enter(Arc::clone(&worker_shared.cancellation));
             #[cfg(unix)]
             {
-                let _ = crate::async_sys::signal::set_worker_thread_signal_mask();
+                let _ = crate::async_sys::signal::unblock_worker_cancellation_signal();
             }
 
             loop {
                 let job = {
                     let mut state = worker_shared.state.lock().unwrap();
                     while state.job.is_none() && !state.terminating {
-                        state.waiting = true;
                         state = worker_shared.wakeup.wait(state).unwrap();
                     }
                     let job = (!state.terminating).then(|| state.job.take()).flatten();
@@ -215,6 +216,11 @@ impl HostWorkerHandle {
                     break;
                 };
                 run_job(&mut job);
+                let completion_id = job.completion_id;
+                complete_job(HostWorkerJobResult {
+                    job_key: job.job_key,
+                    job: job.job,
+                });
 
                 let terminating = {
                     let mut state = worker_shared.state.lock().unwrap();
@@ -230,16 +236,18 @@ impl HostWorkerHandle {
                     {
                         state.running_cancel = RunningCancellation::Idle;
                     }
-                    if !state.terminating && state.job.is_none() {
-                        state.waiting = true;
+                    // Publish Job payload -> Waiting -> notify. A pending
+                    // cancellation-retry event must never expose an unfinished
+                    // payload as a completed Job.
+                    worker_shared.cancellation.finish();
+                    if let Some(next) = &state.job {
+                        worker_shared
+                            .cancellation
+                            .start(next.completion_id.as_i32());
                     }
                     state.terminating
                 };
-                complete_job(HostWorkerJobResult {
-                    completion_id: job.completion_id,
-                    job_key: job.job_key,
-                    job: job.job,
-                });
+                notify_completion(completion_id);
                 if terminating {
                     break;
                 }
@@ -274,7 +282,15 @@ impl HostWorkerHandle {
                 .as_ref()
                 .and_then(|job| job.job.cancellation_override());
         }
-        state.waiting = false;
+        if let Some(job) = &state.job {
+            #[cfg(unix)]
+            let idle = !state.running;
+            #[cfg(windows)]
+            let idle = matches!(state.running_cancel, RunningCancellation::Idle);
+            if idle {
+                self.shared.cancellation.start(job.completion_id.as_i32());
+            }
+        }
         self.shared.wakeup.notify_one();
         previous_job
     }
@@ -307,12 +323,27 @@ impl HostWorkerHandle {
 
     pub(crate) fn cancel(&self) -> AsyncHostResult<i32> {
         #[cfg(unix)]
+        self.shared.cancellation.disable_retry();
+        self.cancel_inner()
+    }
+
+    pub(crate) fn cancel_with_retry(
+        &self,
+        #[cfg(unix)] notifier: Arc<ThreadPoolCompletionNotifier>,
+    ) -> AsyncHostResult<i32> {
+        #[cfg(unix)]
+        self.shared.cancellation.enable_retry(&notifier);
+        self.cancel_inner()
+    }
+
+    fn cancel_inner(&self) -> AsyncHostResult<i32> {
+        if !self.shared.cancellation.request() {
+            return Ok(1);
+        }
+        #[cfg(unix)]
         {
             let cancel = {
                 let state = self.shared.state.lock().unwrap();
-                if state.waiting {
-                    return Ok(1);
-                }
                 state.cancel_override.clone()
             };
             if let Some(cancel) = cancel {
@@ -324,7 +355,7 @@ impl HostWorkerHandle {
             unsafe {
                 libc::pthread_kill(thread.as_pthread_t(), libc::SIGUSR2);
             }
-            Ok(0)
+            Ok(i32::from(self.shared.cancellation.retry_enabled()))
         }
 
         #[cfg(windows)]
@@ -333,7 +364,8 @@ impl HostWorkerHandle {
             use windows_sys::Win32::Foundation::{ERROR_NOT_FOUND, GetLastError};
             use windows_sys::Win32::System::IO::CancelSynchronousIo;
 
-            if self.shared.state.lock().unwrap().waiting {
+            if let WorkerCancellationTarget::Resource(cancel) = self.cancellation_target() {
+                crate::process::cancel_wait(&cancel)?;
                 return Ok(1);
             }
             let Some(thread) = &self.thread else {
@@ -374,8 +406,9 @@ ported_fns! {
         init_job: HostWorkerJob,
         run_job: impl FnMut(&mut HostWorkerJob) + Send + 'static,
         complete_job: impl FnMut(HostWorkerJobResult) + Send + 'static,
+        notify_completion: impl FnMut(WorkerCompletionId) + Send + 'static,
     ) -> HostWorkerHandle {
-        HostWorkerHandle::spawn(init_job, run_job, complete_job)
+        HostWorkerHandle::spawn(init_job, run_job, complete_job, notify_completion)
     }
 
     #[ported(
@@ -401,8 +434,25 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_cancel_worker"
     )]
-    pub(crate) fn cancel_worker(worker: &HostWorkerHandle) -> AsyncHostResult<i32> {
-        worker.cancel()
+    pub(crate) fn cancel_worker_with_retry(
+        worker: &HostWorkerHandle,
+        #[cfg(unix)] notifier: Arc<ThreadPoolCompletionNotifier>,
+    ) -> AsyncHostResult<i32> {
+        worker.cancel_with_retry(#[cfg(unix)] notifier)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_worker_check_cancellation_retry"
+    )]
+    pub(crate) fn worker_check_cancellation_retry(worker: &HostWorkerHandle) -> AsyncHostResult<bool> {
+        if worker.shared.cancellation.is_waiting() {
+            Ok(false)
+        } else {
+            // Native keeps waiting even if the cancellation attempt fails.
+            let _ = worker.cancel_inner();
+            Ok(true)
+        }
     }
 
     #[ported(
@@ -414,9 +464,8 @@ ported_fns! {
     }
 }
 
-#[cfg(windows)]
-pub(crate) fn worker_cancellation_target(worker: &HostWorkerHandle) -> WorkerCancellationTarget {
-    worker.cancellation_target()
+pub(crate) fn cancel_worker(worker: &HostWorkerHandle) -> AsyncHostResult<i32> {
+    worker.cancel()
 }
 
 #[cfg(test)]
@@ -428,15 +477,27 @@ mod tests {
     use slotmap::KeyData;
     use std::sync::mpsc;
 
+    fn spawn_worker(
+        job: HostWorkerJob,
+        run: impl FnMut(&mut HostWorkerJob) + Send + 'static,
+        mut complete: impl FnMut(HostWorkerJobResult) + Send + 'static,
+    ) -> HostWorkerHandle {
+        // Existing lifecycle tests observe completed jobs after notification.
+        let pending = Arc::new(Mutex::new(None));
+        let published = Arc::clone(&pending);
+        super::spawn_worker(
+            job,
+            run,
+            move |job| *published.lock().unwrap() = Some(job),
+            move |_| complete(pending.lock().unwrap().take().unwrap()),
+        )
+    }
+
     fn make_job_key(value: u64) -> HandleKey {
         KeyData::from_ffi(value).into()
     }
 
     fn worker_job_summary(job: &HostWorkerJob) -> (WorkerCompletionId, HandleKey) {
-        (job.completion_id, job.job_key)
-    }
-
-    fn worker_result_summary(job: &HostWorkerJobResult) -> (WorkerCompletionId, HandleKey) {
         (job.completion_id, job.job_key)
     }
 
@@ -457,17 +518,14 @@ mod tests {
             move |job| {
                 sender.send(worker_job_summary(job)).unwrap();
             },
-            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
+            move |job| completion_sender.send(job.job_key).unwrap(),
         );
 
         assert_eq!(
             receiver.recv().unwrap(),
             (WorkerCompletionId::from_abi(7), make_job_key(11))
         );
-        assert_eq!(
-            completion_receiver.recv().unwrap(),
-            (WorkerCompletionId::from_abi(7), make_job_key(11))
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(11));
         assert_eq!(cancel_worker(&worker), Ok(1));
 
         assert!(wake_worker(&worker, make_worker_job(13, 17)).is_none());
@@ -475,11 +533,137 @@ mod tests {
             receiver.recv().unwrap(),
             (WorkerCompletionId::from_abi(13), make_job_key(17))
         );
-        assert_eq!(
-            completion_receiver.recv().unwrap(),
-            (WorkerCompletionId::from_abi(13), make_job_key(17))
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(17));
         assert!(free_worker(worker).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancellation_retry_interrupts_a_syscall_started_after_the_first_signal() {
+        use super::super::CancellableRegion;
+        use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+        use std::time::{Duration, Instant};
+
+        let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
+        let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
+        let notifier = Arc::new(notifier);
+        let completion = Arc::clone(&notifier);
+        let fds = crate::async_sys::internal::fd_util::stub::pipe(false, false).unwrap();
+        let read = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        let write = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = super::spawn_worker(
+            make_worker_job(17, 19),
+            move |job| {
+                let region = CancellableRegion::enter().unwrap();
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                let mut byte = 0u8;
+                let ret = unsafe { libc::read(read.as_raw_fd(), (&raw mut byte).cast(), 1) };
+                let errno = std::io::Error::last_os_error().raw_os_error().unwrap();
+                drop(region);
+                job.job.set_ret(if ret < 0 {
+                    i64::from(-errno)
+                } else {
+                    ret as i64
+                });
+            },
+            move |job| result_tx.send(job.job.ret()).unwrap(),
+            move |id| completion.notify(id.as_i32()).unwrap(),
+        );
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(
+            cancel_worker_with_retry(&worker, Arc::clone(&notifier)),
+            Ok(1)
+        );
+
+        let mut poll = libc::pollfd {
+            fd: recv,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        assert_eq!(unsafe { libc::poll(&mut poll, 1, 5000) }, 1);
+        let mut bytes = [0u8; 4];
+        assert_eq!(notifier.fetch(&mut bytes).unwrap(), 4);
+        assert_eq!(i32::from_ne_bytes(bytes), 17);
+        assert!(
+            result_rx.try_recv().is_err(),
+            "a retry is not job completion"
+        );
+        assert_eq!(worker_check_cancellation_retry(&worker), Ok(true));
+        release_tx.send(()).unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut finished = false;
+        let mut result_at_completion = None;
+        while Instant::now() < deadline {
+            if unsafe { libc::poll(&mut poll, 1, 100) } == 1
+                && notifier.fetch(&mut bytes).unwrap() == 4
+            {
+                assert_eq!(i32::from_ne_bytes(bytes), 17);
+                if !worker_check_cancellation_retry(&worker).unwrap() {
+                    result_at_completion = result_rx.try_recv().ok();
+                    finished = true;
+                    break;
+                }
+            }
+        }
+        // Release the read even on failure, so a regression cannot strand it.
+        drop(write);
+        assert!(free_worker(worker).is_none());
+        assert!(
+            finished,
+            "retry notification must eventually interrupt the read"
+        );
+        assert_eq!(
+            result_at_completion,
+            Some(i64::from(-libc::EINTR)),
+            "payload must be published before completion is accepted"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn legacy_cancellation_does_not_publish_retry_events() {
+        use super::super::CancellableRegion;
+        use std::os::fd::{FromRawFd, OwnedFd};
+        use std::time::Duration;
+
+        let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
+        let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
+        let notifier = Arc::new(notifier);
+        let completion = Arc::clone(&notifier);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (ack_tx, ack_rx) = mpsc::channel();
+        let (finish_tx, finish_rx) = mpsc::channel();
+        let worker = super::spawn_worker(
+            make_worker_job(23, 29),
+            move |_| {
+                let region = CancellableRegion::enter().unwrap();
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                drop(region);
+                assert!(CancellableRegion::enter().is_err());
+                ack_tx.send(()).unwrap();
+                finish_rx.recv().unwrap();
+            },
+            |_| {},
+            move |id| completion.notify(id.as_i32()).unwrap(),
+        );
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(cancel_worker(&worker), Ok(0));
+        release_tx.send(()).unwrap();
+        ack_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(cancel_worker(&worker), Ok(1));
+        let mut bytes = [0u8; 4];
+        assert_eq!(notifier.fetch(&mut bytes).unwrap(), 0);
+        finish_tx.send(()).unwrap();
+        assert!(free_worker(worker).is_none());
+        assert_eq!(notifier.fetch(&mut bytes).unwrap(), 4);
+        assert_eq!(i32::from_ne_bytes(bytes), 23);
     }
 
     #[test]
@@ -491,23 +675,17 @@ mod tests {
             move |job| {
                 sender.send(worker_job_summary(job)).unwrap();
             },
-            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
+            move |job| completion_sender.send(job.job_key).unwrap(),
         );
 
         assert_eq!(receiver.recv().unwrap().0, WorkerCompletionId::from_abi(1));
-        assert_eq!(
-            completion_receiver.recv().unwrap().0,
-            WorkerCompletionId::from_abi(1)
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(2));
 
         assert!(worker_enter_idle(&worker).is_none());
         assert!(wake_worker(&worker, make_worker_job(3, 4)).is_none());
 
         assert_eq!(receiver.recv().unwrap().0, WorkerCompletionId::from_abi(3));
-        assert_eq!(
-            completion_receiver.recv().unwrap().0,
-            WorkerCompletionId::from_abi(3)
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(4));
         assert!(free_worker(worker).is_none());
     }
 
@@ -524,7 +702,7 @@ mod tests {
                     release_receiver.recv().unwrap();
                 }
             },
-            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
+            move |job| completion_sender.send(job.job_key).unwrap(),
         );
 
         assert_eq!(
@@ -534,10 +712,7 @@ mod tests {
         assert!(wake_worker(&worker, make_worker_job(3, 4)).is_none());
         release_sender.send(()).unwrap();
 
-        assert_eq!(
-            completion_receiver.recv().unwrap().0,
-            WorkerCompletionId::from_abi(1)
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(2));
         assert_eq!(
             started_receiver
                 .recv_timeout(std::time::Duration::from_secs(1))
@@ -545,10 +720,7 @@ mod tests {
                 .0,
             WorkerCompletionId::from_abi(3)
         );
-        assert_eq!(
-            completion_receiver.recv().unwrap().0,
-            WorkerCompletionId::from_abi(3)
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(4));
         assert!(free_worker(worker).is_none());
     }
 
@@ -566,7 +738,7 @@ mod tests {
                     release_receiver.recv().unwrap();
                 }
             },
-            move |job| completion_sender.send(job.completion_id).unwrap(),
+            move |job| completion_sender.send(job.job_key).unwrap(),
         );
 
         assert_eq!(
@@ -592,7 +764,7 @@ mod tests {
             completion_receiver
                 .recv_timeout(std::time::Duration::from_secs(1))
                 .unwrap(),
-            WorkerCompletionId::from_abi(1)
+            make_job_key(2)
         );
         assert_eq!(
             started_receiver
@@ -604,7 +776,7 @@ mod tests {
             completion_receiver
                 .recv_timeout(std::time::Duration::from_secs(1))
                 .unwrap(),
-            WorkerCompletionId::from_abi(3)
+            make_job_key(4)
         );
         assert!(free_worker(worker).is_none());
     }
@@ -631,27 +803,21 @@ mod tests {
             move |job| {
                 started_sender.send(worker_job_summary(job)).unwrap();
             },
-            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
+            move |job| completion_sender.send(job.job_key).unwrap(),
         );
 
         assert_eq!(
             started_receiver.recv().unwrap(),
             (WorkerCompletionId::from_abi(1), make_job_key(2))
         );
-        assert_eq!(
-            completion_receiver.recv().unwrap(),
-            (WorkerCompletionId::from_abi(1), make_job_key(2))
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(2));
 
         assert!(wake_worker(&worker, make_worker_job(3, 4)).is_none());
         assert_eq!(
             started_receiver.recv().unwrap(),
             (WorkerCompletionId::from_abi(3), make_job_key(4))
         );
-        assert_eq!(
-            completion_receiver.recv().unwrap(),
-            (WorkerCompletionId::from_abi(3), make_job_key(4))
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(4));
         assert!(free_worker(worker).is_none());
     }
 
@@ -666,7 +832,7 @@ mod tests {
                 started_sender.send(worker_job_summary(job)).unwrap();
                 release_receiver.recv().unwrap();
             },
-            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
+            move |job| completion_sender.send(job.job_key).unwrap(),
         );
 
         assert_eq!(
@@ -681,10 +847,7 @@ mod tests {
         );
 
         release_sender.send(()).unwrap();
-        assert_eq!(
-            completion_receiver.recv().unwrap(),
-            (WorkerCompletionId::from_abi(1), make_job_key(2))
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(2));
         assert!(wake_worker(&worker, make_worker_job(5, 6)).is_none());
         assert_eq!(
             started_receiver
@@ -693,10 +856,7 @@ mod tests {
             (WorkerCompletionId::from_abi(5), make_job_key(6))
         );
         release_sender.send(()).unwrap();
-        assert_eq!(
-            completion_receiver.recv().unwrap(),
-            (WorkerCompletionId::from_abi(5), make_job_key(6))
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(6));
         assert!(free_worker(worker).is_none());
     }
 
@@ -711,7 +871,7 @@ mod tests {
                 started_sender.send(worker_job_summary(job)).unwrap();
                 release_receiver.recv().unwrap();
             },
-            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
+            move |job| completion_sender.send(job.job_key).unwrap(),
         );
 
         assert_eq!(
@@ -720,10 +880,7 @@ mod tests {
         );
         assert!(worker.wake(None).is_none());
         release_sender.send(()).unwrap();
-        assert_eq!(
-            completion_receiver.recv().unwrap().0,
-            WorkerCompletionId::from_abi(21)
-        );
+        assert_eq!(completion_receiver.recv().unwrap(), make_job_key(34));
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
         while worker
@@ -754,10 +911,10 @@ mod tests {
         assert!(queued_job.cancel.is_some());
         let worker = HostWorkerHandle {
             shared: Arc::new(HostWorkerShared {
+                cancellation: Arc::new(WorkerCancellation::new(3)),
                 state: Mutex::new(HostWorkerState {
                     job: Some(queued_job),
                     running_cancel: RunningCancellation::Idle,
-                    waiting: false,
                     terminating: false,
                 }),
                 wakeup: Condvar::new(),

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -538,6 +538,70 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn cancellation_and_completion_do_not_block_on_a_full_pipe() {
+        use super::super::CancellableRegion;
+        use std::os::fd::{FromRawFd, OwnedFd};
+        use std::time::{Duration, Instant};
+
+        let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
+        let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
+        let notifier = Arc::new(notifier);
+        notifier.fill_with_completions(17);
+        let completion = Arc::clone(&notifier);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = super::spawn_worker(
+            make_worker_job(23, 29),
+            move |job| {
+                let region = CancellableRegion::enter().unwrap();
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                // Exercise the real handler synchronously as well as the
+                // cancellation request below, without depending on delivery timing.
+                assert_eq!(unsafe { libc::raise(libc::SIGUSR2) }, 0);
+                drop(region);
+                job.job.set_ret(73);
+            },
+            move |job| result_tx.send(job.job.ret()).unwrap(),
+            move |id| completion.notify(id.as_i32()).unwrap(),
+        );
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(
+            cancel_worker_with_retry(&worker, Arc::clone(&notifier)),
+            Ok(1)
+        );
+        release_tx.send(()).unwrap();
+        let (joined_tx, joined_rx) = mpsc::channel();
+        let join = std::thread::spawn(move || {
+            assert!(free_worker(worker).is_none());
+            joined_tx.send(()).unwrap();
+        });
+
+        let joined_without_fetch = joined_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+        if !joined_without_fetch {
+            // Unblock the old implementation so this regression fails cleanly
+            // instead of leaving a Worker stuck inside the signal handler.
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while !join.is_finished() && Instant::now() < deadline {
+                notifier.fetch(&mut [0; 4096]).unwrap();
+                std::thread::yield_now();
+            }
+            assert!(
+                join.is_finished(),
+                "Worker did not exit even after draining"
+            );
+        }
+        join.join().unwrap();
+        assert_eq!(result_rx.try_recv().unwrap(), 73);
+        assert!(
+            joined_without_fetch,
+            "Worker join depended on guest draining the full pipe"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn cancellation_retry_interrupts_a_syscall_started_after_the_first_signal() {
         use super::super::CancellableRegion;
         use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -35,6 +35,10 @@ use super::cancellation::{CurrentWorker, WorkerCancellation};
 #[cfg(unix)]
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 
+// The combined Wasm cancellation ABI extends native's 0 (retry later) and
+// 1 (keep waiting) with the finished case from worker_check_cancellation_retry.
+pub(crate) const WORKER_JOB_FINISHED: i32 = 2;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WorkerCompletionId(i32);
 
@@ -331,6 +335,9 @@ impl HostWorkerHandle {
         &self,
         #[cfg(unix)] notifier: Arc<ThreadPoolCompletionNotifier>,
     ) -> AsyncHostResult<i32> {
+        if self.shared.cancellation.is_waiting() {
+            return Ok(WORKER_JOB_FINISHED);
+        }
         #[cfg(unix)]
         self.shared.cancellation.enable_retry(&notifier);
         self.cancel_inner()
@@ -439,20 +446,6 @@ ported_fns! {
         #[cfg(unix)] notifier: Arc<ThreadPoolCompletionNotifier>,
     ) -> AsyncHostResult<i32> {
         worker.cancel_with_retry(#[cfg(unix)] notifier)
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_worker_check_cancellation_retry"
-    )]
-    pub(crate) fn worker_check_cancellation_retry(worker: &HostWorkerHandle) -> AsyncHostResult<bool> {
-        if worker.shared.cancellation.is_waiting() {
-            Ok(false)
-        } else {
-            // Native keeps waiting even if the cancellation attempt fails.
-            let _ = worker.cancel_inner();
-            Ok(true)
-        }
     }
 
     #[ported(
@@ -592,7 +585,10 @@ mod tests {
             result_rx.try_recv().is_err(),
             "a retry is not job completion"
         );
-        assert_eq!(worker_check_cancellation_retry(&worker), Ok(true));
+        assert_eq!(
+            cancel_worker_with_retry(&worker, Arc::clone(&notifier)),
+            Ok(1)
+        );
         release_tx.send(()).unwrap();
 
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -603,7 +599,9 @@ mod tests {
                 && notifier.fetch(&mut bytes).unwrap() == 4
             {
                 assert_eq!(i32::from_ne_bytes(bytes), 17);
-                if !worker_check_cancellation_retry(&worker).unwrap() {
+                if cancel_worker_with_retry(&worker, Arc::clone(&notifier)).unwrap()
+                    == WORKER_JOB_FINISHED
+                {
                     result_at_completion = result_rx.try_recv().ok();
                     finished = true;
                     break;

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -245,6 +245,9 @@ impl HostWorkerHandle {
                     // payload as a completed Job.
                     worker_shared.cancellation.finish();
                     if let Some(next) = &state.job {
+                        // An early wake from a direct caller advances cancellation
+                        // to the next Job. Async's guest accepts the previous
+                        // completion before waking us again.
                         worker_shared
                             .cancellation
                             .start(next.completion_id.as_i32());
@@ -331,6 +334,9 @@ impl HostWorkerHandle {
         self.cancel_inner()
     }
 
+    /// Inspect or cancel the current Job, not an earlier completion ID.
+    /// The guest must accept completion before assigning the next Job; an
+    /// early wake can advance this state before the old notification is read.
     pub(crate) fn cancel_with_retry(
         &self,
         #[cfg(unix)] notifier: Arc<ThreadPoolCompletionNotifier>,

--- a/crates/moonrun/src/async_sys/signal/mod.rs
+++ b/crates/moonrun/src/async_sys/signal/mod.rs
@@ -45,8 +45,8 @@ use windows as platform;
 
 #[cfg(unix)]
 pub(crate) use unix::{
-    SigwaitJob, SigwaitTarget, init_thread_pool_signal_mask, make_sigwait_job,
-    restore_thread_pool_signal_mask, set_worker_thread_signal_mask,
+    SigwaitJob, SigwaitTarget, block_worker_thread_signals, init_thread_pool_signal_mask,
+    make_sigwait_job, restore_thread_pool_signal_mask, unblock_worker_cancellation_signal,
 };
 
 ported_fns! {

--- a/crates/moonrun/src/async_sys/signal/unix.rs
+++ b/crates/moonrun/src/async_sys/signal/unix.rs
@@ -235,15 +235,22 @@ pub(crate) fn restore_thread_pool_signal_mask(old: &libc::sigset_t) -> AsyncHost
     })
 }
 
-pub(crate) fn set_worker_thread_signal_mask() -> AsyncHostResult<libc::sigset_t> {
+pub(crate) fn block_worker_thread_signals() -> AsyncHostResult<libc::sigset_t> {
     let mut worker_mask = unsafe { std::mem::zeroed::<libc::sigset_t>() };
     check_signal_call(unsafe { libc::sigfillset(&mut worker_mask) })?;
-    check_signal_call(unsafe { libc::sigdelset(&mut worker_mask, libc::SIGUSR2) })?;
     let mut old = unsafe { std::mem::zeroed::<libc::sigset_t>() };
     check_pthread_call(unsafe {
         libc::pthread_sigmask(libc::SIG_SETMASK, &worker_mask, &mut old)
     })?;
     Ok(old)
+}
+
+pub(crate) fn unblock_worker_cancellation_signal() -> AsyncHostResult<()> {
+    let mut signal = empty_signal_set()?;
+    check_signal_call(unsafe { libc::sigaddset(&mut signal, libc::SIGUSR2) })?;
+    check_pthread_call(unsafe {
+        libc::pthread_sigmask(libc::SIG_UNBLOCK, &signal, std::ptr::null_mut())
+    })
 }
 
 pub(super) fn signal_int() -> i32 {

--- a/crates/moonrun/src/async_sys/socket.rs
+++ b/crates/moonrun/src/async_sys/socket.rs
@@ -1351,6 +1351,38 @@ ported_fns! {
 
     #[ported(
         source = "src/socket/socket.c",
+        original = "moonbitlang_async_allow_reuse_port"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn allow_reuse_port(fd: RawSocket) -> AsyncHostResult<()> {
+        let enable: libc::c_int = 1;
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_REUSEPORT,
+                (&raw const enable).cast(),
+                std::mem::size_of_val(&enable) as libc::socklen_t,
+            )
+        } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_allow_reuse_port"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn allow_reuse_port(_fd: RawSocket) -> AsyncHostResult<()> {
+        // Native treats platforms without SO_REUSEPORT as a successful no-op.
+        Ok(())
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
         original = "moonbitlang_async_set_ipv6_only"
     )]
     #[cfg(unix)]
@@ -1817,6 +1849,46 @@ fn set_tcp_int(fd: RawSocket, option: libc::c_int, value: i32) -> AsyncHostResul
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn reuse_port_allows_two_listeners_on_the_same_address() {
+        use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+        let [first, second] = std::array::from_fn(|_| {
+            let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+            assert!(fd >= 0);
+            unsafe { OwnedFd::from_raw_fd(fd) }
+        });
+        let mut addr = unsafe { std::mem::zeroed::<libc::sockaddr_in>() };
+        addr.sin_family = libc::AF_INET as _;
+        addr.sin_addr.s_addr = u32::from_ne_bytes([127, 0, 0, 1]);
+        let mut len = std::mem::size_of_val(&addr) as libc::socklen_t;
+        allow_reuse_port(first.as_raw_fd()).unwrap();
+        assert_eq!(
+            unsafe { libc::bind(first.as_raw_fd(), (&raw const addr).cast(), len) },
+            0
+        );
+        listen(first.as_raw_fd()).unwrap();
+        assert_eq!(
+            unsafe { libc::getsockname(first.as_raw_fd(), (&raw mut addr).cast(), &mut len) },
+            0
+        );
+        assert_eq!(
+            unsafe { libc::bind(second.as_raw_fd(), (&raw const addr).cast(), len) },
+            -1
+        );
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::EADDRINUSE)
+        );
+        allow_reuse_port(second.as_raw_fd()).unwrap();
+        assert_eq!(
+            unsafe { libc::bind(second.as_raw_fd(), (&raw const addr).cast(), len) },
+            0
+        );
+        listen(second.as_raw_fd()).unwrap();
+    }
 
     #[test]
     fn if_nametoindex_rejects_unpaired_surrogate() {

--- a/crates/moonrun/src/filesystem/job/runner.rs
+++ b/crates/moonrun/src/filesystem/job/runner.rs
@@ -18,6 +18,7 @@
 
 //! Blocking filesystem operations executed by Filesystem Jobs.
 
+use crate::async_sys::internal::event_loop::thread_pool::CancellableRegion;
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
@@ -348,6 +349,7 @@ fn open_raw_native_file(
     };
     let append_flag = if append { libc::O_APPEND } else { 0 };
     let filename = CString::new(filename.into_vec()).map_err(|_| AsyncHostError::Inval)?;
+    let region = CancellableRegion::enter()?;
     let fd = unsafe {
         libc::open(
             filename.as_ptr(),
@@ -355,6 +357,7 @@ fn open_raw_native_file(
             mode as libc::c_uint,
         )
     };
+    drop(region);
     if fd < 0 {
         return Err(last_native_error());
     }
@@ -431,6 +434,7 @@ fn open_raw_native_file(
         .chain(std::iter::once(0))
         .collect::<Vec<_>>();
     let handle: HANDLE = loop {
+        let region = CancellableRegion::enter()?;
         let handle = unsafe {
             CreateFileW(
                 filename.as_ptr(),
@@ -442,6 +446,7 @@ fn open_raw_native_file(
                 std::ptr::null_mut(),
             )
         };
+        drop(region);
         if handle != INVALID_HANDLE_VALUE {
             break handle;
         }
@@ -451,7 +456,10 @@ fn open_raw_native_file(
         if error != ERROR_PIPE_BUSY as i32 {
             return Err(AsyncHostError::Native(error));
         }
-        if unsafe { WaitNamedPipeW(filename.as_ptr(), NMPWAIT_WAIT_FOREVER) } == 0 {
+        let region = CancellableRegion::enter()?;
+        let ready = unsafe { WaitNamedPipeW(filename.as_ptr(), NMPWAIT_WAIT_FOREVER) };
+        drop(region);
+        if ready == 0 {
             return Err(last_native_error());
         }
     };
@@ -565,7 +573,9 @@ pub(super) fn handle_is_socket(handle: RawFile) -> bool {
 fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHostResult<usize> {
     let ret = if position < 0 {
         loop {
+            let region = CancellableRegion::enter()?;
             let ret = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+            drop(region);
             if ret >= 0 {
                 break ret;
             }
@@ -580,7 +590,10 @@ fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHos
                 events: libc::POLLIN,
                 revents: 0,
             };
-            if unsafe { libc::poll(&mut pfd, 1, -1) } < 0 {
+            let region = CancellableRegion::enter()?;
+            let ready = unsafe { libc::poll(&mut pfd, 1, -1) };
+            drop(region);
+            if ready < 0 {
                 break -1;
             }
         }
@@ -601,7 +614,9 @@ fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHos
 fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostResult<usize> {
     let ret = if position < 0 {
         loop {
+            let region = CancellableRegion::enter()?;
             let ret = unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) };
+            drop(region);
             if ret >= 0 {
                 break ret;
             }
@@ -616,7 +631,10 @@ fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostRes
                 events: libc::POLLOUT,
                 revents: 0,
             };
-            if unsafe { libc::poll(&mut pfd, 1, -1) } < 0 {
+            let region = CancellableRegion::enter()?;
+            let ready = unsafe { libc::poll(&mut pfd, 1, -1) };
+            drop(region);
+            if ready < 0 {
                 break -1;
             }
         }
@@ -753,7 +771,10 @@ fn lock_native_file(fd: RawFile, exclusive: bool) -> AsyncHostResult<()> {
     } else {
         libc::LOCK_SH
     };
-    if unsafe { libc::flock(fd, operation) } < 0 {
+    let region = CancellableRegion::enter()?;
+    let result = unsafe { libc::flock(fd, operation) };
+    drop(region);
+    if result < 0 {
         Err(last_native_error())
     } else {
         Ok(())
@@ -983,6 +1004,7 @@ fn read_from_native_file(handle: RawFile, buf: &mut [u8], position: i64) -> Asyn
     } else {
         Some(current_file_pointer(handle)?)
     };
+    let region = CancellableRegion::enter()?;
     let result = unsafe {
         ReadFile(
             handle,
@@ -992,6 +1014,7 @@ fn read_from_native_file(handle: RawFile, buf: &mut [u8], position: i64) -> Asyn
             overlapped_ptr,
         )
     };
+    drop(region);
     let result = if result != 0 {
         usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
     } else {
@@ -1047,6 +1070,7 @@ fn write_to_native_file(handle: RawFile, data: &[u8], position: i64) -> AsyncHos
     } else {
         Some(current_file_pointer(handle)?)
     };
+    let region = CancellableRegion::enter()?;
     let result = unsafe {
         WriteFile(
             handle,
@@ -1056,6 +1080,7 @@ fn write_to_native_file(handle: RawFile, data: &[u8], position: i64) -> AsyncHos
             overlapped_ptr,
         )
     };
+    drop(region);
     let result = if result != 0 {
         usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
     } else {
@@ -1345,7 +1370,10 @@ fn lock_native_file(file: RawFile, exclusive: bool) -> AsyncHostResult<()> {
     } else {
         0
     };
-    if unsafe { LockFileEx(file, flags, 0, 1, 0, &mut overlapped) } == 0 {
+    let region = CancellableRegion::enter()?;
+    let result = unsafe { LockFileEx(file, flags, 0, 1, 0, &mut overlapped) };
+    drop(region);
+    if result == 0 {
         Err(last_native_error())
     } else {
         Ok(())

--- a/crates/moonrun/src/filesystem/job/runner.rs
+++ b/crates/moonrun/src/filesystem/job/runner.rs
@@ -598,6 +598,8 @@ fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHos
             }
         }
     } else {
+        // Async's io.mbt submits positioned Unix I/O as non-cancellable.
+        // Match native: the guest waits for pread instead of cancelling it.
         unsafe {
             libc::pread(
                 fd,
@@ -639,6 +641,8 @@ fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostRes
             }
         }
     } else {
+        // Positioned Unix writes are also non-cancellable in async's io.mbt;
+        // leave pwrite outside the region, as in native thread_pool.c.
         unsafe {
             libc::pwrite(
                 fd,

--- a/crates/moonrun/src/process/ambient.rs
+++ b/crates/moonrun/src/process/ambient.rs
@@ -787,6 +787,7 @@ fn wait_for_process(
 
 #[cfg(target_os = "linux")]
 fn wait_for_process_pidfd(pidfd: RawFile, defer_reap: bool) -> AsyncHostResult<i64> {
+    let _region = crate::async_sys::internal::event_loop::thread_pool::CancellableRegion::enter()?;
     let mut siginfo = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
     // Policy mode reaps only after atomically revoking PID authority.
     let flags = libc::WEXITED | if defer_reap { libc::WNOWAIT } else { 0 };
@@ -802,6 +803,7 @@ fn wait_for_process_pidfd(pidfd: RawFile, defer_reap: bool) -> AsyncHostResult<i
 
 #[cfg(unix)]
 fn wait_for_process_pid(pid: i32, defer_reap: bool) -> AsyncHostResult<i64> {
+    let _region = crate::async_sys::internal::event_loop::thread_pool::CancellableRegion::enter()?;
     if !defer_reap {
         let mut status = 0;
         let ret = unsafe { libc::waitpid(pid, &mut status, 0) };

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -83,7 +83,7 @@ fn test_moonrun_against_upstream_async() {
         .args(["test", "--target", "wasm", "--no-parallelize"])
         .assert()
         .success()
-        .stdout_eq("Total tests: 531, passed: 531, failed: 0.\n");
+        .stdout_eq("Total tests: 540, passed: 540, failed: 0.\n");
 }
 
 struct TestDir(moon_test_util::test_dir::TestDir);


### PR DESCRIPTION
- Related issues: moonbitlang/async#595
- PR kind: Bugfix (upstream backport)

## Summary

A cancellation signal can arrive just before a worker enters a blocking syscall. Port async #595's cancellation acknowledgement around cancellable file operations and process waits, together with its notification-driven retries. Publish the owned Job result before setting `Waiting`, so an earlier retry notification cannot expose an unavailable result as completion.

The Wasm guest uses one `cancel_worker_with_retry` import both to initiate cancellation and to check job notifications. It combines native's cancellation call and retry check: `0` requests a timer retry, `1` keeps waiting, and `2` confirms that the job finished and its result is available. A worker that acknowledged cancellation but has not published its result still returns `1`. Both initial cancellation and subsequent checks share the same cancellation implementation.

The completion check refers to the Worker's current Job. Async keeps pending Jobs in its scheduler queue and accepts the previous completion before assigning the next Job to that Worker. Direct host callers can queue an early wake, but the cancellation status does not describe an older Job after the Worker advances; this import carries no Job ID.

Cancellation eligibility matches native: async submits positioned I/O with `cancellable=platform is Windows`. Once assigned to a Worker, Unix positioned reads and writes run without guest cancellation, so `pread` and `pwrite` retain native's absence of a cancellable region. Windows positioned I/O remains covered by a cancellable region.

Unix notification delivery uses a host FIFO for completion IDs and one preallocated atomic retry slot per Worker that enables retries. A nonblocking pipe carries coalesced wakeups. This deliberately differs from native's pipe of IDs: a direct Wasm guest can stop draining notifications or fill the pipe, so signal handlers and completed Workers must not wait for guest consumption. The handler only updates atomics and attempts a nonblocking wakeup; it never locks or allocates. Both pipe ends remain owned by the notifier while publishers are alive, even if the guest closes its duplicate reader.

Fetching clears the old wake before inspecting pending IDs, so concurrent publication either joins that fetch or creates another wake. Partial fetches restore readiness on the level-triggered completion source. Only pending retries scan registered retry slots; normal completion delivery does not scan Workers. Regression coverage includes actual cancellation signal delivery with a full pipe, both Worker teardown entry points, coalescing, concurrent publication, partial fetches, and closed guest handles.

The historical `cancel_worker` import retains timer-based retries and its original return values, so older Wasm guests cannot mistake retry notifications for completed Jobs. Ordinary completion IDs retain FIFO order; duplicate retry requests for the same current Job coalesce. Both cancellation imports keep their exact `i64`-to-`i32` signature.

The coordinating guest also requires the Linux port-reuse import and enables existing worker and reuse-port regressions on Wasm. This runtime port includes those requirements and pins the coordinating guest regressions.

Worker freeing retains the native termination wakeup and join, with notification backpressure removed. Cancellation after the guest event loop stops remains a correctness `FIXME`: a signal arriving before a blocking syscall may still need a retry, and no guest remains to request it. An additional teardown retry loop and forced termination of noncooperative computation are outside this change.

This PR targets `main` and builds on the merged signal-delivery backport (#2175). Worker notifications use the revised completion source; Run signals retain #2175's separate coalesced, nonblocking source. Merge this runtime change before the coordinating async guest PR, and keep async #595 labeled required until both changes have landed.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS

Merged signal-delivery prerequisite: https://github.com/moonbitlang/moon/pull/2175. Coordinating guest PR: https://github.com/moonbitlang/async/pull/598.

