### PR TITLE
fix(test): narrow build locking and skip outline compilation

### DIFF
--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -21,7 +21,6 @@ use moonutil::{
     build_options::TestIndexRange,
     cli_support::AutoSyncFlags,
     command_output::CommandOutput,
-    locks::lock_directory,
     project::PackageDirs,
     target::{TargetBackend, lower_surface_targets},
 };
@@ -88,10 +87,6 @@ pub(crate) fn run_bench(
     super::validate_test_or_bench_invocation(&cli, &bench_cmd)?;
     let resolve_output =
         super::sync_and_resolve_test_or_bench_project(&cli, &bench_cmd, &dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
     super::run_test_or_bench_from_resolved(
         &cli,
         &bench_cmd,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -127,7 +127,7 @@ impl ResolvedTestSelection {
             ResolvedTestSelection::Workspace { packages } => Ok(packages
                 .iter()
                 .copied()
-                .map(UserIntent::Test)
+                .map(|package| cmd.package_intent(package))
                 .collect::<Vec<_>>()
                 .into()),
             ResolvedTestSelection::Packages { .. } | ResolvedTestSelection::Paths { .. } => {
@@ -165,7 +165,7 @@ impl ResolvedTestSelection {
                     ResolvedTestSelection::Paths { .. } => InputDirective::default(),
                     ResolvedTestSelection::Workspace { .. } => unreachable!(),
                 };
-                Ok((test_intents_from_filter(filter), directive).into())
+                Ok((test_intents_from_filter(filter, cmd), directive).into())
             }
         }
     }
@@ -419,10 +419,6 @@ fn run_test_impl(
     validate_test_or_bench_invocation(cli, &test_cmd)?;
     let resolve_output =
         sync_and_resolve_test_or_bench_project(cli, &test_cmd, &dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
     let ret_value = run_test_or_bench_from_resolved(
         cli,
         &test_cmd,
@@ -557,10 +553,11 @@ fn run_test_in_single_file_rr(
         cmd.build_flags.resolve_single_target_backend()?.or(backend)
     };
 
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(target_dir, user_log)?;
-    }
+    let lock = if cli.dry_run {
+        None
+    } else {
+        Some(lock_directory(target_dir, user_log)?)
+    };
     let build_flags = effective_test_build_flags(&cmd.build_flags, cmd.profile);
 
     let compile_config = rr_build::prepare_resolved_build(
@@ -595,7 +592,8 @@ fn run_test_in_single_file_rr(
         None
     };
     let directive = rr_build::build_patch_directive_for_package(pkg, false, trace_pkg, None, true)?;
-    let intent = (vec![UserIntent::Test(pkg)], directive).into();
+    let test_cmd: TestLikeSubcommand<'_> = cmd.into();
+    let intent = (vec![test_cmd.package_intent(pkg)], directive).into();
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         compile_config,
         user_log,
@@ -607,7 +605,6 @@ fn run_test_in_single_file_rr(
         cli.dry_run,
     )?;
 
-    let test_cmd: TestLikeSubcommand<'_> = cmd.into();
     run_test_workflow(
         cli,
         &test_cmd,
@@ -615,6 +612,7 @@ fn run_test_in_single_file_rr(
         target_dir,
         false,
         vec![(build_meta, build_graph, filter)],
+        lock,
         output,
     )
 }
@@ -690,6 +688,16 @@ impl<'a> From<&'a BenchSubcommand> for TestLikeSubcommand<'a> {
             patch_file: &None,
             include_skipped: false,
             filter: &None,
+        }
+    }
+}
+
+impl TestLikeSubcommand<'_> {
+    fn package_intent(&self, package: PackageId) -> UserIntent {
+        if self.outline {
+            UserIntent::TestOutline(package)
+        } else {
+            UserIntent::Test(package)
         }
     }
 }
@@ -985,10 +993,6 @@ fn run_test_rr(
     output: &CommandOutput,
 ) -> Result<i32, anyhow::Error> {
     let resolve_output = sync_and_resolve_test_or_bench_project(cli, cmd, dirs, output.user_log())?;
-    let _lock;
-    if !cli.dry_run {
-        _lock = lock_directory(&dirs.target_dir, output.user_log())?;
-    }
     run_test_or_bench_from_resolved(
         cli,
         cmd,
@@ -1002,7 +1006,8 @@ fn run_test_rr(
 
 /// Plans, builds, and runs tests from resolved project data.
 ///
-/// The caller must hold the target-directory lock for a non-dry-run command.
+/// Holds the target-directory lock through planning and the initial build,
+/// then releases it before executing tests or benchmarks.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn run_test_or_bench_from_resolved(
     cli: &UniversalFlags,
@@ -1020,6 +1025,11 @@ pub(crate) fn run_test_or_bench_from_resolved(
         mooncake_bin_dir,
         ..
     } = dirs;
+    let lock = if cli.dry_run {
+        None
+    } else {
+        Some(lock_directory(target_dir, user_log)?)
+    };
     info!(run_mode = ?cmd.run_mode, update = cmd.update, build_only = cmd.build_only, "starting rupes-recta test run");
     let planned_runs = if selected_target_backends.is_empty() {
         plan_test_or_bench_rr_from_resolved_all(
@@ -1058,6 +1068,7 @@ pub(crate) fn run_test_or_bench_from_resolved(
         target_dir,
         display_backend_hint,
         planned_runs,
+        lock,
         output,
     )
 }
@@ -1066,8 +1077,12 @@ pub(crate) fn run_test_or_bench_from_resolved(
 ///
 /// Project and standalone plans share this initial build barrier. Each mode
 /// handles the whole invocation, including any snapshot-update rebuilds.
-/// The caller holds the target-directory lock throughout a non-dry-run workflow.
+/// Normal builds transfer the target-directory lock acquired before planning.
+/// Outline and build-only read their generated metadata under the same lock;
+/// test execution and profiling release it after the initial build.
+/// Dry-run planning acquires its own lock only when it executes prebuild scripts.
 #[instrument(level = Level::DEBUG, skip_all)]
+#[allow(clippy::too_many_arguments)]
 fn run_test_workflow(
     cli: &UniversalFlags,
     cmd: &TestLikeSubcommand<'_>,
@@ -1075,6 +1090,7 @@ fn run_test_workflow(
     target_dir: &Path,
     display_backend_hint: bool,
     planned_runs: Vec<(rr_build::BuildMeta, rr_build::BuildInput, TestFilter)>,
+    lock: Option<std::fs::File>,
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
     let user_log = output.user_log();
@@ -1143,6 +1159,9 @@ fn run_test_workflow(
         )?;
         return Ok(0);
     }
+    // n2 has closed the shared database. Test execution must not block checks
+    // or other builds that use this target directory.
+    drop(lock);
     if cmd.profile {
         return profile::profile_tests(
             cli,
@@ -1169,7 +1188,8 @@ fn run_test_workflow(
 
 /// Runs already-built tests or benchmarks and reports their accumulated results.
 /// With `--update`, promotes snapshots and rebuilds before each filtered rerun.
-/// The caller must hold the target-directory lock throughout this operation.
+/// Each promotion and rebuild holds the target-directory lock, but test
+/// execution and reporting do not. Callers must not retain an outer lock.
 #[instrument(level = Level::DEBUG, skip_all)]
 #[allow(clippy::too_many_arguments)]
 fn run_tests_with_updates(
@@ -1212,6 +1232,10 @@ fn run_tests_with_updates(
             if !cmd.update {
                 break;
             }
+
+            // Promotion changes build inputs. Keep it and the partial rebuild
+            // under one lock, then release it before the next test run.
+            let lock = lock_directory(target_dir, user_log)?;
 
             // Only the latest run can request another promotion. Keep results
             // for tests outside the rerun filter in the final report.
@@ -1271,6 +1295,7 @@ fn run_tests_with_updates(
                     Ok(())
                 }),
             )?;
+            drop(lock);
             if !result.successful() {
                 exit_code = exit_code.max(result.return_code_for_success());
                 continue 'backends;
@@ -1566,7 +1591,7 @@ fn calc_user_intent_from_packages(
         let intents: Vec<_> = backend_affected_packages
             .iter()
             .copied()
-            .map(UserIntent::Test)
+            .map(|package| cmd.package_intent(package))
             .collect();
         debug!(intent_count = intents.len(), "generated default intents");
         return Ok(intents.into());
@@ -1583,7 +1608,9 @@ fn calc_user_intent_from_packages(
             package_count = pkgs.len(),
             "building intents from filtered targets"
         );
-        pkgs.into_iter().map(UserIntent::Test).collect::<Vec<_>>()
+        pkgs.into_iter()
+            .map(|package| cmd.package_intent(package))
+            .collect::<Vec<_>>()
     } else {
         vec![]
     };
@@ -1643,7 +1670,7 @@ fn package_names(
         .collect()
 }
 
-fn test_intents_from_filter(filter: &TestFilter) -> Vec<UserIntent> {
+fn test_intents_from_filter(filter: &TestFilter, cmd: &TestLikeSubcommand<'_>) -> Vec<UserIntent> {
     let Some(filt) = filter.filter.as_ref() else {
         return vec![];
     };
@@ -1654,7 +1681,10 @@ fn test_intents_from_filter(filter: &TestFilter) -> Vec<UserIntent> {
             packages.push(target.package);
         }
     }
-    packages.into_iter().map(UserIntent::Test).collect()
+    packages
+        .into_iter()
+        .map(|package| cmd.package_intent(package))
+        .collect()
 }
 
 fn has_explicit_test_selector(cmd: &TestLikeSubcommand<'_>) -> bool {

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -612,20 +612,38 @@ pub(crate) fn collect_test_outline(
     include_skipped: bool,
     bench: bool,
 ) -> anyhow::Result<Vec<TestOutlineEntry>> {
-    let executables = gather_tests(build_meta);
-    debug!(count = executables.len(), "collecting test outline entries");
+    // Outline plans request metadata without executables. Collect it directly
+    // rather than requiring the executable/metadata pairs used for test runs.
+    let mut metadata = build_meta
+        .artifacts
+        .iter()
+        .filter_map(|(artifact, paths)| match artifact {
+            ArtifactKey::GeneratedTestMetadata {
+                package,
+                target_kind,
+            } => Some((
+                package.build_target(*target_kind),
+                paths
+                    .first()
+                    .expect("test metadata should resolve to one path"),
+            )),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    metadata.sort_by_key(|(_, path)| *path);
+    debug!(count = metadata.len(), "collecting test outline entries");
     let mut entries = Vec::new();
 
-    for test in executables {
-        let (included, file_filt) = filter.check_package(test.target);
+    for (target, path) in metadata {
+        let (included, file_filt) = filter.check_package(target);
         if !included {
             continue;
         }
 
-        let meta_bytes = std::fs::read(test.meta)
-            .with_context(|| format!("Failed to read test metadata at {}", test.meta.display()))?;
+        let meta_bytes = std::fs::read(path)
+            .with_context(|| format!("Failed to read test metadata at {}", path.display()))?;
         let meta: MooncGenTestInfo = serde_json_lenient::from_slice(&meta_bytes)
-            .with_context(|| format!("Failed to parse test metadata at {}", test.meta.display()))?;
+            .with_context(|| format!("Failed to parse test metadata at {}", path.display()))?;
 
         let mut file_ranges = vec![];
         apply_filter(
@@ -653,7 +671,7 @@ pub(crate) fn collect_test_outline(
         let pkgname = build_meta
             .resolve_output
             .pkg_dirs
-            .get_package(test.target.package)
+            .get_package(target.package)
             .fqn
             .to_string();
         for (file, tests) in tests_by_file {

--- a/crates/moon/tests/test_cases/test_outline/mod.rs
+++ b/crates/moon/tests/test_cases/test_outline/mod.rs
@@ -1,4 +1,4 @@
-use crate::{TestDir, get_stdout, util::check};
+use crate::{TestDir, get_stdout, moon_cmd, util::check};
 use expect_test::expect;
 
 fn normalize_outline(output: String) -> String {
@@ -31,4 +31,73 @@ fn test_outline() {
 1. username/outline/lib hello.mbt:9 index=2 name="beta"
 "#]],
     );
+}
+
+#[test]
+fn outline_skips_native_compilation() {
+    let dir = TestDir::new_empty();
+    std::fs::write(dir.join("moon.mod.json"), r#"{"name":"test/outline"}"#).unwrap();
+    std::fs::write(dir.join("moon.pkg.json"), r#"{"native-stub":["broken.c"]}"#).unwrap();
+    std::fs::write(
+        dir.join("broken.c"),
+        "#error outline must not compile C stubs\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("test.mbt"),
+        "test \"alpha\" { inspect(1, content=\"1\") }\n",
+    )
+    .unwrap();
+
+    moon_cmd(&dir)
+        .args(["test", "--outline", "--target", "native", "--quiet"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+   1. test/outline test.mbt:1 index=0 name="alpha"
+
+"#]]);
+
+    // Metadata generation may also emit the driver source, but it must not
+    // compile MoonBit packages or produce native code and link artifacts.
+    for entry in walkdir::WalkDir::new(dir.join("_build")) {
+        let entry = entry.unwrap();
+        assert!(
+            !matches!(
+                entry
+                    .path()
+                    .extension()
+                    .and_then(|extension| extension.to_str()),
+                Some("core" | "mi" | "c" | "o" | "obj" | "exe")
+            ),
+            "outline produced a compiled artifact: {}",
+            entry.path().display()
+        );
+    }
+}
+
+#[test]
+fn standalone_outline_only_needs_test_metadata() {
+    let dir = TestDir::new_empty();
+    std::fs::write(
+        dir.join("script.mbtx"),
+        "test \"alpha\" { missing_function() }\n",
+    )
+    .unwrap();
+
+    moon_cmd(&dir)
+        .args([
+            "test",
+            "script.mbtx",
+            "--outline",
+            "--target",
+            "js",
+            "--quiet",
+        ])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+   1. moon/test/single script.mbtx:1 index=0 name="alpha"
+
+"#]]);
 }

--- a/crates/moon/tests/test_lock_lifetime.rs
+++ b/crates/moon/tests/test_lock_lifetime.rs
@@ -1,0 +1,120 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::{fs, path::Path};
+
+// Run check synchronously inside the MoonBit test. If the outer command still
+// holds the build lock, check times out and the MoonBit assertion fails.
+const CHECK: &str = r#"
+extern "js" fn check() -> Int =
+  #| () => require("node:child_process").spawnSync(
+  #|   process.env.MOON_TEST_MOON,
+  #|   ["--target-dir", process.env.MOON_TEST_TARGET_DIR,
+  #|    "check", process.env.MOON_TEST_CHECK_PATH, "--target", "js", "--quiet"],
+  #|   { stdio: "inherit", timeout: 30000 }
+  #| ).status ?? -1
+"#;
+
+fn moon(root: &Path) -> snapbox::cmd::Command {
+    let target = root.join("custom build");
+    snapbox::cmd::Command::new(snapbox::cargo_bin!("moon"))
+        .current_dir(root)
+        .env("MOON_TOOLCHAIN_ROOT", moonutil::toolchain::toolchain_root())
+        .env("MOON_DEP_CACHE", "off")
+        .env("MOON_TEST_MOON", snapbox::cargo_bin!("moon"))
+        .env("MOON_TEST_TARGET_DIR", &target)
+        .env("MOON_TEST_CHECK_PATH", ".")
+        .arg("--target-dir")
+        .arg(target)
+}
+
+#[test]
+fn test_and_bench_allow_check_during_execution() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("moon.mod.json"),
+        r#"{"name":"test/lock","preferred-target":"js"}"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("moon.pkg.json"),
+        r#"{"import":["moonbitlang/core/bench"]}"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("test.mbt"),
+        format!(
+            r#"{CHECK}
+test {{ assert_eq(check(), 0) }}
+test "bench" (b : @bench.T) {{ assert_eq(check(), 0); b.bench(fn() {{ () }}) }}
+"#
+        ),
+    )
+    .unwrap();
+
+    for command in ["test", "bench"] {
+        moon(root).arg(command).assert().success();
+    }
+}
+
+#[test]
+fn standalone_test_allows_check_during_execution() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("script.mbtx"),
+        format!("{CHECK}\ntest {{ assert_eq(check(), 0) }}\n"),
+    )
+    .unwrap();
+    moon(dir.path())
+        .env("MOON_TEST_CHECK_PATH", "script.mbtx")
+        .args(["test", "script.mbtx", "--target", "js"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_update_allows_check_on_each_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("moon.mod.json"), r#"{"name":"test/lock"}"#).unwrap();
+    fs::write(root.join("moon.pkg.json"), "{}").unwrap();
+    fs::write(
+        root.join("test.mbt"),
+        format!(
+            r#"{CHECK}
+test {{ assert_eq(check(), 0); inspect(1, content="0") }}
+"#
+        ),
+    )
+    .unwrap();
+    moon(root)
+        .args(["test", "--target", "js", "--update"])
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read_to_string(root.join("test.mbt")).unwrap(),
+        format!(
+            r#"{CHECK}
+test {{ assert_eq(check(), 0); inspect(1, content=(
+  #|1
+)) }}
+"#
+        )
+    );
+}

--- a/crates/moonbuild-rupes-recta/src/intent.rs
+++ b/crates/moonbuild-rupes-recta/src/intent.rs
@@ -45,6 +45,8 @@ pub enum UserIntent {
     Prove(PackageId),
     /// Test a package (emit test driver and build for all test targets).
     Test(PackageId),
+    /// List a package's tests (generate test metadata without building executables).
+    TestOutline(PackageId),
     /// Bench a package (same artifact set as Test; runtime behavior differs elsewhere).
     Bench(PackageId),
     /// Bundle all non-virtual packages in a module.
@@ -168,7 +170,7 @@ impl UserIntent {
                     target_kind: TargetKind::Source,
                 });
             }
-            UserIntent::Test(pkg) | UserIntent::Bench(pkg) => {
+            UserIntent::Test(pkg) | UserIntent::TestOutline(pkg) | UserIntent::Bench(pkg) => {
                 let pkg_info = resolved.pkg_dirs.get_package(pkg);
                 if !pkg_info.has_implementation() {
                     // Pure virtual package: we can't do anything
@@ -184,7 +186,7 @@ impl UserIntent {
                         target_backend,
                     );
 
-                    // Request execution and test metadata per target; skip
+                    // Use the same target selection for execution and outline; skip
                     // Whitebox if no *_wbtest.mbt is declared.
                     for &k in TargetKind::all_tests() {
                         if k == TargetKind::WhiteboxTest
@@ -204,20 +206,24 @@ impl UserIntent {
                         {
                             continue;
                         }
-                        out.push(ArtifactKey::Executable {
-                            package: pkg,
-                            target_kind: k,
-                        });
-                        out.push(ArtifactKey::GeneratedTestDriver {
-                            package: pkg,
-                            target_kind: k,
-                        });
+                        if !matches!(self, UserIntent::TestOutline(_)) {
+                            out.push(ArtifactKey::Executable {
+                                package: pkg,
+                                target_kind: k,
+                            });
+                            out.push(ArtifactKey::GeneratedTestDriver {
+                                package: pkg,
+                                target_kind: k,
+                            });
+                        }
                         out.push(ArtifactKey::GeneratedTestMetadata {
                             package: pkg,
                             target_kind: k,
                         });
                     }
-                    if target_backend == TargetBackend::Js {
+                    if target_backend == TargetBackend::Js
+                        && !matches!(self, UserIntent::TestOutline(_))
+                    {
                         out.push(ArtifactKey::NodeTestPackageConfig { package: pkg });
                     }
                 }

--- a/docs/dev/reference/tests.md
+++ b/docs/dev/reference/tests.md
@@ -15,12 +15,23 @@ for the whole invocation. Build-only emits one combined artifact listing across
 backends. Ordinary test and benchmark execution goes through
 `run_tests_with_updates`, which owns the execution, snapshot promotion, rebuild,
 and rerun loop, together with the final report.
-The command entry points hold the target-directory lock from before planning
-until the entire workflow finishes, including test execution and promotion.
+The target-directory lock is held from before planning through the initial
+build, including prebuild scripts and generated metadata. It is released before
+test execution or profiling. Outline and build-only read and print their
+generated metadata under the same lock. Test and benchmark execution and reporting
+do not block another `moon check` or build. All commands still share the target
+directory's n2 database; build execution remains serialized. Releasing the lock
+does not reserve the test artifacts against replacement by another build.
 
-1. The CLI resolves packages and test targets (via Rupes Recta build planning). Each
-   selected `BuildTarget` produces two artifacts: the executable (`make_executable`) and
-   a JSON metadata file (`generate_test_info`).
+`--outline` plans only generated test metadata, using the same test-target
+selection as an ordinary test invocation. Required prebuild steps still run,
+and metadata generation may also emit test-driver source, but MoonBit and native
+compilation and executable linking are skipped. Outline collection reads the
+metadata directly and does not require executable artifacts.
+
+1. For test execution, the CLI resolves packages and test targets (via Rupes
+   Recta build planning). Each selected `BuildTarget` produces two artifacts: the
+   executable (`make_executable`) and a JSON metadata file (`generate_test_info`).
 2. When an invocation selects more than one Target Backend, each backend is
    planned and lowered independently, then their Execution Plans are composed
    into one n2 graph. The entire graph must build successfully before any test
@@ -64,9 +75,10 @@ snapshot tests. The CLI enforces a single target backend in this mode (updating
 multiple backends at once would diverge binary outputs) and disallows patch
 files.
 
-1. After each run, `perform_promotion` scans that run's
-   `ReplaceableTestResults`. For every `ExpectTestFailed` or `SnapshotTestFailed`
-   case it:
+1. After each run, the workflow reacquires the target-directory lock before
+   promotion and holds it through any partial rebuild. `perform_promotion` scans
+   that run's `ReplaceableTestResults`. For every `ExpectTestFailed` or
+   `SnapshotTestFailed` case it:
 
    - Records the owning `BuildTarget`, file path, and index in a `PackageFilter`.
    - Batches the failure payloads and forwards them to `apply_expect` /
@@ -78,9 +90,9 @@ files.
    - Rebuilds just the affected test artifacts by cloning the saved build graph
      and calling `execute_build_partial` with the target nodes returned from the
      filter.
-   - Re-runs the filtered subset of tests by wrapping the `PackageFilter` inside a
-     temporary `TestFilter`. Only the promoted cases are executed, which keeps
-     reruns fast even for large suites.
+   - Releases the lock before re-running the filtered subset of tests, with the
+     `PackageFilter` wrapped inside a temporary `TestFilter`. Only the promoted
+     cases are executed, which keeps reruns fast even for large suites.
    - Merges the rerun results back into the main `ReplaceableTestResults` so the
      final summary reflects the updated outcomes.
 


### PR DESCRIPTION
Long-running tests and benchmarks currently hold the target-directory lock, making a quick `moon check`, including checks used by `moon ide doc`, wait for test execution to finish.

Release the lock after the initial build and before test execution or profiling. Snapshot updates reacquire it for promotion and partial rebuilding, then release it before each rerun. Planning, prebuild steps, and writes to the shared build database remain serialized; outline and build-only collection retain the lock while reading generated metadata.

`moon test --outline` now requests only test metadata and its required prebuild steps, skipping package compilation, native compilation, and linking. It uses the existing test-target selection and reads metadata directly, without requiring executable artifacts.

Regression tests cover concurrent checks during test, benchmark, standalone, and update execution, plus outline generation with invalid native stubs and test bodies that cannot be type-checked. The first commit adds the regressions; the second implements the changes and updates the execution-flow documentation. Build execution continues to share the same database, leaving parallel builds as separate work.
