### PR TITLE
refactor(test): unify test execution workflow

### DIFF
--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -79,11 +79,11 @@ pub(crate) fn run_bench(
         .package_dirs()?;
 
     if cmd.build_flags.target.is_empty() {
-        return run_bench_internal(&cli, &cmd, &dirs, None, None, output);
+        return run_bench_internal(&cli, &cmd, &dirs, false, None, output);
     }
     let surface_targets = cmd.build_flags.target.clone();
     let targets = lower_surface_targets(&surface_targets);
-    let display_backend_hint = if targets.len() > 1 { Some(()) } else { None };
+    let display_backend_hint = targets.len() > 1;
     let bench_cmd: super::TestLikeSubcommand<'_> = (&cmd).into();
     super::validate_test_or_bench_invocation(&cli, &bench_cmd)?;
     let resolve_output =
@@ -113,7 +113,7 @@ fn run_bench_internal(
     cli: &UniversalFlags,
     cmd: &BenchSubcommand,
     dirs: &PackageDirs,
-    display_backend_hint: Option<()>,
+    display_backend_hint: bool,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {

--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -520,7 +520,31 @@ fn profile_run_subcommand(cmd: RunSubcommand) -> anyhow::Result<RunSubcommand> {
     })
 }
 
-pub(crate) fn profile_test_invocations(
+pub(crate) fn profile_tests(
+    cli: &UniversalFlags,
+    source_dir: &Path,
+    target_dir: &Path,
+    builds: &[(crate::rr_build::BuildMeta, crate::run::TestFilter)],
+    include_skipped: bool,
+    output: &CommandOutput,
+) -> anyhow::Result<i32> {
+    builds
+        .iter()
+        .try_fold(0, |exit_code, (build_meta, filter)| {
+            let result = profile_test_invocations(
+                cli,
+                source_dir,
+                target_dir,
+                build_meta,
+                filter,
+                include_skipped,
+                output,
+            )?;
+            Ok(exit_code.max(result))
+        })
+}
+
+fn profile_test_invocations(
     cli: &UniversalFlags,
     source_dir: &Path,
     target_dir: &Path,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -30,7 +30,7 @@ use crate::rr_build;
 use crate::rr_build::{BuildConfig, CalcUserIntentOutput};
 use crate::run::collect_test_outline;
 use crate::run::perform_promotion;
-use crate::run::{TestFilter, TestIndex, TestOutlineEntry};
+use crate::run::{ReplaceableTestResults, TestFilter, TestIndex, TestOutlineEntry};
 use anyhow::Context;
 use anyhow::bail;
 use clap::builder::ArgPredicate;
@@ -398,14 +398,14 @@ fn run_test_impl(
     if cmd.build_flags.target.is_empty() {
         debug!("no explicit backend target provided; using defaults");
         let selected_target_backend = cmd.profile.then_some(TargetBackend::Native);
-        return run_test_internal(cli, cmd, &dirs, None, selected_target_backend, output);
+        return run_test_internal(cli, cmd, &dirs, false, selected_target_backend, output);
     }
     let surface_targets = &cmd.build_flags.target;
     let targets = lower_surface_targets(surface_targets);
     if cmd.update && targets.len() > 1 {
         return Err(anyhow::anyhow!("cannot update test on multiple targets"));
     }
-    let display_backend_hint = if targets.len() > 1 { Some(()) } else { None };
+    let display_backend_hint = targets.len() > 1;
     let test_cmd: TestLikeSubcommand<'_> = cmd.into();
     validate_test_or_bench_invocation(cli, &test_cmd)?;
     let resolve_output =
@@ -470,7 +470,7 @@ fn run_test_internal(
     cli: &UniversalFlags,
     cmd: &TestSubcommand,
     dirs: &PackageDirs,
-    display_backend_hint: Option<()>,
+    display_backend_hint: bool,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
@@ -599,16 +599,13 @@ fn run_test_in_single_file_rr(
     )?;
 
     let test_cmd: TestLikeSubcommand<'_> = cmd.into();
-    rr_test_from_plan(
+    run_test_workflow(
         cli,
         &test_cmd,
         source_dir,
         target_dir,
-        None,
-        &build_meta,
-        build_graph,
-        filter,
-        None,
+        false,
+        vec![(build_meta, build_graph, filter)],
         output,
     )
 }
@@ -886,7 +883,7 @@ pub(crate) fn run_test_or_bench_internal(
     cli: &UniversalFlags,
     cmd: TestLikeSubcommand,
     dirs: &PackageDirs,
-    display_backend_hint: Option<()>,
+    display_backend_hint: bool,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
@@ -974,7 +971,7 @@ fn run_test_rr(
     cli: &UniversalFlags,
     cmd: &TestLikeSubcommand<'_>,
     dirs: &PackageDirs,
-    display_backend_hint: Option<()>, // FIXME: unsure why it's option but as-is for now
+    display_backend_hint: bool,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
 ) -> Result<i32, anyhow::Error> {
@@ -1002,7 +999,7 @@ pub(crate) fn run_test_or_bench_from_resolved(
     cli: &UniversalFlags,
     cmd: &TestLikeSubcommand<'_>,
     dirs: &PackageDirs,
-    display_backend_hint: Option<()>,
+    display_backend_hint: bool,
     selected_target_backends: &[TargetBackend],
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
     output: &CommandOutput,
@@ -1045,31 +1042,48 @@ pub(crate) fn run_test_or_bench_from_resolved(
             .flatten()
             .collect::<Vec<_>>()
     };
-    let effective_display_backend_hint = if planned_runs.len() > 1 {
-        Some(())
-    } else {
-        display_backend_hint
-    };
+    run_test_workflow(
+        cli,
+        cmd,
+        source_dir,
+        target_dir,
+        display_backend_hint,
+        planned_runs,
+        output,
+    )
+}
 
-    let mut build_only_artifacts = cmd.build_only.then_some(TestArtifacts {
-        artifacts_path: Vec::new(),
-        test_filter_args: Vec::new(),
-    });
-
+/// Executes the complete test or benchmark workflow for project and standalone plans.
+///
+/// All backends build before any test runs. Snapshot updates then alternate
+/// promotion, partial rebuilds, and filtered runs for each backend.
+/// The caller holds the target-directory lock throughout a non-dry-run workflow.
+#[instrument(level = Level::DEBUG, skip_all)]
+fn run_test_workflow(
+    cli: &UniversalFlags,
+    cmd: &TestLikeSubcommand<'_>,
+    source_dir: &Path,
+    target_dir: &Path,
+    display_backend_hint: bool,
+    planned_runs: Vec<(rr_build::BuildMeta, rr_build::BuildInput, TestFilter)>,
+    output: &CommandOutput,
+) -> anyhow::Result<i32> {
+    let user_log = output.user_log();
     if planned_runs.is_empty() {
         return Ok(0);
     }
+    let display_backend_hint = display_backend_hint || planned_runs.len() > 1;
+    let (build_metas_and_filters, build_inputs): (Vec<_>, Vec<_>) = planned_runs
+        .into_iter()
+        .map(|(meta, input, filter)| ((meta, filter), input))
+        .unzip();
+    let build_graph = rr_build::compose_build_inputs(build_inputs)?;
 
     if cli.dry_run {
-        let (build_metas_and_filters, build_inputs): (Vec<_>, Vec<_>) = planned_runs
-            .into_iter()
-            .map(|(meta, input, filter)| ((meta, filter), input))
-            .unzip();
-        let build_input = rr_build::compose_build_inputs(build_inputs)?;
         output.write_result(|writer| {
             rr_build::write_dry_run(
                 writer,
-                &build_input,
+                &build_graph,
                 build_metas_and_filters
                     .iter()
                     .flat_map(|(meta, _)| meta.artifacts.values()),
@@ -1077,23 +1091,21 @@ pub(crate) fn run_test_or_bench_from_resolved(
                 target_dir,
             )
         })?;
+        // Test command lines depend on generated metadata, which dry-run does
+        // not materialize. Profile dry-run therefore also stops at the build graph.
         return Ok(0);
     }
 
-    for (build_meta, _, _) in &planned_runs {
+    for (build_meta, _) in &build_metas_and_filters {
         rr_build::generate_all_pkgs_json(build_meta)?;
     }
-    let (build_metas_and_filters, build_inputs): (Vec<_>, Vec<_>) = planned_runs
-        .into_iter()
-        .map(|(meta, input, filter)| ((meta, filter), input))
-        .unzip();
+    let build_config = BuildConfig::from_flags(cmd.build_flags, &cli.unstable_feature, cli.verbose);
+    // n2 consumes its graph, so retain a copy for snapshot-update rebuilds.
+    let build_graph_backup = cmd.update.then(|| build_graph.clone());
     let build_metas = build_metas_and_filters
         .iter()
         .map(|(meta, _)| meta)
         .collect::<Vec<_>>();
-    let build_graph = rr_build::compose_build_inputs(build_inputs)?;
-    let build_config = BuildConfig::from_flags(cmd.build_flags, &cli.unstable_feature, cli.verbose);
-    let build_graph_backup = cmd.update.then(|| build_graph.clone());
     let result = rr_build::execute_test_build(
         &build_config,
         build_graph,
@@ -1101,40 +1113,170 @@ pub(crate) fn run_test_or_bench_from_resolved(
         &build_metas,
         user_log,
     )?;
-    drop(build_metas);
     if !result.successful() {
         return Ok(result.return_code_for_success());
     }
-    let built = BuiltTestExecution {
-        build_config,
-        build_graph_backup,
-    };
 
+    let mut build_only_artifacts = TestArtifacts {
+        artifacts_path: Vec::new(),
+        test_filter_args: Vec::new(),
+    };
     let mut exit_code = 0;
-    for (build_meta, filter) in build_metas_and_filters {
+    'backends: for (build_meta, mut filter) in build_metas_and_filters {
+        let build_meta = &build_meta;
         debug!(
             artifact_count = build_meta.artifacts.len(),
             backend = ?build_meta.target_backend(),
-            "planned rupes-recta build graph"
+            "executing rupes-recta test workflow"
         );
 
-        exit_code = exit_code.max(rr_test_after_build(
-            cli,
-            cmd,
-            source_dir,
-            target_dir,
-            effective_display_backend_hint,
-            &build_meta,
-            filter,
-            &built,
-            build_only_artifacts.as_mut(),
-            output,
-        )?);
+        if cmd.outline {
+            let entries = collect_test_outline(
+                build_meta,
+                &filter,
+                cmd.include_skipped,
+                cmd.run_mode == RunMode::Bench,
+            )?;
+            print_test_outline(&entries, user_log);
+            continue;
+        }
+
+        if cmd.build_only {
+            let artifacts = collect_test_artifacts_for_build_only(
+                build_meta,
+                &filter,
+                cmd.include_skipped,
+                cmd.run_mode == RunMode::Bench,
+            )?;
+            build_only_artifacts
+                .artifacts_path
+                .extend(artifacts.artifacts_path);
+            build_only_artifacts
+                .test_filter_args
+                .extend(artifacts.test_filter_args);
+            continue;
+        }
+
+        if cmd.profile {
+            exit_code = exit_code.max(profile::profile_test_invocations(
+                cli,
+                source_dir,
+                target_dir,
+                build_meta,
+                &filter,
+                cmd.include_skipped,
+                output,
+            )?);
+            continue;
+        }
+
+        let mut test_result = ReplaceableTestResults::default();
+        let mut run_count = 0;
+        loop {
+            let latest_result = crate::run::run_tests(
+                build_meta,
+                source_dir,
+                target_dir,
+                &filter,
+                cmd.include_skipped,
+                cmd.run_mode == RunMode::Bench,
+                cmd.no_parallelize,
+                cmd.build_flags.jobs,
+                cmd.moonrun_policy,
+                user_log,
+            )?;
+            run_count += 1;
+            test_result.merge(&latest_result);
+            if !cmd.update {
+                break;
+            }
+
+            // Only the latest run can request another promotion. Keep results
+            // for tests outside the rerun filter in the final report.
+            let (rerun_count, rerun_filter) =
+                perform_promotion(&build_meta.resolve_output.pkg_dirs, &latest_result)
+                    .expect("Failed to promote tests");
+            debug!(
+                rerun_count,
+                pending_targets = rerun_filter.0.len(),
+                "promotion pass completed"
+            );
+            if rerun_filter.is_empty() {
+                break;
+            }
+
+            // Preserve the existing limit semantics: promotion happens even
+            // on the last allowed run, but no further rebuild or run follows.
+            if run_count >= cmd.update_limit {
+                user_log.warn(format!(
+                    "reached the limit of {} update passes, stopping further updates.",
+                    cmd.update_limit
+                ));
+                break;
+            }
+
+            let build_graph = build_graph_backup
+                .as_ref()
+                .cloned()
+                .expect("build graph backup should be present when update is true");
+            let want_files = rerun_filter
+                .0
+                .keys()
+                .copied()
+                .flat_map(artifacts_from_target)
+                .flat_map(|artifact| {
+                    build_meta
+                        .artifacts
+                        .get(&artifact)
+                        .expect("test result from the last test run should be present")
+                        .as_slice()
+                });
+            let result = rr_build::execute_build_partial(
+                &build_config,
+                build_graph,
+                target_dir,
+                Some(build_meta),
+                user_log,
+                Box::new(|work| {
+                    trace!("requesting rerun artifacts");
+                    for file_path in want_files {
+                        let file_path_str = file_path.to_string_lossy();
+                        let file = work
+                            .lookup(&file_path_str)
+                            .expect("File should exist in work");
+                        work.want_file(file).context("Failed to want file")?;
+                    }
+                    Ok(())
+                }),
+            )?;
+            if !result.successful() {
+                exit_code = exit_code.max(result.return_code_for_success());
+                continue 'backends;
+            }
+            filter = TestFilter {
+                filter: Some(rerun_filter),
+                name_filter: cmd.filter.clone(),
+            };
+        }
+
+        test_result.print_result(build_meta, cli.verbose, cmd.test_failure_json);
+        let summary = test_result.summary();
+        let backend_hint =
+            display_backend_hint.then_some(build_meta.target_backend().to_backend_ext());
+        print_test_summary(
+            summary.total,
+            summary.passed,
+            cli.quiet,
+            backend_hint,
+            user_log,
+        );
+        if summary.total != summary.passed {
+            exit_code = exit_code.max(2);
+        }
     }
-    if !cli.dry_run
-        && let Some(test_artifacts) = build_only_artifacts
-    {
-        println!("{}", serde_json_lenient::to_string(&test_artifacts)?);
+    if cmd.build_only {
+        // Emit one JSON object for the whole invocation, including all backends.
+        println!("{}", serde_json_lenient::to_string(&build_only_artifacts)?);
     }
     Ok(exit_code)
 }
@@ -1626,309 +1768,6 @@ fn validate_original_package_selection_filters(
     }
 
     Ok(())
-}
-
-#[instrument(level = Level::DEBUG, skip_all)]
-#[allow(clippy::too_many_arguments)] // FIXME
-fn rr_test_from_plan(
-    cli: &UniversalFlags,
-    cmd: &TestLikeSubcommand<'_>,
-    source_dir: &Path,
-    target_dir: &Path,
-    display_backend_hint: Option<()>,
-    build_meta: &rr_build::BuildMeta,
-    build_graph: rr_build::BuildInput,
-    filter: TestFilter,
-    build_only_artifacts: Option<&mut TestArtifacts>,
-    output: &CommandOutput,
-) -> Result<i32, anyhow::Error> {
-    let built = match execute_test_build_from_plan(
-        cli,
-        cmd,
-        source_dir,
-        target_dir,
-        build_meta,
-        build_graph,
-        output,
-    )? {
-        TestBuildExecution::DryRun => return Ok(0),
-        TestBuildExecution::BuildFailed(exit_code) => return Ok(exit_code),
-        TestBuildExecution::Built(built) => *built,
-    };
-
-    rr_test_after_build(
-        cli,
-        cmd,
-        source_dir,
-        target_dir,
-        display_backend_hint,
-        build_meta,
-        filter,
-        &built,
-        build_only_artifacts,
-        output,
-    )
-}
-
-#[instrument(level = Level::DEBUG, skip_all)]
-#[allow(clippy::too_many_arguments)]
-fn rr_test_after_build(
-    cli: &UniversalFlags,
-    cmd: &TestLikeSubcommand<'_>,
-    source_dir: &Path,
-    target_dir: &Path,
-    display_backend_hint: Option<()>,
-    build_meta: &rr_build::BuildMeta,
-    filter: TestFilter,
-    built: &BuiltTestExecution,
-    build_only_artifacts: Option<&mut TestArtifacts>,
-    output: &CommandOutput,
-) -> Result<i32, anyhow::Error> {
-    let user_log = output.user_log();
-
-    if cmd.outline {
-        let entries = collect_test_outline(
-            build_meta,
-            &filter,
-            cmd.include_skipped,
-            cmd.run_mode == RunMode::Bench,
-        )?;
-        print_test_outline(&entries, user_log);
-        return Ok(0);
-    }
-
-    if cmd.build_only {
-        // Match legacy behavior: print test artifacts as JSON.
-        let test_artifacts = collect_test_artifacts_for_build_only(
-            build_meta,
-            &filter,
-            cmd.include_skipped,
-            cmd.run_mode == RunMode::Bench,
-        )?;
-        if let Some(artifacts) = build_only_artifacts {
-            artifacts
-                .artifacts_path
-                .extend(test_artifacts.artifacts_path);
-            artifacts
-                .test_filter_args
-                .extend(test_artifacts.test_filter_args);
-        } else {
-            println!("{}", serde_json_lenient::to_string(&test_artifacts)?);
-        }
-        return Ok(0);
-    }
-
-    if cmd.profile {
-        return profile::profile_test_invocations(
-            cli,
-            source_dir,
-            target_dir,
-            build_meta,
-            &filter,
-            cmd.include_skipped,
-            output,
-        );
-    }
-
-    let mut test_result = crate::run::run_tests(
-        build_meta,
-        source_dir,
-        target_dir,
-        &filter,
-        cmd.include_skipped,
-        cmd.run_mode == RunMode::Bench,
-        cmd.no_parallelize,
-        cmd.build_flags.jobs,
-        cmd.moonrun_policy,
-        user_log,
-    )?;
-    let _initial_summary = test_result.summary();
-
-    let backend_hint = display_backend_hint.map(|_| build_meta.target_backend().to_backend_ext());
-
-    if cmd.update {
-        let mut loop_count = 1; // matching legacy; we already have 1 test run before
-        let mut last_test_result = None;
-        loop {
-            // Promote test results
-            let promotion_source = last_test_result.as_ref().unwrap_or(&test_result);
-            let (rerun_count, rerun_filter_raw) =
-                perform_promotion(&build_meta.resolve_output.pkg_dirs, promotion_source)
-                    .expect("Failed to promote tests");
-            debug!(
-                rerun_count,
-                pending_targets = rerun_filter_raw.0.len(),
-                "promotion pass completed"
-            );
-            if rerun_filter_raw.is_empty() {
-                break; // Nothing to promote
-            }
-
-            // Apply loop count limits
-            if loop_count >= cmd.update_limit {
-                user_log.warn(format!(
-                    "reached the limit of {} update passes, stopping further updates.",
-                    cmd.update_limit
-                ));
-                break;
-            }
-            loop_count += 1;
-
-            // Get the graph from backup
-            let build_graph = built
-                .build_graph_backup
-                .as_ref()
-                .cloned()
-                .expect("build graph backup should be present when update is true");
-
-            // Calculate which files to rebuild
-            let want_files = rerun_filter_raw
-                .0
-                .keys()
-                .cloned() // All targets to rerun
-                .flat_map(artifacts_from_target)
-                .flat_map(|artifact| {
-                    build_meta
-                        .artifacts
-                        .get(&artifact)
-                        .expect("test result from the last test run should be present")
-                        .as_slice()
-                });
-
-            // Run the build
-            let result = rr_build::execute_build_partial(
-                &built.build_config,
-                build_graph,
-                target_dir,
-                Some(build_meta),
-                user_log,
-                Box::new(|work| {
-                    trace!("requesting rerun artifacts");
-                    for file_path in want_files {
-                        let file_path_str = file_path.to_string_lossy();
-                        let file = work
-                            .lookup(&file_path_str)
-                            .expect("File should exist in work");
-                        work.want_file(file).context("Failed to want file")?;
-                    }
-                    Ok(())
-                }),
-            )?;
-
-            if !result.successful() {
-                return Ok(result.return_code_for_success());
-            }
-
-            // Run the tests
-            let rerun_filter = TestFilter {
-                filter: Some(rerun_filter_raw),
-                name_filter: cmd.filter.clone(),
-            };
-            let new_test_result = crate::run::run_tests(
-                build_meta,
-                source_dir,
-                target_dir,
-                &rerun_filter,
-                cmd.include_skipped,
-                cmd.run_mode == RunMode::Bench,
-                cmd.no_parallelize,
-                cmd.build_flags.jobs,
-                cmd.moonrun_policy,
-                user_log,
-            )?;
-            let _rerun_summary = new_test_result.summary();
-
-            // Merge test results
-            test_result.merge(&new_test_result);
-            last_test_result = Some(new_test_result);
-        }
-    }
-
-    test_result.print_result(build_meta, cli.verbose, cmd.test_failure_json);
-    let summary = test_result.summary();
-    print_test_summary(
-        summary.total,
-        summary.passed,
-        cli.quiet,
-        backend_hint,
-        user_log,
-    );
-
-    if summary.total == summary.passed {
-        Ok(0)
-    } else {
-        Ok(2)
-    }
-}
-
-struct BuiltTestExecution {
-    build_config: BuildConfig,
-    build_graph_backup: Option<rr_build::BuildInput>,
-}
-
-enum TestBuildExecution {
-    DryRun,
-    BuildFailed(i32),
-    Built(Box<BuiltTestExecution>),
-}
-
-#[allow(clippy::too_many_arguments)]
-fn execute_test_build_from_plan(
-    cli: &UniversalFlags,
-    cmd: &TestLikeSubcommand<'_>,
-    source_dir: &Path,
-    target_dir: &Path,
-    build_meta: &rr_build::BuildMeta,
-    build_graph: rr_build::BuildInput,
-    output: &CommandOutput,
-) -> Result<TestBuildExecution, anyhow::Error> {
-    let user_log = output.user_log();
-    if cli.dry_run {
-        output.write_result(|writer| {
-            rr_build::write_dry_run(
-                writer,
-                &build_graph,
-                build_meta.artifacts.values(),
-                source_dir,
-                target_dir,
-            )
-        })?;
-        // Test command lines depend on generated metadata, which dry-run does
-        // not materialize. Profile dry-run therefore stops at the build graph.
-        return Ok(TestBuildExecution::DryRun);
-    }
-
-    // Generate the all_pkgs.json for indirect dependency resolution
-    // before executing the build
-    rr_build::generate_all_pkgs_json(build_meta)?;
-
-    let build_config = BuildConfig::from_flags(cmd.build_flags, &cli.unstable_feature, cli.verbose);
-
-    // since n2 build consumes the graph, we back it up for reruns
-    let build_graph_backup = cmd.update.then(|| build_graph.clone());
-    let result = rr_build::execute_test_build(
-        &build_config,
-        build_graph,
-        target_dir,
-        &[build_meta],
-        user_log,
-    )?;
-    debug!(
-        success = result.successful(),
-        exit_code = result.return_code_for_success(),
-        "executed rupes-recta build"
-    );
-
-    if !result.successful() {
-        return Ok(TestBuildExecution::BuildFailed(
-            result.return_code_for_success(),
-        ));
-    }
-
-    Ok(TestBuildExecution::Built(Box::new(BuiltTestExecution {
-        build_config,
-        build_graph_backup,
-    })))
 }
 
 /// Collect test artifacts for --build-only mode, matching legacy behavior.

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -30,7 +30,7 @@ use crate::rr_build;
 use crate::rr_build::{BuildConfig, CalcUserIntentOutput};
 use crate::run::collect_test_outline;
 use crate::run::perform_promotion;
-use crate::run::{ReplaceableTestResults, TestFilter, TestIndex, TestOutlineEntry};
+use crate::run::{ReplaceableTestResults, TestFilter, TestIndex};
 use anyhow::Context;
 use anyhow::bail;
 use clap::builder::ArgPredicate;
@@ -205,30 +205,39 @@ fn print_test_summary(
     }
 }
 
-fn print_test_outline(entries: &[TestOutlineEntry], user_log: &UserLog) {
-    if entries.is_empty() {
-        user_log.warn("no test entry found.");
-        return;
-    }
-
-    for (i, entry) in entries.iter().enumerate() {
-        let line = entry
-            .line_number
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "?".to_string());
-        let mut line_out = format!(
-            "{:>4}. {} {}:{} index={}",
-            i + 1,
-            entry.package,
-            entry.file,
-            line,
-            entry.index
-        );
-        if let Some(name) = &entry.name {
-            line_out.push_str(&format!(" name={name:?}"));
+fn print_test_outlines(
+    builds: &[(rr_build::BuildMeta, TestFilter)],
+    include_skipped: bool,
+    bench: bool,
+    user_log: &UserLog,
+) -> anyhow::Result<()> {
+    for (build_meta, filter) in builds {
+        let entries = collect_test_outline(build_meta, filter, include_skipped, bench)?;
+        if entries.is_empty() {
+            user_log.warn("no test entry found.");
+            continue;
         }
-        println!("{line_out}");
+
+        for (i, entry) in entries.iter().enumerate() {
+            let line = entry
+                .line_number
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "?".to_string());
+            let mut line_out = format!(
+                "{:>4}. {} {}:{} index={}",
+                i + 1,
+                entry.package,
+                entry.file,
+                line,
+                entry.index
+            );
+            if let Some(name) = &entry.name {
+                line_out.push_str(&format!(" name={name:?}"));
+            }
+            println!("{line_out}");
+        }
     }
+    Ok(())
 }
 
 /// Test the current package
@@ -1053,10 +1062,10 @@ pub(crate) fn run_test_or_bench_from_resolved(
     )
 }
 
-/// Executes the complete test or benchmark workflow for project and standalone plans.
+/// Builds all selected backends, then dispatches the test or benchmark mode.
 ///
-/// All backends build before any test runs. Snapshot updates then alternate
-/// promotion, partial rebuilds, and filtered runs for each backend.
+/// Project and standalone plans share this initial build barrier. Each mode
+/// handles the whole invocation, including any snapshot-update rebuilds.
 /// The caller holds the target-directory lock throughout a non-dry-run workflow.
 #[instrument(level = Level::DEBUG, skip_all)]
 fn run_test_workflow(
@@ -1117,58 +1126,71 @@ fn run_test_workflow(
         return Ok(result.return_code_for_success());
     }
 
-    let mut build_only_artifacts = TestArtifacts {
-        artifacts_path: Vec::new(),
-        test_filter_args: Vec::new(),
-    };
+    if cmd.outline {
+        print_test_outlines(
+            &build_metas_and_filters,
+            cmd.include_skipped,
+            cmd.run_mode == RunMode::Bench,
+            user_log,
+        )?;
+        return Ok(0);
+    }
+    if cmd.build_only {
+        print_test_artifacts(
+            &build_metas_and_filters,
+            cmd.include_skipped,
+            cmd.run_mode == RunMode::Bench,
+        )?;
+        return Ok(0);
+    }
+    if cmd.profile {
+        return profile::profile_tests(
+            cli,
+            source_dir,
+            target_dir,
+            &build_metas_and_filters,
+            cmd.include_skipped,
+            output,
+        );
+    }
+
+    run_tests_with_updates(
+        cli,
+        cmd,
+        source_dir,
+        target_dir,
+        display_backend_hint,
+        build_metas_and_filters,
+        &build_config,
+        build_graph_backup,
+        user_log,
+    )
+}
+
+/// Runs already-built tests or benchmarks and reports their accumulated results.
+/// With `--update`, promotes snapshots and rebuilds before each filtered rerun.
+/// The caller must hold the target-directory lock throughout this operation.
+#[instrument(level = Level::DEBUG, skip_all)]
+#[allow(clippy::too_many_arguments)]
+fn run_tests_with_updates(
+    cli: &UniversalFlags,
+    cmd: &TestLikeSubcommand<'_>,
+    source_dir: &Path,
+    target_dir: &Path,
+    display_backend_hint: bool,
+    builds: Vec<(rr_build::BuildMeta, TestFilter)>,
+    build_config: &BuildConfig,
+    build_graph_backup: Option<rr_build::BuildInput>,
+    user_log: &UserLog,
+) -> anyhow::Result<i32> {
     let mut exit_code = 0;
-    'backends: for (build_meta, mut filter) in build_metas_and_filters {
+    'backends: for (build_meta, mut filter) in builds {
         let build_meta = &build_meta;
         debug!(
             artifact_count = build_meta.artifacts.len(),
             backend = ?build_meta.target_backend(),
             "executing rupes-recta test workflow"
         );
-
-        if cmd.outline {
-            let entries = collect_test_outline(
-                build_meta,
-                &filter,
-                cmd.include_skipped,
-                cmd.run_mode == RunMode::Bench,
-            )?;
-            print_test_outline(&entries, user_log);
-            continue;
-        }
-
-        if cmd.build_only {
-            let artifacts = collect_test_artifacts_for_build_only(
-                build_meta,
-                &filter,
-                cmd.include_skipped,
-                cmd.run_mode == RunMode::Bench,
-            )?;
-            build_only_artifacts
-                .artifacts_path
-                .extend(artifacts.artifacts_path);
-            build_only_artifacts
-                .test_filter_args
-                .extend(artifacts.test_filter_args);
-            continue;
-        }
-
-        if cmd.profile {
-            exit_code = exit_code.max(profile::profile_test_invocations(
-                cli,
-                source_dir,
-                target_dir,
-                build_meta,
-                &filter,
-                cmd.include_skipped,
-                output,
-            )?);
-            continue;
-        }
 
         let mut test_result = ReplaceableTestResults::default();
         let mut run_count = 0;
@@ -1232,7 +1254,7 @@ fn run_test_workflow(
                         .as_slice()
                 });
             let result = rr_build::execute_build_partial(
-                &build_config,
+                build_config,
                 build_graph,
                 target_dir,
                 Some(build_meta),
@@ -1273,10 +1295,6 @@ fn run_test_workflow(
         if summary.total != summary.passed {
             exit_code = exit_code.max(2);
         }
-    }
-    if cmd.build_only {
-        // Emit one JSON object for the whole invocation, including all backends.
-        println!("{}", serde_json_lenient::to_string(&build_only_artifacts)?);
     }
     Ok(exit_code)
 }
@@ -1770,36 +1788,39 @@ fn validate_original_package_selection_filters(
     Ok(())
 }
 
-/// Collect test artifacts for --build-only mode, matching legacy behavior.
+/// Print one combined artifact listing for --build-only mode across all backends.
 /// For JS backend, serializes each invocation's filter arguments.
-/// For other backends, returns executable paths directly.
+/// For other backends, lists executable paths directly.
 /// Only includes artifacts that have actual tests (skips empty test executables).
-fn collect_test_artifacts_for_build_only(
-    build_meta: &rr_build::BuildMeta,
-    filter: &TestFilter,
+fn print_test_artifacts(
+    builds: &[(rr_build::BuildMeta, TestFilter)],
     include_skipped: bool,
     bench: bool,
-) -> anyhow::Result<TestArtifacts> {
+) -> anyhow::Result<()> {
     let mut artifacts_path = vec![];
     let mut test_filter_args = vec![];
 
-    for invocation in
-        crate::run::collect_test_invocations(build_meta, filter, include_skipped, bench)?
-    {
-        // JS build-only output carries the serialized filter beside the executable.
-        if matches!(build_meta.target_backend(), TargetBackend::Js) {
-            let filter_arg = serde_json::to_string(&invocation.args)
-                .context("failed to serialize JS test filter args")?;
+    for (build_meta, filter) in builds {
+        for invocation in
+            crate::run::collect_test_invocations(build_meta, filter, include_skipped, bench)?
+        {
+            // JS build-only output carries the serialized filter beside the executable.
+            if matches!(build_meta.target_backend(), TargetBackend::Js) {
+                let filter_arg = serde_json::to_string(&invocation.args)
+                    .context("failed to serialize JS test filter args")?;
 
-            artifacts_path.push(invocation.executable);
-            test_filter_args.push(filter_arg);
-        } else {
-            artifacts_path.push(invocation.executable);
+                artifacts_path.push(invocation.executable);
+                test_filter_args.push(filter_arg);
+            } else {
+                artifacts_path.push(invocation.executable);
+            }
         }
     }
 
-    Ok(TestArtifacts {
+    let artifacts = TestArtifacts {
         artifacts_path,
         test_filter_args,
-    })
+    };
+    println!("{}", serde_json_lenient::to_string(&artifacts)?);
+    Ok(())
 }

--- a/crates/moon/src/run/mod.rs
+++ b/crates/moon/src/run/mod.rs
@@ -26,8 +26,8 @@ mod runtime;
 pub(crate) use child::assign_process_to_job;
 pub(crate) use child::run;
 pub(crate) use runtest::{
-    PackageFilter, TestFilter, TestIndex, TestOutlineEntry, collect_test_invocations,
-    collect_test_outline, perform_promotion, run_tests,
+    PackageFilter, ReplaceableTestResults, TestFilter, TestIndex, TestOutlineEntry,
+    collect_test_invocations, collect_test_outline, perform_promotion, run_tests,
 };
 pub(crate) use runtime::{
     ExecutionMode, command_for, command_for_with_moonrun_policy,

--- a/crates/moon/src/run/mod.rs
+++ b/crates/moon/src/run/mod.rs
@@ -26,8 +26,8 @@ mod runtime;
 pub(crate) use child::assign_process_to_job;
 pub(crate) use child::run;
 pub(crate) use runtest::{
-    PackageFilter, ReplaceableTestResults, TestFilter, TestIndex, TestOutlineEntry,
-    collect_test_invocations, collect_test_outline, perform_promotion, run_tests,
+    PackageFilter, ReplaceableTestResults, TestFilter, TestIndex, collect_test_invocations,
+    collect_test_outline, perform_promotion, run_tests,
 };
 pub(crate) use runtime::{
     ExecutionMode, command_for, command_for_with_moonrun_policy,

--- a/docs/dev/reference/tests.md
+++ b/docs/dev/reference/tests.md
@@ -7,6 +7,13 @@ behavior can change.
 
 ## Build + run pipeline
 
+Project tests, standalone-file tests, and benchmarks enter the same
+`run_test_workflow` after planning. It owns the initial build, the execution loop
+(including snapshot-update rebuilds), and reporting. Dry-run stops at the build
+graph; outline, build-only, and profiling branch after the initial build. The
+command entry points hold the target-directory lock from before planning until
+the entire workflow finishes, including test execution and promotion.
+
 1. The CLI resolves packages and test targets (via Rupes Recta build planning). Each
    selected `BuildTarget` produces two artifacts: the executable (`make_executable`) and
    a JSON metadata file (`generate_test_info`).
@@ -53,7 +60,7 @@ snapshot tests. The CLI enforces a single target backend in this mode (updating
 multiple backends at once would diverge binary outputs) and disallows patch
 files.
 
-1. After the initial run, `perform_promotion` scans the aggregated
+1. After each run, `perform_promotion` scans that run's
    `ReplaceableTestResults`. For every `ExpectTestFailed` or `SnapshotTestFailed`
    case it:
 
@@ -74,8 +81,10 @@ files.
      final summary reflects the updated outcomes.
 
 3. The loop repeats until either the filter is empty or the pass count hits
-   `--limit`. When the limit triggers the runner stops promoting and leaves any
-   remaining failures in the final output.
+   `--limit`. The initial run counts as the first pass. Promotion happens before
+   checking the limit, so the last pass can still modify files, but no rebuild or
+   rerun follows. The final report retains the last observed results, including
+   results for tests outside the rerun filter.
 
 During promotion the expect/snapshot helpers in `moonbuild::expect` are
 responsible for touching files. The CLI does not stream diffs; failures are still

--- a/docs/dev/reference/tests.md
+++ b/docs/dev/reference/tests.md
@@ -8,11 +8,15 @@ behavior can change.
 ## Build + run pipeline
 
 Project tests, standalone-file tests, and benchmarks enter the same
-`run_test_workflow` after planning. It owns the initial build, the execution loop
-(including snapshot-update rebuilds), and reporting. Dry-run stops at the build
-graph; outline, build-only, and profiling branch after the initial build. The
-command entry points hold the target-directory lock from before planning until
-the entire workflow finishes, including test execution and promotion.
+`run_test_workflow` after planning. It owns the initial build and dispatches the
+selected mode. Dry-run stops at the build graph. After the initial build,
+outline, build-only, and profiling each dispatch once to a dedicated handler
+for the whole invocation. Build-only emits one combined artifact listing across
+backends. Ordinary test and benchmark execution goes through
+`run_tests_with_updates`, which owns the execution, snapshot promotion, rebuild,
+and rerun loop, together with the final report.
+The command entry points hold the target-directory lock from before planning
+until the entire workflow finishes, including test execution and promotion.
 
 1. The CLI resolves packages and test targets (via Rupes Recta build planning). Each
    selected `BuildTarget` produces two artifacts: the executable (`make_executable`) and


### PR DESCRIPTION
- Related issues: None
- PR kind: Refactor

## Summary

Project and standalone tests use different initial-build paths, while `rr_test_after_build` can rebuild during `--update`. This makes the execution order difficult to follow when reasoning about lock lifetimes.

Route project tests, standalone tests, and benchmarks through one `run_test_workflow` for the initial build and mode dispatch. Dedicated handlers own outline output, build-only artifact output, profiling, and ordinary test execution. `run_tests_with_updates` keeps execution, snapshot promotion, rebuilds, filtered reruns, and reporting together. Remove the duplicate initial-build helpers and handoff types, replace the backend-hint `Option<()>` with `bool`, and document the execution flow.

The workflow preserves the build barrier across all selected backends, promotion-before-limit ordering, filtered reruns with accumulated results, and one combined build-only JSON result. Lock lifetimes remain unchanged so concurrency changes can be reviewed separately.

## Metadata

- [ ] Tests added/updated for bug fixes or new features (not applicable: behavior-preserving refactor)
- [x] Compatible with Windows/Linux/macOS
