### PR TITLE
refactor(moonrun): clarify worker cancellation ownership and outcomes

### DIFF
--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -29,10 +29,14 @@ Windows positioned I/O is cancellable and has the corresponding region.
 
 The Worker handle and its thread share one allocation containing scheduling
 and cancellation state. Each executing Job borrows that state through a stack
-context with an immutable Job ID. A private scope guard registers the context
-in thread-local storage and restores the previous binding before the context
-leaves the stack. `with_cancellable_region` borrows this context only for its
-synchronous closure, so syscall regions cannot escape or retain a Worker.
+context with an immutable `WorkerCompletionId`. A private scope guard borrows
+the context, registers it in thread-local storage, and clears that binding
+before the context leaves the stack. A Worker executes one Job at a time, and
+each syscall region must end before another begins; assertions reject nesting
+without replacing the active context or clearing its region mark.
+`with_cancellable_region` borrows this context only for its synchronous closure,
+so syscall regions cannot escape or retain a Worker. The closure and cancellation
+check return errors through the same `AsyncHostResult`.
 The region mark remains atomic for access by the interrupting signal handler;
 cancellation status and retry mode remain atomic for access by the requesting
 thread. No reference counts are changed when entering or leaving a region.
@@ -72,6 +76,14 @@ waits for the completion notification to retire the Worker, as native does.
 Older guests have no retry check and would treat retry notifications as
 completed Jobs. Both imports take one `i64` Worker handle and return an `i32`
 status; the historical import retains its original return values.
+Internally, `CancellationOutcome` names these scheduler actions and is encoded
+only when returning through the guest import. The separate internal state
+`CANCELLATION_ACKNOWLEDGED` does not mean the Job has finished.
+
+Switching a Job from `cancel_worker_with_retry` to legacy `cancel_worker`
+disables further retry publication, but cannot retract a pending retry or one
+already being published by a signal handler. A guest that has enabled retries
+must still check completion before accepting those notifications.
 
 The completion check describes the Worker's current Job; the import takes no
 Job ID. Async's `EventLoop::handle_completed_job` accepts the previous completion

--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -27,6 +27,16 @@ Accordingly, `pread` and `pwrite` have no cancellable region, as in native
 `thread_pool.c`.
 Windows positioned I/O is cancellable and has the corresponding region.
 
+The Worker handle and its thread share one allocation containing scheduling
+and cancellation state. Each executing Job borrows that state through a stack
+context with an immutable Job ID. A private scope guard registers the context
+in thread-local storage and restores the previous binding before the context
+leaves the stack. `with_cancellable_region` borrows this context only for its
+synchronous closure, so syscall regions cannot escape or retain a Worker.
+The region mark remains atomic for access by the interrupting signal handler;
+cancellation status and retry mode remain atomic for access by the requesting
+thread. No reference counts are changed when entering or leaving a region.
+
 Native writes its shared Job result before setting `Waiting`. Moonrun preserves
 that order using its existing result channel: send the host-owned Job, set
 `Waiting`, then notify. This transfers Rust ownership within the same process;

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -6492,7 +6492,7 @@ mod tests {
                 move |worker_job| {
                     started_tx.send(()).unwrap();
                     release_rx.recv().unwrap();
-                    assert!(thread_pool::CancellableRegion::enter().is_err());
+                    assert!(thread_pool::with_cancellable_region(|| ()).is_err());
                     ack_tx.send(()).unwrap();
                     finish_rx.recv().unwrap();
                     worker_job.job.set_ret(73);

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -3860,7 +3860,7 @@ impl AsyncHost {
 
     pub(crate) fn cancel_worker(&self, worker_handle: u64) -> AsyncHostResult<i32> {
         let worker_key = self.handles.borrow().worker(worker_handle)?;
-        self.workers.cancel(worker_key)
+        Ok(self.workers.cancel(worker_key)?.as_i32())
     }
 
     pub(crate) fn cancel_worker_with_retry(&self, worker_handle: u64) -> AsyncHostResult<i32> {
@@ -3872,10 +3872,10 @@ impl AsyncHost {
         )?;
         // Waiting is published only after the worker sends its owned result.
         // Reacquire it even when this was originally a retry notification.
-        if status == thread_pool::WORKER_JOB_FINISHED {
+        if status == thread_pool::CancellationOutcome::JobFinished {
             self.restore_completed_worker_jobs();
         }
-        Ok(status)
+        Ok(status.as_i32())
     }
 
     #[cfg(unix)]
@@ -6492,7 +6492,7 @@ mod tests {
                 move |worker_job| {
                     started_tx.send(()).unwrap();
                     release_rx.recv().unwrap();
-                    assert!(thread_pool::with_cancellable_region(|| ()).is_err());
+                    assert!(thread_pool::with_cancellable_region(|| Ok(())).is_err());
                     ack_tx.send(()).unwrap();
                     finish_rx.recv().unwrap();
                     worker_job.job.set_ret(73);

--- a/crates/moonrun/src/async_host/workers.rs
+++ b/crates/moonrun/src/async_host/workers.rs
@@ -29,7 +29,8 @@ use slotmap::SecondaryMap;
 
 use super::{AsyncHostError, AsyncHostResult, HandleKey};
 use crate::async_sys::internal::event_loop::thread_pool::{
-    self, HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WorkerCompletionId,
+    self, CancellationOutcome, HostWorkerHandle, HostWorkerJob, HostWorkerJobResult,
+    WorkerCompletionId,
 };
 
 pub(super) struct InstanceWorkers {
@@ -96,10 +97,10 @@ impl InstanceWorkers {
         Ok(thread_pool::worker_enter_idle(worker))
     }
 
-    pub(super) fn cancel(&self, worker: HandleKey) -> AsyncHostResult<i32> {
+    pub(super) fn cancel(&self, worker: HandleKey) -> AsyncHostResult<CancellationOutcome> {
         let workers = self.workers.borrow();
         let worker = workers.get(worker).ok_or(AsyncHostError::Badf)?;
-        cancel_host_worker(worker)
+        thread_pool::cancel_worker(worker)
     }
 
     pub(super) fn cancel_with_retry(
@@ -108,7 +109,7 @@ impl InstanceWorkers {
         #[cfg(unix)] notifier: std::sync::Arc<
             crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier,
         >,
-    ) -> AsyncHostResult<i32> {
+    ) -> AsyncHostResult<CancellationOutcome> {
         let workers = self.workers.borrow();
         let worker = workers.get(worker).ok_or(AsyncHostError::Badf)?;
         thread_pool::cancel_worker_with_retry(
@@ -124,7 +125,7 @@ impl InstanceWorkers {
             .borrow_mut()
             .remove(worker)
             .ok_or(AsyncHostError::Badf)?;
-        let _ = cancel_host_worker(&worker);
+        let _ = thread_pool::cancel_worker(&worker);
         Ok(thread_pool::free_worker(worker))
     }
 
@@ -161,7 +162,7 @@ impl InstanceWorkers {
         // native free_worker; neither join nor repeated signals can forcibly
         // stop noncooperative computation.
         for (_, worker) in &workers {
-            let _ = cancel_host_worker(worker);
+            let _ = thread_pool::cancel_worker(worker);
         }
         workers
             .into_iter()
@@ -182,10 +183,6 @@ impl Drop for InstanceWorkers {
 pub(super) struct StoppedWorker {
     pub(super) key: HandleKey,
     pub(super) unrun_job: Option<HostWorkerJob>,
-}
-
-fn cancel_host_worker(worker: &HostWorkerHandle) -> AsyncHostResult<i32> {
-    thread_pool::cancel_worker(worker)
 }
 
 #[cfg(test)]
@@ -244,14 +241,14 @@ mod tests {
             .unwrap();
 
         worker_started.recv_timeout(Duration::from_secs(1)).unwrap();
-        assert_eq!(workers.cancel(worker), Ok(0));
+        assert_eq!(workers.cancel(worker), Ok(CancellationOutcome::RetryLater));
         proceed.send(()).unwrap();
 
         let first_completion = completion.recv_timeout(Duration::from_secs(1));
         if first_completion.is_err() {
             // Release the old implementation so a failing assertion does not
             // leave its Worker blocked in read(2).
-            assert_eq!(workers.cancel(worker), Ok(0));
+            assert_eq!(workers.cancel(worker), Ok(CancellationOutcome::RetryLater));
             completion.recv_timeout(Duration::from_secs(1)).unwrap();
         }
         let completion_id = first_completion.expect("the first cancellation was lost");

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
@@ -262,6 +262,48 @@ mod tests {
     use super::*;
 
     #[test]
+    fn cancellation_scope_is_cleared_during_unwind() {
+        let worker = Arc::new(WorkerCancellation::new(1));
+        let result = std::panic::catch_unwind(|| {
+            let _current = CurrentWorker::enter(Arc::clone(&worker));
+            let _region = CancellableRegion::enter().unwrap();
+            panic!("unwind through the active cancellation region");
+        });
+        assert!(result.is_err());
+        assert!(current_worker().is_null());
+        assert!(!worker.inside.load(Ordering::SeqCst));
+        assert_eq!(worker.state.load(Ordering::SeqCst), RUNNING);
+        assert!(CancellableRegion::enter().is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retry_notifications_follow_the_current_job_when_a_worker_is_reused() {
+        use std::os::fd::{FromRawFd, OwnedFd};
+
+        let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
+        let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
+        let notifier = Arc::new(notifier);
+        let worker = Arc::new(WorkerCancellation::new(0));
+        let _current = CurrentWorker::enter(Arc::clone(&worker));
+        for id in [i32::MIN, i32::MAX] {
+            worker.start(id);
+            let region = CancellableRegion::enter().unwrap();
+            worker.enable_retry(&notifier);
+            assert!(worker.request());
+            cancellation_signal_handler(libc::SIGUSR2);
+            drop(region);
+
+            let mut bytes = [0; 4];
+            assert_eq!(notifier.fetch(&mut bytes).unwrap(), 4);
+            assert_eq!(i32::from_ne_bytes(bytes), id);
+            cancellation_signal_handler(libc::SIGUSR2);
+            assert_eq!(notifier.fetch(&mut bytes).unwrap(), 0);
+            worker.finish();
+        }
+    }
+
+    #[test]
     fn cancellation_before_syscall_is_acknowledged_and_reset_for_next_job() {
         let worker = Arc::new(WorkerCancellation::new(1));
         let current = CurrentWorker::enter(Arc::clone(&worker));

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
@@ -23,8 +23,10 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::event_loop::{
     CancellationRetryNotifier, ThreadPoolCompletionNotifier,
 };
+#[cfg(unix)]
+use std::sync::Arc;
 use std::sync::{
-    Arc, OnceLock,
+    OnceLock,
     atomic::{AtomicBool, AtomicI32, Ordering},
 };
 
@@ -35,10 +37,9 @@ const WAITING: i32 = 3;
 
 #[derive(Debug)]
 pub(super) struct WorkerCancellation {
+    // Status of the assigned Job. The Worker's scheduling mutex separately
+    // tracks whether execution has begun and which native operation to cancel.
     state: AtomicI32,
-    inside: AtomicBool,
-    #[cfg(unix)]
-    job_id: AtomicI32,
     #[cfg(unix)]
     retry_enabled: AtomicBool,
     #[cfg(unix)]
@@ -46,14 +47,9 @@ pub(super) struct WorkerCancellation {
 }
 
 impl WorkerCancellation {
-    pub(super) fn new(id: i32) -> Self {
-        #[cfg(windows)]
-        let _ = id;
+    pub(super) fn new() -> Self {
         Self {
             state: AtomicI32::new(RUNNING),
-            inside: AtomicBool::new(false),
-            #[cfg(unix)]
-            job_id: AtomicI32::new(id),
             #[cfg(unix)]
             retry_enabled: AtomicBool::new(false),
             #[cfg(unix)]
@@ -61,24 +57,34 @@ impl WorkerCancellation {
         }
     }
 
-    pub(super) fn start(&self, id: i32) {
-        #[cfg(windows)]
-        let _ = id;
-        self.inside.store(false, Ordering::SeqCst);
+    pub(super) fn start(&self) {
         #[cfg(unix)]
         {
             self.retry_enabled.store(false, Ordering::SeqCst);
             if let Some(notifier) = self.notifier.get() {
                 notifier.reset();
             }
-            self.job_id.store(id, Ordering::SeqCst);
         }
         self.state.store(RUNNING, Ordering::SeqCst);
     }
 
     pub(super) fn finish(&self) {
-        self.inside.store(false, Ordering::SeqCst);
         self.state.store(WAITING, Ordering::SeqCst);
+    }
+
+    /// Borrow the Worker's cancellation state for this Job's execution only.
+    /// The TLS binding and all syscall regions end before the result is published.
+    pub(super) fn run<T>(&self, id: i32, operation: impl FnOnce() -> T) -> T {
+        #[cfg(windows)]
+        let _ = id;
+        let job = CurrentJob {
+            cancellation: self,
+            #[cfg(unix)]
+            id,
+            inside: AtomicBool::new(false),
+        };
+        let _binding = CurrentJobBinding::enter(&job);
+        operation()
     }
 
     pub(super) fn is_waiting(&self) -> bool {
@@ -114,23 +120,39 @@ impl WorkerCancellation {
 }
 
 #[cfg(unix)]
-static WORKER_KEY: OnceLock<libc::pthread_key_t> = OnceLock::new();
+static CURRENT_JOB_KEY: OnceLock<libc::pthread_key_t> = OnceLock::new();
 #[cfg(windows)]
-static WORKER_KEY: OnceLock<u32> = OnceLock::new();
+static CURRENT_JOB_KEY: OnceLock<u32> = OnceLock::new();
 
-pub(super) struct CurrentWorker(Arc<WorkerCancellation>);
+// This context lives on the executing thread's stack. Only cancellation state
+// is shared with the requesting thread; the Job ID stays immutable. The region
+// mark is atomic because the signal handler can interrupt this same thread.
+struct CurrentJob<'a> {
+    cancellation: &'a WorkerCancellation,
+    #[cfg(unix)]
+    id: i32,
+    inside: AtomicBool,
+}
 
-impl CurrentWorker {
-    pub(super) fn enter(worker: Arc<WorkerCancellation>) -> Self {
+// This private guard cannot escape WorkerCancellation::run. Its borrow keeps
+// the stack context in place until TLS is restored, including during unwinding.
+struct CurrentJobBinding<'a> {
+    _job: &'a CurrentJob<'a>,
+    previous: *const CurrentJob<'a>,
+}
+
+impl<'a> CurrentJobBinding<'a> {
+    fn enter(job: &'a CurrentJob<'a>) -> Self {
+        let previous = current_job();
         #[cfg(unix)]
         {
-            let key = WORKER_KEY.get_or_init(|| {
+            let key = CURRENT_JOB_KEY.get_or_init(|| {
                 let mut key = 0;
                 assert_eq!(unsafe { libc::pthread_key_create(&mut key, None) }, 0);
                 key
             });
             assert_eq!(
-                unsafe { libc::pthread_setspecific(*key, Arc::as_ptr(&worker).cast()) },
+                unsafe { libc::pthread_setspecific(*key, std::ptr::from_ref(job).cast()) },
                 0
             );
         }
@@ -139,37 +161,42 @@ impl CurrentWorker {
             use windows_sys::Win32::System::Threading::{
                 TLS_OUT_OF_INDEXES, TlsAlloc, TlsSetValue,
             };
-            let key = WORKER_KEY.get_or_init(|| {
+            let key = CURRENT_JOB_KEY.get_or_init(|| {
                 let key = unsafe { TlsAlloc() };
                 assert_ne!(key, TLS_OUT_OF_INDEXES);
                 key
             });
-            assert_ne!(unsafe { TlsSetValue(*key, Arc::as_ptr(&worker).cast()) }, 0);
+            assert_ne!(
+                unsafe { TlsSetValue(*key, std::ptr::from_ref(job).cast()) },
+                0
+            );
         }
-        Self(worker)
+        Self {
+            _job: job,
+            previous,
+        }
     }
 }
 
-impl Drop for CurrentWorker {
+impl Drop for CurrentJobBinding<'_> {
     fn drop(&mut self) {
-        // Clear the TLS pointer before releasing the Arc that keeps it alive.
+        // Restore TLS before the borrowed context can leave the stack.
         #[cfg(unix)]
         unsafe {
-            libc::pthread_setspecific(*WORKER_KEY.get().unwrap(), std::ptr::null());
+            libc::pthread_setspecific(*CURRENT_JOB_KEY.get().unwrap(), self.previous.cast());
         }
         #[cfg(windows)]
         unsafe {
             windows_sys::Win32::System::Threading::TlsSetValue(
-                *WORKER_KEY.get().unwrap(),
-                std::ptr::null(),
+                *CURRENT_JOB_KEY.get().unwrap(),
+                self.previous.cast(),
             );
         }
-        let _ = &self.0;
     }
 }
 
-fn current_worker() -> *const WorkerCancellation {
-    let Some(key) = WORKER_KEY.get() else {
+fn current_job<'a>() -> *const CurrentJob<'a> {
+    let Some(key) = CURRENT_JOB_KEY.get() else {
         return std::ptr::null();
     };
     #[cfg(unix)]
@@ -182,52 +209,40 @@ fn current_worker() -> *const WorkerCancellation {
     }
 }
 
-/// Own the cancellation mark only for one cancellable syscall. Synchronous
-/// callers outside a Worker keep their existing behavior.
-pub(crate) struct CancellableRegion {
-    worker: Option<Arc<WorkerCancellation>>,
-    _same_thread: std::marker::PhantomData<*const ()>,
+struct CancellableRegion<'a> {
+    inside: &'a AtomicBool,
+    was_inside: bool,
 }
 
-impl CancellableRegion {
-    pub(crate) fn enter() -> AsyncHostResult<Self> {
-        let raw = current_worker();
-        let worker = if raw.is_null() {
-            None
-        } else {
-            // CurrentWorker owns a strong reference until this thread leaves
-            // its loop. Incrementing it keeps the region valid independently.
-            Some(unsafe {
-                Arc::increment_strong_count(raw);
-                Arc::from_raw(raw)
-            })
-        };
-        if let Some(worker) = &worker {
-            worker.inside.store(true, Ordering::SeqCst);
-            if worker.state.load(Ordering::SeqCst) == CANCELLING {
-                worker.state.store(CANCELLED, Ordering::SeqCst);
-                worker.inside.store(false, Ordering::SeqCst);
-                #[cfg(unix)]
-                return Err(AsyncHostError::Native(libc::EINTR));
-                #[cfg(windows)]
-                return Err(AsyncHostError::Native(
-                    windows_sys::Win32::Foundation::ERROR_OPERATION_ABORTED as i32,
-                ));
-            }
-        }
-        Ok(Self {
-            worker,
-            _same_thread: std::marker::PhantomData,
-        })
-    }
-}
-
-impl Drop for CancellableRegion {
+impl Drop for CancellableRegion<'_> {
     fn drop(&mut self) {
-        if let Some(worker) = &self.worker {
-            worker.inside.store(false, Ordering::SeqCst);
-        }
+        self.inside.store(self.was_inside, Ordering::SeqCst);
     }
+}
+
+/// Run a cancellable syscall, or skip it if the Worker acknowledges cancellation.
+/// Synchronous callers outside a Worker execute the operation normally.
+pub(crate) fn with_cancellable_region<T>(operation: impl FnOnce() -> T) -> AsyncHostResult<T> {
+    // A non-null pointer is installed only by WorkerCancellation::run, whose
+    // borrowed context outlives this synchronous call. The region guard stays
+    // private so neither it nor this reference can escape through the result.
+    let Some(job) = (unsafe { current_job().as_ref() }) else {
+        return Ok(operation());
+    };
+    let _region = CancellableRegion {
+        inside: &job.inside,
+        was_inside: job.inside.swap(true, Ordering::SeqCst),
+    };
+    if job.cancellation.state.load(Ordering::SeqCst) == CANCELLING {
+        job.cancellation.state.store(CANCELLED, Ordering::SeqCst);
+        #[cfg(unix)]
+        return Err(AsyncHostError::Native(libc::EINTR));
+        #[cfg(windows)]
+        return Err(AsyncHostError::Native(
+            windows_sys::Win32::Foundation::ERROR_OPERATION_ABORTED as i32,
+        ));
+    }
+    Ok(operation())
 }
 
 #[cfg(unix)]
@@ -240,17 +255,19 @@ pub(super) extern "C" fn cancellation_signal_handler(_: i32) {
     #[cfg(target_os = "macos")]
     let errno = unsafe { libc::__error() };
     let saved_errno = unsafe { *errno };
-    let worker = current_worker();
-    if let Some(worker) = unsafe { worker.as_ref() }
-        && worker.state.load(Ordering::SeqCst) == CANCELLING
-        && worker.inside.load(Ordering::SeqCst)
-        && worker.retry_enabled()
-        && let Some(notifier) = worker.notifier.get()
+    // This handler runs on the interrupted thread, while the installed Job
+    // context is still borrowed by WorkerCancellation::run.
+    let job = current_job();
+    if let Some(job) = unsafe { job.as_ref() }
+        && job.cancellation.state.load(Ordering::SeqCst) == CANCELLING
+        && job.inside.load(Ordering::SeqCst)
+        && job.cancellation.retry_enabled()
+        && let Some(notifier) = job.cancellation.notifier.get()
     {
         // The signal may arrive before the syscall begins. Record a retry in
         // this Worker's preallocated slot; publication never locks or waits
         // for the guest to drain the notification source.
-        notifier.notify_from_signal(worker.job_id.load(Ordering::SeqCst));
+        notifier.notify_from_signal(job.id);
     }
     unsafe {
         *errno = saved_errno;
@@ -263,17 +280,17 @@ mod tests {
 
     #[test]
     fn cancellation_scope_is_cleared_during_unwind() {
-        let worker = Arc::new(WorkerCancellation::new(1));
+        let worker = WorkerCancellation::new();
         let result = std::panic::catch_unwind(|| {
-            let _current = CurrentWorker::enter(Arc::clone(&worker));
-            let _region = CancellableRegion::enter().unwrap();
-            panic!("unwind through the active cancellation region");
+            worker.run(1, || {
+                with_cancellable_region(|| panic!("unwind through the active cancellation region"))
+                    .unwrap();
+            });
         });
         assert!(result.is_err());
-        assert!(current_worker().is_null());
-        assert!(!worker.inside.load(Ordering::SeqCst));
+        assert!(current_job().is_null());
         assert_eq!(worker.state.load(Ordering::SeqCst), RUNNING);
-        assert!(CancellableRegion::enter().is_ok());
+        assert!(with_cancellable_region(|| ()).is_ok());
     }
 
     #[cfg(unix)]
@@ -284,15 +301,17 @@ mod tests {
         let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
         let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
         let notifier = Arc::new(notifier);
-        let worker = Arc::new(WorkerCancellation::new(0));
-        let _current = CurrentWorker::enter(Arc::clone(&worker));
+        let worker = WorkerCancellation::new();
         for id in [i32::MIN, i32::MAX] {
-            worker.start(id);
-            let region = CancellableRegion::enter().unwrap();
-            worker.enable_retry(&notifier);
-            assert!(worker.request());
-            cancellation_signal_handler(libc::SIGUSR2);
-            drop(region);
+            worker.start();
+            worker.run(id, || {
+                with_cancellable_region(|| {
+                    worker.enable_retry(&notifier);
+                    assert!(worker.request());
+                    cancellation_signal_handler(libc::SIGUSR2);
+                })
+                .unwrap();
+            });
 
             let mut bytes = [0; 4];
             assert_eq!(notifier.fetch(&mut bytes).unwrap(), 4);
@@ -305,27 +324,51 @@ mod tests {
 
     #[test]
     fn cancellation_before_syscall_is_acknowledged_and_reset_for_next_job() {
-        let worker = Arc::new(WorkerCancellation::new(1));
-        let current = CurrentWorker::enter(Arc::clone(&worker));
+        let worker = WorkerCancellation::new();
         assert!(worker.request());
-        assert!(CancellableRegion::enter().is_err());
+        worker.run(1, || {
+            assert!(with_cancellable_region(|| panic!("cancelled syscall executed")).is_err());
+        });
         assert!(
             !worker.request(),
             "acknowledgement stops further cancellation attempts"
         );
-        assert!(!worker.inside.load(Ordering::SeqCst));
 
         worker.finish();
-        worker.start(2);
-        let region = CancellableRegion::enter().unwrap();
-        assert!(worker.inside.load(Ordering::SeqCst));
-        drop(region);
-        assert!(!worker.inside.load(Ordering::SeqCst));
-        drop(current);
-        assert!(current_worker().is_null());
+        worker.start();
+        assert_eq!(worker.run(2, || with_cancellable_region(|| 42)), Ok(42));
+        assert!(current_job().is_null());
         assert!(
-            CancellableRegion::enter().is_ok(),
+            with_cancellable_region(|| ()).is_ok(),
             "synchronous callers have no worker cancellation state"
         );
+    }
+
+    #[test]
+    fn nested_job_and_region_scopes_restore_the_outer_context() {
+        let outer = WorkerCancellation::new();
+        let inner = WorkerCancellation::new();
+        outer.run(1, || {
+            with_cancellable_region(|| {
+                let outer_job = current_job();
+                let result = std::panic::catch_unwind(|| {
+                    inner.run(2, || {
+                        assert_ne!(current_job(), outer_job);
+                        with_cancellable_region(|| panic!("unwind through the inner job")).unwrap();
+                    });
+                });
+                assert!(result.is_err());
+                assert_eq!(current_job(), outer_job);
+
+                let result = std::panic::catch_unwind(|| {
+                    with_cancellable_region(|| panic!("unwind through the inner region")).unwrap();
+                });
+                assert!(result.is_err());
+                assert!(unsafe { (*outer_job).inside.load(Ordering::SeqCst) });
+            })
+            .unwrap();
+            assert!(!unsafe { (*current_job()).inside.load(Ordering::SeqCst) });
+        });
+        assert!(current_job().is_null());
     }
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/cancellation.rs
@@ -18,6 +18,7 @@
 
 //! Native-shaped cancellation acknowledgement around potentially blocking calls.
 
+use super::worker::WorkerCompletionId;
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 #[cfg(unix)]
 use crate::async_sys::internal::event_loop::{
@@ -32,15 +33,21 @@ use std::sync::{
 
 const RUNNING: i32 = 0;
 const CANCELLING: i32 = 1;
-const CANCELLED: i32 = 2;
+const CANCELLATION_ACKNOWLEDGED: i32 = 2;
 const WAITING: i32 = 3;
 
 #[derive(Debug)]
 pub(super) struct WorkerCancellation {
-    // Status of the assigned Job. The Worker's scheduling mutex separately
-    // tracks whether execution has begun and which native operation to cancel.
+    // The requesting thread marks Cancelling; the executing thread acknowledges
+    // it and publishes Waiting only after the result. Assignment resets Running.
+    // SeqCst orders these transitions with the region mark and cancellation
+    // check; the later check-to-syscall window still requires signal retries.
+    // The scheduling mutex separately tracks execution and its native target.
     state: AtomicI32,
     #[cfg(unix)]
+    // Cancellation calls and Job assignment write this; the signal handler reads
+    // it. The notifier is initialized before enabling retries. Disabling them
+    // does not retract a retry already published or being published by a handler.
     retry_enabled: AtomicBool,
     #[cfg(unix)]
     notifier: OnceLock<CancellationRetryNotifier>,
@@ -74,13 +81,17 @@ impl WorkerCancellation {
 
     /// Borrow the Worker's cancellation state for this Job's execution only.
     /// The TLS binding and all syscall regions end before the result is published.
-    pub(super) fn run<T>(&self, id: i32, operation: impl FnOnce() -> T) -> T {
+    pub(super) fn run<T>(
+        &self,
+        completion_id: WorkerCompletionId,
+        operation: impl FnOnce() -> T,
+    ) -> T {
         #[cfg(windows)]
-        let _ = id;
+        let _ = completion_id;
         let job = CurrentJob {
             cancellation: self,
             #[cfg(unix)]
-            id,
+            completion_id,
             inside: AtomicBool::new(false),
         };
         let _binding = CurrentJobBinding::enter(&job);
@@ -125,25 +136,29 @@ static CURRENT_JOB_KEY: OnceLock<libc::pthread_key_t> = OnceLock::new();
 static CURRENT_JOB_KEY: OnceLock<u32> = OnceLock::new();
 
 // This context lives on the executing thread's stack. Only cancellation state
-// is shared with the requesting thread; the Job ID stays immutable. The region
-// mark is atomic because the signal handler can interrupt this same thread.
+// is shared with the requesting thread; the completion ID stays immutable.
 struct CurrentJob<'a> {
     cancellation: &'a WorkerCancellation,
     #[cfg(unix)]
-    id: i32,
+    completion_id: WorkerCompletionId,
+    // The executing thread marks syscall entry/exit; its Unix signal handler
+    // reads the mark. Keep it atomic even though both run on the same thread.
     inside: AtomicBool,
 }
 
 // This private guard cannot escape WorkerCancellation::run. Its borrow keeps
-// the stack context in place until TLS is restored, including during unwinding.
+// the stack context in place until TLS is cleared, including during unwinding.
 struct CurrentJobBinding<'a> {
+    // Lifetime-only borrow: TLS holds a raw pointer and cannot express this.
     _job: &'a CurrentJob<'a>,
-    previous: *const CurrentJob<'a>,
 }
 
 impl<'a> CurrentJobBinding<'a> {
     fn enter(job: &'a CurrentJob<'a>) -> Self {
-        let previous = current_job();
+        assert!(
+            current_job().is_null(),
+            "a Worker cannot execute nested Jobs"
+        );
         #[cfg(unix)]
         {
             let key = CURRENT_JOB_KEY.get_or_init(|| {
@@ -171,25 +186,22 @@ impl<'a> CurrentJobBinding<'a> {
                 0
             );
         }
-        Self {
-            _job: job,
-            previous,
-        }
+        Self { _job: job }
     }
 }
 
 impl Drop for CurrentJobBinding<'_> {
     fn drop(&mut self) {
-        // Restore TLS before the borrowed context can leave the stack.
+        // Clear TLS before the borrowed context can leave the stack.
         #[cfg(unix)]
         unsafe {
-            libc::pthread_setspecific(*CURRENT_JOB_KEY.get().unwrap(), self.previous.cast());
+            libc::pthread_setspecific(*CURRENT_JOB_KEY.get().unwrap(), std::ptr::null());
         }
         #[cfg(windows)]
         unsafe {
             windows_sys::Win32::System::Threading::TlsSetValue(
                 *CURRENT_JOB_KEY.get().unwrap(),
-                self.previous.cast(),
+                std::ptr::null(),
             );
         }
     }
@@ -211,30 +223,37 @@ fn current_job<'a>() -> *const CurrentJob<'a> {
 
 struct CancellableRegion<'a> {
     inside: &'a AtomicBool,
-    was_inside: bool,
 }
 
 impl Drop for CancellableRegion<'_> {
     fn drop(&mut self) {
-        self.inside.store(self.was_inside, Ordering::SeqCst);
+        self.inside.store(false, Ordering::SeqCst);
     }
 }
 
 /// Run a cancellable syscall, or skip it if the Worker acknowledges cancellation.
 /// Synchronous callers outside a Worker execute the operation normally.
-pub(crate) fn with_cancellable_region<T>(operation: impl FnOnce() -> T) -> AsyncHostResult<T> {
+/// An operation must not enter another cancellable region while this one is active.
+pub(crate) fn with_cancellable_region<T>(
+    operation: impl FnOnce() -> AsyncHostResult<T>,
+) -> AsyncHostResult<T> {
     // A non-null pointer is installed only by WorkerCancellation::run, whose
     // borrowed context outlives this synchronous call. The region guard stays
     // private so neither it nor this reference can escape through the result.
     let Some(job) = (unsafe { current_job().as_ref() }) else {
-        return Ok(operation());
+        return operation();
     };
+    assert!(
+        !job.inside.swap(true, Ordering::SeqCst),
+        "cancellable syscall regions cannot nest"
+    );
     let _region = CancellableRegion {
         inside: &job.inside,
-        was_inside: job.inside.swap(true, Ordering::SeqCst),
     };
     if job.cancellation.state.load(Ordering::SeqCst) == CANCELLING {
-        job.cancellation.state.store(CANCELLED, Ordering::SeqCst);
+        job.cancellation
+            .state
+            .store(CANCELLATION_ACKNOWLEDGED, Ordering::SeqCst);
         #[cfg(unix)]
         return Err(AsyncHostError::Native(libc::EINTR));
         #[cfg(windows)]
@@ -242,7 +261,7 @@ pub(crate) fn with_cancellable_region<T>(operation: impl FnOnce() -> T) -> Async
             windows_sys::Win32::Foundation::ERROR_OPERATION_ABORTED as i32,
         ));
     }
-    Ok(operation())
+    operation()
 }
 
 #[cfg(unix)]
@@ -267,7 +286,7 @@ pub(super) extern "C" fn cancellation_signal_handler(_: i32) {
         // The signal may arrive before the syscall begins. Record a retry in
         // this Worker's preallocated slot; publication never locks or waits
         // for the guest to drain the notification source.
-        notifier.notify_from_signal(job.id);
+        notifier.notify_from_signal(job.completion_id.as_i32());
     }
     unsafe {
         *errno = saved_errno;
@@ -282,15 +301,18 @@ mod tests {
     fn cancellation_scope_is_cleared_during_unwind() {
         let worker = WorkerCancellation::new();
         let result = std::panic::catch_unwind(|| {
-            worker.run(1, || {
-                with_cancellable_region(|| panic!("unwind through the active cancellation region"))
-                    .unwrap();
+            worker.run(WorkerCompletionId::from_abi(1), || {
+                with_cancellable_region::<()>(|| {
+                    panic!("unwind through the active cancellation region")
+                })
+                .unwrap();
             });
         });
         assert!(result.is_err());
         assert!(current_job().is_null());
-        assert_eq!(worker.state.load(Ordering::SeqCst), RUNNING);
-        assert!(with_cancellable_region(|| ()).is_ok());
+        // Outside a Job, cancellation on this Worker cannot affect the call.
+        assert!(worker.request());
+        assert!(with_cancellable_region(|| Ok(())).is_ok());
     }
 
     #[cfg(unix)]
@@ -304,11 +326,12 @@ mod tests {
         let worker = WorkerCancellation::new();
         for id in [i32::MIN, i32::MAX] {
             worker.start();
-            worker.run(id, || {
+            worker.run(WorkerCompletionId::from_abi(id), || {
                 with_cancellable_region(|| {
                     worker.enable_retry(&notifier);
                     assert!(worker.request());
                     cancellation_signal_handler(libc::SIGUSR2);
+                    Ok(())
                 })
                 .unwrap();
             });
@@ -326,8 +349,10 @@ mod tests {
     fn cancellation_before_syscall_is_acknowledged_and_reset_for_next_job() {
         let worker = WorkerCancellation::new();
         assert!(worker.request());
-        worker.run(1, || {
-            assert!(with_cancellable_region(|| panic!("cancelled syscall executed")).is_err());
+        worker.run(WorkerCompletionId::from_abi(1), || {
+            assert!(
+                with_cancellable_region::<()>(|| panic!("cancelled syscall executed")).is_err()
+            );
         });
         assert!(
             !worker.request(),
@@ -336,39 +361,71 @@ mod tests {
 
         worker.finish();
         worker.start();
-        assert_eq!(worker.run(2, || with_cancellable_region(|| 42)), Ok(42));
+        assert_eq!(
+            worker.run(WorkerCompletionId::from_abi(2), || with_cancellable_region(
+                || Ok(42)
+            )),
+            Ok(42)
+        );
         assert!(current_job().is_null());
         assert!(
-            with_cancellable_region(|| ()).is_ok(),
+            with_cancellable_region(|| Ok(())).is_ok(),
             "synchronous callers have no worker cancellation state"
         );
     }
 
     #[test]
-    fn nested_job_and_region_scopes_restore_the_outer_context() {
-        let outer = WorkerCancellation::new();
-        let inner = WorkerCancellation::new();
-        outer.run(1, || {
-            with_cancellable_region(|| {
-                let outer_job = current_job();
-                let result = std::panic::catch_unwind(|| {
-                    inner.run(2, || {
-                        assert_ne!(current_job(), outer_job);
-                        with_cancellable_region(|| panic!("unwind through the inner job")).unwrap();
-                    });
-                });
-                assert!(result.is_err());
-                assert_eq!(current_job(), outer_job);
-
-                let result = std::panic::catch_unwind(|| {
-                    with_cancellable_region(|| panic!("unwind through the inner region")).unwrap();
-                });
-                assert!(result.is_err());
-                assert!(unsafe { (*outer_job).inside.load(Ordering::SeqCst) });
-            })
-            .unwrap();
-            assert!(!unsafe { (*current_job()).inside.load(Ordering::SeqCst) });
+    fn nested_job_scope_is_rejected_without_losing_the_current_job() {
+        let worker = WorkerCancellation::new();
+        worker.run(WorkerCompletionId::from_abi(1), || {
+            let result = std::panic::catch_unwind(|| {
+                worker.run(WorkerCompletionId::from_abi(2), || ());
+            });
+            assert!(result.is_err());
+            assert!(worker.request());
+            assert!(
+                with_cancellable_region::<()>(|| panic!("current Job binding was lost")).is_err()
+            );
         });
         assert!(current_job().is_null());
+    }
+
+    #[test]
+    fn nested_region_is_rejected_without_clearing_the_active_region() {
+        let worker = WorkerCancellation::new();
+        worker.run(WorkerCompletionId::from_abi(1), || {
+            with_cancellable_region(|| {
+                // Both attempts must fail: rejecting the first must leave
+                // the outer region marked until its own scope exits.
+                for _ in 0..2 {
+                    let result = std::panic::catch_unwind(|| with_cancellable_region(|| Ok(())));
+                    assert!(result.is_err());
+                }
+                Ok(())
+            })
+            .unwrap();
+            assert_eq!(with_cancellable_region(|| Ok(42)), Ok(42));
+        });
+    }
+
+    #[test]
+    fn operation_errors_leave_the_region_and_cancellation_skips_the_operation() {
+        let worker = WorkerCancellation::new();
+        worker.run(WorkerCompletionId::from_abi(1), || {
+            assert_eq!(
+                with_cancellable_region(|| Err::<(), _>(AsyncHostError::Fault)),
+                Err(AsyncHostError::Fault)
+            );
+            assert_eq!(with_cancellable_region(|| Ok(42)), Ok(42));
+            assert!(worker.request());
+            assert!(
+                with_cancellable_region::<()>(|| panic!("cancelled operation must not run"))
+                    .is_err()
+            );
+        });
+        assert_eq!(
+            with_cancellable_region(|| Err::<(), _>(AsyncHostError::Fault)),
+            Err(AsyncHostError::Fault)
+        );
     }
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -23,7 +23,7 @@ mod sleep;
 mod types;
 mod worker;
 
-pub(crate) use cancellation::CancellableRegion;
+pub(crate) use cancellation::with_cancellable_region;
 #[cfg(any(feature = "v8", feature = "wasmtime", test))]
 pub(crate) use jobs::make_sleep_job;
 #[cfg(any(feature = "v8", feature = "wasmtime"))]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -30,13 +30,12 @@ pub(crate) use jobs::make_sleep_job;
 pub(crate) use jobs::{errno_is_cancelled, get_platform};
 pub(crate) use jobs::{job_get_err, job_get_ret, make_failed_job};
 pub(crate) use runner::run_host_job;
-pub(crate) use types::{HostHandle, Job, JobPayload, ResourceTable};
+pub(crate) use types::{CancellationOutcome, HostHandle, Job, JobPayload, ResourceTable};
 #[cfg(unix)]
 pub(crate) use types::{JobCancellation, JobCancellationOverride};
 pub(crate) use worker::{
-    HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WORKER_JOB_FINISHED, WorkerCompletionId,
-    cancel_worker, cancel_worker_with_retry, free_worker, spawn_worker, wake_worker,
-    worker_enter_idle,
+    HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WorkerCompletionId, cancel_worker,
+    cancel_worker_with_retry, free_worker, spawn_worker, wake_worker, worker_enter_idle,
 };
 
 #[cfg(test)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -30,13 +30,37 @@ use std::sync::Arc;
 pub(crate) type ResourceHandle = u64;
 pub(crate) type HostHandle = ResourceHandle;
 
+/// What the guest scheduler should do after requesting Worker cancellation.
+/// These outcomes are distinct from the Worker's internal cancellation state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CancellationOutcome {
+    /// The scheduler must request cancellation again after a timer.
+    RetryLater,
+    /// Wait for a notification, which may itself request a cancellation retry.
+    NeedWait,
+    /// The Job result has been published; acknowledgement alone is insufficient.
+    JobFinished,
+}
+
+impl CancellationOutcome {
+    // Native's 0/1 outcomes, extended by the combined Wasm cancellation import
+    // with the finished case from worker_check_cancellation_retry.
+    pub(crate) fn as_i32(self) -> i32 {
+        match self {
+            Self::RetryLater => 0,
+            Self::NeedWait => 1,
+            Self::JobFinished => 2,
+        }
+    }
+}
+
 /// A Job-specific replacement for the platform's default Worker cancellation.
 ///
 /// This is the Rust equivalent of native `struct job::cancel_handler`: most
 /// Jobs do not provide one and are cancelled through the Worker thread.
 #[cfg(unix)]
 pub(crate) trait JobCancellationOverride: std::fmt::Debug + Send + Sync {
-    fn cancel(&self) -> AsyncHostResult<i32>;
+    fn cancel(&self) -> AsyncHostResult<CancellationOutcome>;
 }
 
 #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -31,7 +31,7 @@ use std::os::unix::thread::JoinHandleExt;
 use super::Job;
 #[cfg(unix)]
 use super::JobCancellation;
-use super::cancellation::{CurrentWorker, WorkerCancellation};
+use super::cancellation::WorkerCancellation;
 #[cfg(unix)]
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 
@@ -115,7 +115,7 @@ struct HostWorkerState {
 
 #[derive(Debug)]
 struct HostWorkerShared {
-    cancellation: Arc<WorkerCancellation>,
+    cancellation: WorkerCancellation,
     state: Mutex<HostWorkerState>,
     wakeup: Condvar,
 }
@@ -171,7 +171,7 @@ impl HostWorkerHandle {
         let init_cancel = init_job.job.cancellation_override();
 
         let shared = Arc::new(HostWorkerShared {
-            cancellation: Arc::new(WorkerCancellation::new(init_job.completion_id.as_i32())),
+            cancellation: WorkerCancellation::new(),
             state: Mutex::new(HostWorkerState {
                 job: Some(init_job),
                 #[cfg(unix)]
@@ -188,7 +188,6 @@ impl HostWorkerHandle {
         #[cfg(unix)]
         let parent_signal_mask = crate::async_sys::signal::block_worker_thread_signals().ok();
         let thread = std::thread::spawn(move || {
-            let _current = CurrentWorker::enter(Arc::clone(&worker_shared.cancellation));
             #[cfg(unix)]
             {
                 let _ = crate::async_sys::signal::unblock_worker_cancellation_signal();
@@ -219,7 +218,9 @@ impl HostWorkerHandle {
                 let Some(mut job) = job else {
                     break;
                 };
-                run_job(&mut job);
+                worker_shared
+                    .cancellation
+                    .run(job.completion_id.as_i32(), || run_job(&mut job));
                 let completion_id = job.completion_id;
                 complete_job(HostWorkerJobResult {
                     job_key: job.job_key,
@@ -244,13 +245,11 @@ impl HostWorkerHandle {
                     // cancellation-retry event must never expose an unfinished
                     // payload as a completed Job.
                     worker_shared.cancellation.finish();
-                    if let Some(next) = &state.job {
+                    if state.job.is_some() {
                         // An early wake from a direct caller advances cancellation
                         // to the next Job. Async's guest accepts the previous
                         // completion before waking us again.
-                        worker_shared
-                            .cancellation
-                            .start(next.completion_id.as_i32());
+                        worker_shared.cancellation.start();
                     }
                     state.terminating
                 };
@@ -289,13 +288,13 @@ impl HostWorkerHandle {
                 .as_ref()
                 .and_then(|job| job.job.cancellation_override());
         }
-        if let Some(job) = &state.job {
+        if state.job.is_some() {
             #[cfg(unix)]
             let idle = !state.running;
             #[cfg(windows)]
             let idle = matches!(state.running_cancel, RunningCancellation::Idle);
             if idle {
-                self.shared.cancellation.start(job.completion_id.as_i32());
+                self.shared.cancellation.start();
             }
         }
         self.shared.wakeup.notify_one();
@@ -539,7 +538,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn cancellation_and_completion_do_not_block_on_a_full_pipe() {
-        use super::super::CancellableRegion;
+        use super::super::with_cancellable_region;
         use std::os::fd::{FromRawFd, OwnedFd};
         use std::time::{Duration, Instant};
 
@@ -554,13 +553,14 @@ mod tests {
         let worker = super::spawn_worker(
             make_worker_job(23, 29),
             move |job| {
-                let region = CancellableRegion::enter().unwrap();
-                started_tx.send(()).unwrap();
-                release_rx.recv().unwrap();
-                // Exercise the real handler synchronously as well as the
-                // cancellation request below, without depending on delivery timing.
-                assert_eq!(unsafe { libc::raise(libc::SIGUSR2) }, 0);
-                drop(region);
+                with_cancellable_region(|| {
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    // Exercise the real handler synchronously as well as the
+                    // cancellation request below, without depending on delivery timing.
+                    assert_eq!(unsafe { libc::raise(libc::SIGUSR2) }, 0);
+                })
+                .unwrap();
                 job.job.set_ret(73);
             },
             move |job| result_tx.send(job.job.ret()).unwrap(),
@@ -603,7 +603,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn cancellation_retry_interrupts_a_syscall_started_after_the_first_signal() {
-        use super::super::CancellableRegion;
+        use super::super::with_cancellable_region;
         use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
         use std::time::{Duration, Instant};
 
@@ -620,13 +620,15 @@ mod tests {
         let worker = super::spawn_worker(
             make_worker_job(17, 19),
             move |job| {
-                let region = CancellableRegion::enter().unwrap();
-                started_tx.send(()).unwrap();
-                release_rx.recv().unwrap();
-                let mut byte = 0u8;
-                let ret = unsafe { libc::read(read.as_raw_fd(), (&raw mut byte).cast(), 1) };
-                let errno = std::io::Error::last_os_error().raw_os_error().unwrap();
-                drop(region);
+                let (ret, errno) = with_cancellable_region(|| {
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    let mut byte = 0u8;
+                    let ret = unsafe { libc::read(read.as_raw_fd(), (&raw mut byte).cast(), 1) };
+                    let errno = std::io::Error::last_os_error().raw_os_error().unwrap();
+                    (ret, errno)
+                })
+                .unwrap();
                 job.job.set_ret(if ret < 0 {
                     i64::from(-errno)
                 } else {
@@ -695,7 +697,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn legacy_cancellation_does_not_publish_retry_events() {
-        use super::super::CancellableRegion;
+        use super::super::with_cancellable_region;
         use std::os::fd::{FromRawFd, OwnedFd};
         use std::time::Duration;
 
@@ -710,11 +712,12 @@ mod tests {
         let worker = super::spawn_worker(
             make_worker_job(23, 29),
             move |_| {
-                let region = CancellableRegion::enter().unwrap();
-                started_tx.send(()).unwrap();
-                release_rx.recv().unwrap();
-                drop(region);
-                assert!(CancellableRegion::enter().is_err());
+                with_cancellable_region(|| {
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                })
+                .unwrap();
+                assert!(with_cancellable_region(|| ()).is_err());
                 ack_tx.send(()).unwrap();
                 finish_rx.recv().unwrap();
             },
@@ -979,7 +982,7 @@ mod tests {
         assert!(queued_job.cancel.is_some());
         let worker = HostWorkerHandle {
             shared: Arc::new(HostWorkerShared {
-                cancellation: Arc::new(WorkerCancellation::new(3)),
+                cancellation: WorkerCancellation::new(),
                 state: Mutex::new(HostWorkerState {
                     job: Some(queued_job),
                     running_cancel: RunningCancellation::Idle,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -28,16 +28,12 @@ use crate::resource::ResourceRef;
 #[cfg(unix)]
 use std::os::unix::thread::JoinHandleExt;
 
-use super::Job;
 #[cfg(unix)]
 use super::JobCancellation;
 use super::cancellation::WorkerCancellation;
+use super::{CancellationOutcome, Job};
 #[cfg(unix)]
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
-
-// The combined Wasm cancellation ABI extends native's 0 (retry later) and
-// 1 (keep waiting) with the finished case from worker_check_cancellation_retry.
-pub(crate) const WORKER_JOB_FINISHED: i32 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WorkerCompletionId(i32);
@@ -220,7 +216,7 @@ impl HostWorkerHandle {
                 };
                 worker_shared
                     .cancellation
-                    .run(job.completion_id.as_i32(), || run_job(&mut job));
+                    .run(job.completion_id, || run_job(&mut job));
                 let completion_id = job.completion_id;
                 complete_job(HostWorkerJobResult {
                     job_key: job.job_key,
@@ -327,7 +323,7 @@ impl HostWorkerHandle {
         }
     }
 
-    pub(crate) fn cancel(&self) -> AsyncHostResult<i32> {
+    pub(crate) fn cancel(&self) -> AsyncHostResult<CancellationOutcome> {
         #[cfg(unix)]
         self.shared.cancellation.disable_retry();
         self.cancel_inner()
@@ -339,18 +335,18 @@ impl HostWorkerHandle {
     pub(crate) fn cancel_with_retry(
         &self,
         #[cfg(unix)] notifier: Arc<ThreadPoolCompletionNotifier>,
-    ) -> AsyncHostResult<i32> {
+    ) -> AsyncHostResult<CancellationOutcome> {
         if self.shared.cancellation.is_waiting() {
-            return Ok(WORKER_JOB_FINISHED);
+            return Ok(CancellationOutcome::JobFinished);
         }
         #[cfg(unix)]
         self.shared.cancellation.enable_retry(&notifier);
         self.cancel_inner()
     }
 
-    fn cancel_inner(&self) -> AsyncHostResult<i32> {
+    fn cancel_inner(&self) -> AsyncHostResult<CancellationOutcome> {
         if !self.shared.cancellation.request() {
-            return Ok(1);
+            return Ok(CancellationOutcome::NeedWait);
         }
         #[cfg(unix)]
         {
@@ -367,7 +363,11 @@ impl HostWorkerHandle {
             unsafe {
                 libc::pthread_kill(thread.as_pthread_t(), libc::SIGUSR2);
             }
-            Ok(i32::from(self.shared.cancellation.retry_enabled()))
+            Ok(if self.shared.cancellation.retry_enabled() {
+                CancellationOutcome::NeedWait
+            } else {
+                CancellationOutcome::RetryLater
+            })
         }
 
         #[cfg(windows)]
@@ -378,17 +378,17 @@ impl HostWorkerHandle {
 
             if let WorkerCancellationTarget::Resource(cancel) = self.cancellation_target() {
                 crate::process::cancel_wait(&cancel)?;
-                return Ok(1);
+                return Ok(CancellationOutcome::NeedWait);
             }
             let Some(thread) = &self.thread else {
                 return Err(AsyncHostError::Badf);
             };
             if unsafe { CancelSynchronousIo(thread.as_raw_handle()) } != 0 {
-                Ok(1)
+                Ok(CancellationOutcome::NeedWait)
             } else {
                 let error = unsafe { GetLastError() };
                 if error == ERROR_NOT_FOUND {
-                    Ok(0)
+                    Ok(CancellationOutcome::RetryLater)
                 } else {
                     Err(AsyncHostError::Native(error as i32))
                 }
@@ -449,7 +449,7 @@ ported_fns! {
     pub(crate) fn cancel_worker_with_retry(
         worker: &HostWorkerHandle,
         #[cfg(unix)] notifier: Arc<ThreadPoolCompletionNotifier>,
-    ) -> AsyncHostResult<i32> {
+    ) -> AsyncHostResult<CancellationOutcome> {
         worker.cancel_with_retry(#[cfg(unix)] notifier)
     }
 
@@ -462,7 +462,7 @@ ported_fns! {
     }
 }
 
-pub(crate) fn cancel_worker(worker: &HostWorkerHandle) -> AsyncHostResult<i32> {
+pub(crate) fn cancel_worker(worker: &HostWorkerHandle) -> AsyncHostResult<CancellationOutcome> {
     worker.cancel()
 }
 
@@ -524,7 +524,7 @@ mod tests {
             (WorkerCompletionId::from_abi(7), make_job_key(11))
         );
         assert_eq!(completion_receiver.recv().unwrap(), make_job_key(11));
-        assert_eq!(cancel_worker(&worker), Ok(1));
+        assert_eq!(cancel_worker(&worker), Ok(CancellationOutcome::NeedWait));
 
         assert!(wake_worker(&worker, make_worker_job(13, 17)).is_none());
         assert_eq!(
@@ -559,6 +559,7 @@ mod tests {
                     // Exercise the real handler synchronously as well as the
                     // cancellation request below, without depending on delivery timing.
                     assert_eq!(unsafe { libc::raise(libc::SIGUSR2) }, 0);
+                    Ok(())
                 })
                 .unwrap();
                 job.job.set_ret(73);
@@ -569,7 +570,7 @@ mod tests {
         started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         assert_eq!(
             cancel_worker_with_retry(&worker, Arc::clone(&notifier)),
-            Ok(1)
+            Ok(CancellationOutcome::NeedWait)
         );
         release_tx.send(()).unwrap();
         let (joined_tx, joined_rx) = mpsc::channel();
@@ -626,7 +627,7 @@ mod tests {
                     let mut byte = 0u8;
                     let ret = unsafe { libc::read(read.as_raw_fd(), (&raw mut byte).cast(), 1) };
                     let errno = std::io::Error::last_os_error().raw_os_error().unwrap();
-                    (ret, errno)
+                    Ok((ret, errno))
                 })
                 .unwrap();
                 job.job.set_ret(if ret < 0 {
@@ -641,7 +642,7 @@ mod tests {
         started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         assert_eq!(
             cancel_worker_with_retry(&worker, Arc::clone(&notifier)),
-            Ok(1)
+            Ok(CancellationOutcome::NeedWait)
         );
 
         let mut poll = libc::pollfd {
@@ -659,7 +660,7 @@ mod tests {
         );
         assert_eq!(
             cancel_worker_with_retry(&worker, Arc::clone(&notifier)),
-            Ok(1)
+            Ok(CancellationOutcome::NeedWait)
         );
         release_tx.send(()).unwrap();
 
@@ -672,7 +673,7 @@ mod tests {
             {
                 assert_eq!(i32::from_ne_bytes(bytes), 17);
                 if cancel_worker_with_retry(&worker, Arc::clone(&notifier)).unwrap()
-                    == WORKER_JOB_FINISHED
+                    == CancellationOutcome::JobFinished
                 {
                     result_at_completion = result_rx.try_recv().ok();
                     finished = true;
@@ -721,6 +722,7 @@ mod tests {
                         assert_eq!(unsafe { libc::raise(libc::SIGUSR2) }, 0);
                         handled_tx.send(()).unwrap();
                     }
+                    Ok(())
                 })
                 .unwrap();
                 finish_rx.recv().unwrap();
@@ -731,12 +733,12 @@ mod tests {
         started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         assert_eq!(
             cancel_worker_with_retry(&worker, Arc::clone(&notifier)),
-            Ok(1)
+            Ok(CancellationOutcome::NeedWait)
         );
         signal_tx.send(()).unwrap();
         handled_rx.recv_timeout(Duration::from_secs(5)).unwrap();
 
-        assert_eq!(cancel_worker(&worker), Ok(0));
+        assert_eq!(cancel_worker(&worker), Ok(CancellationOutcome::RetryLater));
         signal_tx.send(()).unwrap();
         handled_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         let mut bytes = [0; 4];
@@ -771,9 +773,10 @@ mod tests {
                 with_cancellable_region(|| {
                     started_tx.send(()).unwrap();
                     release_rx.recv().unwrap();
+                    Ok(())
                 })
                 .unwrap();
-                assert!(with_cancellable_region(|| ()).is_err());
+                assert!(with_cancellable_region(|| Ok(())).is_err());
                 ack_tx.send(()).unwrap();
                 finish_rx.recv().unwrap();
             },
@@ -781,10 +784,10 @@ mod tests {
             move |id| completion.notify(id.as_i32()).unwrap(),
         );
         started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
-        assert_eq!(cancel_worker(&worker), Ok(0));
+        assert_eq!(cancel_worker(&worker), Ok(CancellationOutcome::RetryLater));
         release_tx.send(()).unwrap();
         ack_rx.recv_timeout(Duration::from_secs(5)).unwrap();
-        assert_eq!(cancel_worker(&worker), Ok(1));
+        assert_eq!(cancel_worker(&worker), Ok(CancellationOutcome::NeedWait));
         let mut bytes = [0u8; 4];
         assert_eq!(notifier.fetch(&mut bytes).unwrap(), 0);
         finish_tx.send(()).unwrap();

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -696,6 +696,62 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn switching_to_legacy_cancellation_preserves_a_published_retry() {
+        use super::super::with_cancellable_region;
+        use std::os::fd::{FromRawFd, OwnedFd};
+        use std::time::Duration;
+
+        let (notifier, recv) = ThreadPoolCompletionNotifier::new().unwrap();
+        let _recv = unsafe { OwnedFd::from_raw_fd(recv) };
+        let notifier = Arc::new(notifier);
+        let completion = Arc::clone(&notifier);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (signal_tx, signal_rx) = mpsc::channel();
+        let (handled_tx, handled_rx) = mpsc::channel();
+        let (finish_tx, finish_rx) = mpsc::channel();
+        let worker = super::spawn_worker(
+            make_worker_job(23, 29),
+            move |_| {
+                with_cancellable_region(|| {
+                    started_tx.send(()).unwrap();
+                    for _ in 0..2 {
+                        signal_rx.recv().unwrap();
+                        // Complete the real handler before acknowledging each
+                        // phase, independently of pthread_kill delivery timing.
+                        assert_eq!(unsafe { libc::raise(libc::SIGUSR2) }, 0);
+                        handled_tx.send(()).unwrap();
+                    }
+                })
+                .unwrap();
+                finish_rx.recv().unwrap();
+            },
+            |_| {},
+            move |id| completion.notify(id.as_i32()).unwrap(),
+        );
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(
+            cancel_worker_with_retry(&worker, Arc::clone(&notifier)),
+            Ok(1)
+        );
+        signal_tx.send(()).unwrap();
+        handled_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+
+        assert_eq!(cancel_worker(&worker), Ok(0));
+        signal_tx.send(()).unwrap();
+        handled_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        let mut bytes = [0; 4];
+        assert_eq!(notifier.fetch(&mut bytes).unwrap(), 4);
+        assert_eq!(i32::from_ne_bytes(bytes), 23);
+        assert_eq!(notifier.fetch(&mut bytes).unwrap(), 0);
+
+        finish_tx.send(()).unwrap();
+        assert!(free_worker(worker).is_none());
+        assert_eq!(notifier.fetch(&mut bytes).unwrap(), 4);
+        assert_eq!(i32::from_ne_bytes(bytes), 23);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn legacy_cancellation_does_not_publish_retry_events() {
         use super::super::with_cancellable_region;
         use std::os::fd::{FromRawFd, OwnedFd};

--- a/crates/moonrun/src/async_sys/signal/unix.rs
+++ b/crates/moonrun/src/async_sys/signal/unix.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex, Weak};
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::event_loop::{
     ThreadPoolCompletionNotifier,
-    thread_pool::{JobCancellation, JobCancellationOverride},
+    thread_pool::{CancellationOutcome, JobCancellation, JobCancellationOverride},
 };
 use crate::async_sys::internal::fd_util::stub as fd_util;
 use crate::run_signal::{SignalReceiver, SignalTargetGuard, signal_mask};
@@ -79,10 +79,10 @@ struct SigwaitCancellation {
 }
 
 impl JobCancellationOverride for SigwaitCancellation {
-    fn cancel(&self) -> AsyncHostResult<i32> {
+    fn cancel(&self) -> AsyncHostResult<CancellationOutcome> {
         let mut state = self.state.lock().map_err(|_| AsyncHostError::Inval)?;
         if state.cancelled {
-            return Ok(0);
+            return Ok(CancellationOutcome::RetryLater);
         }
         state.cancelled = true;
         if let Some(wake) = self.wake.upgrade()
@@ -91,7 +91,7 @@ impl JobCancellationOverride for SigwaitCancellation {
             state.cancelled = false;
             return Err(error);
         }
-        Ok(0)
+        Ok(CancellationOutcome::RetryLater)
     }
 }
 
@@ -429,7 +429,10 @@ mod tests {
             make_sigwait_job(&receiver, &[libc::SIGINT], Arc::clone(&notifier)).unwrap();
 
         assert_eq!(sender.send(libc::SIGINT), Ok(true));
-        assert_eq!(waiter.cancellation_override().cancel(), Ok(0));
+        assert_eq!(
+            waiter.cancellation_override().cancel(),
+            Ok(CancellationOutcome::RetryLater)
+        );
         assert_eq!(sender.send(libc::SIGINT), Ok(false));
         assert_eq!(waiter.run(), Ok(0));
 

--- a/crates/moonrun/src/filesystem/job/runner.rs
+++ b/crates/moonrun/src/filesystem/job/runner.rs
@@ -349,12 +349,14 @@ fn open_raw_native_file(
     };
     let append_flag = if append { libc::O_APPEND } else { 0 };
     let filename = CString::new(filename.into_vec()).map_err(|_| AsyncHostError::Inval)?;
-    let fd = with_cancellable_region(|| unsafe {
-        libc::open(
-            filename.as_ptr(),
-            access_flag | sync_flag | create_flag | append_flag | libc::O_CLOEXEC,
-            mode as libc::c_uint,
-        )
+    let fd = with_cancellable_region(|| {
+        Ok(unsafe {
+            libc::open(
+                filename.as_ptr(),
+                access_flag | sync_flag | create_flag | append_flag | libc::O_CLOEXEC,
+                mode as libc::c_uint,
+            )
+        })
     })?;
     if fd < 0 {
         return Err(last_native_error());
@@ -432,16 +434,18 @@ fn open_raw_native_file(
         .chain(std::iter::once(0))
         .collect::<Vec<_>>();
     let handle: HANDLE = loop {
-        let handle = with_cancellable_region(|| unsafe {
-            CreateFileW(
-                filename.as_ptr(),
-                access_flag,
-                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                std::ptr::null(),
-                create_mode,
-                flags,
-                std::ptr::null_mut(),
-            )
+        let handle = with_cancellable_region(|| {
+            Ok(unsafe {
+                CreateFileW(
+                    filename.as_ptr(),
+                    access_flag,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    std::ptr::null(),
+                    create_mode,
+                    flags,
+                    std::ptr::null_mut(),
+                )
+            })
         })?;
         if handle != INVALID_HANDLE_VALUE {
             break handle;
@@ -452,8 +456,8 @@ fn open_raw_native_file(
         if error != ERROR_PIPE_BUSY as i32 {
             return Err(AsyncHostError::Native(error));
         }
-        let ready = with_cancellable_region(|| unsafe {
-            WaitNamedPipeW(filename.as_ptr(), NMPWAIT_WAIT_FOREVER)
+        let ready = with_cancellable_region(|| {
+            Ok(unsafe { WaitNamedPipeW(filename.as_ptr(), NMPWAIT_WAIT_FOREVER) })
         })?;
         if ready == 0 {
             return Err(last_native_error());
@@ -569,8 +573,8 @@ pub(super) fn handle_is_socket(handle: RawFile) -> bool {
 fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHostResult<usize> {
     let ret = if position < 0 {
         loop {
-            let ret = with_cancellable_region(|| unsafe {
-                libc::read(fd, buf.as_mut_ptr().cast(), buf.len())
+            let ret = with_cancellable_region(|| {
+                Ok(unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) })
             })?;
             if ret >= 0 {
                 break ret;
@@ -586,7 +590,7 @@ fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHos
                 events: libc::POLLIN,
                 revents: 0,
             };
-            let ready = with_cancellable_region(|| unsafe { libc::poll(&mut pfd, 1, -1) })?;
+            let ready = with_cancellable_region(|| Ok(unsafe { libc::poll(&mut pfd, 1, -1) }))?;
             if ready < 0 {
                 break -1;
             }
@@ -610,8 +614,8 @@ fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHos
 fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostResult<usize> {
     let ret = if position < 0 {
         loop {
-            let ret = with_cancellable_region(|| unsafe {
-                libc::write(fd, data.as_ptr().cast(), data.len())
+            let ret = with_cancellable_region(|| {
+                Ok(unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) })
             })?;
             if ret >= 0 {
                 break ret;
@@ -627,7 +631,7 @@ fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostRes
                 events: libc::POLLOUT,
                 revents: 0,
             };
-            let ready = with_cancellable_region(|| unsafe { libc::poll(&mut pfd, 1, -1) })?;
+            let ready = with_cancellable_region(|| Ok(unsafe { libc::poll(&mut pfd, 1, -1) }))?;
             if ready < 0 {
                 break -1;
             }
@@ -767,7 +771,7 @@ fn lock_native_file(fd: RawFile, exclusive: bool) -> AsyncHostResult<()> {
     } else {
         libc::LOCK_SH
     };
-    let result = with_cancellable_region(|| unsafe { libc::flock(fd, operation) })?;
+    let result = with_cancellable_region(|| Ok(unsafe { libc::flock(fd, operation) }))?;
     if result < 0 {
         Err(last_native_error())
     } else {
@@ -998,7 +1002,7 @@ fn read_from_native_file(handle: RawFile, buf: &mut [u8], position: i64) -> Asyn
     } else {
         Some(current_file_pointer(handle)?)
     };
-    let result = with_cancellable_region(|| -> AsyncHostResult<_> {
+    let result = with_cancellable_region(|| {
         Ok(unsafe {
             ReadFile(
                 handle,
@@ -1008,7 +1012,7 @@ fn read_from_native_file(handle: RawFile, buf: &mut [u8], position: i64) -> Asyn
                 overlapped_ptr,
             )
         })
-    })??;
+    })?;
     let result = if result != 0 {
         usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
     } else {
@@ -1064,7 +1068,7 @@ fn write_to_native_file(handle: RawFile, data: &[u8], position: i64) -> AsyncHos
     } else {
         Some(current_file_pointer(handle)?)
     };
-    let result = with_cancellable_region(|| -> AsyncHostResult<_> {
+    let result = with_cancellable_region(|| {
         Ok(unsafe {
             WriteFile(
                 handle,
@@ -1074,7 +1078,7 @@ fn write_to_native_file(handle: RawFile, data: &[u8], position: i64) -> AsyncHos
                 overlapped_ptr,
             )
         })
-    })??;
+    })?;
     let result = if result != 0 {
         usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
     } else {
@@ -1364,8 +1368,9 @@ fn lock_native_file(file: RawFile, exclusive: bool) -> AsyncHostResult<()> {
     } else {
         0
     };
-    let result =
-        with_cancellable_region(|| unsafe { LockFileEx(file, flags, 0, 1, 0, &mut overlapped) })?;
+    let result = with_cancellable_region(|| {
+        Ok(unsafe { LockFileEx(file, flags, 0, 1, 0, &mut overlapped) })
+    })?;
     if result == 0 {
         Err(last_native_error())
     } else {

--- a/crates/moonrun/src/filesystem/job/runner.rs
+++ b/crates/moonrun/src/filesystem/job/runner.rs
@@ -18,7 +18,7 @@
 
 //! Blocking filesystem operations executed by Filesystem Jobs.
 
-use crate::async_sys::internal::event_loop::thread_pool::CancellableRegion;
+use crate::async_sys::internal::event_loop::thread_pool::with_cancellable_region;
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
@@ -349,15 +349,13 @@ fn open_raw_native_file(
     };
     let append_flag = if append { libc::O_APPEND } else { 0 };
     let filename = CString::new(filename.into_vec()).map_err(|_| AsyncHostError::Inval)?;
-    let region = CancellableRegion::enter()?;
-    let fd = unsafe {
+    let fd = with_cancellable_region(|| unsafe {
         libc::open(
             filename.as_ptr(),
             access_flag | sync_flag | create_flag | append_flag | libc::O_CLOEXEC,
             mode as libc::c_uint,
         )
-    };
-    drop(region);
+    })?;
     if fd < 0 {
         return Err(last_native_error());
     }
@@ -434,8 +432,7 @@ fn open_raw_native_file(
         .chain(std::iter::once(0))
         .collect::<Vec<_>>();
     let handle: HANDLE = loop {
-        let region = CancellableRegion::enter()?;
-        let handle = unsafe {
+        let handle = with_cancellable_region(|| unsafe {
             CreateFileW(
                 filename.as_ptr(),
                 access_flag,
@@ -445,8 +442,7 @@ fn open_raw_native_file(
                 flags,
                 std::ptr::null_mut(),
             )
-        };
-        drop(region);
+        })?;
         if handle != INVALID_HANDLE_VALUE {
             break handle;
         }
@@ -456,9 +452,9 @@ fn open_raw_native_file(
         if error != ERROR_PIPE_BUSY as i32 {
             return Err(AsyncHostError::Native(error));
         }
-        let region = CancellableRegion::enter()?;
-        let ready = unsafe { WaitNamedPipeW(filename.as_ptr(), NMPWAIT_WAIT_FOREVER) };
-        drop(region);
+        let ready = with_cancellable_region(|| unsafe {
+            WaitNamedPipeW(filename.as_ptr(), NMPWAIT_WAIT_FOREVER)
+        })?;
         if ready == 0 {
             return Err(last_native_error());
         }
@@ -573,9 +569,9 @@ pub(super) fn handle_is_socket(handle: RawFile) -> bool {
 fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHostResult<usize> {
     let ret = if position < 0 {
         loop {
-            let region = CancellableRegion::enter()?;
-            let ret = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
-            drop(region);
+            let ret = with_cancellable_region(|| unsafe {
+                libc::read(fd, buf.as_mut_ptr().cast(), buf.len())
+            })?;
             if ret >= 0 {
                 break ret;
             }
@@ -590,9 +586,7 @@ fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHos
                 events: libc::POLLIN,
                 revents: 0,
             };
-            let region = CancellableRegion::enter()?;
-            let ready = unsafe { libc::poll(&mut pfd, 1, -1) };
-            drop(region);
+            let ready = with_cancellable_region(|| unsafe { libc::poll(&mut pfd, 1, -1) })?;
             if ready < 0 {
                 break -1;
             }
@@ -616,9 +610,9 @@ fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHos
 fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostResult<usize> {
     let ret = if position < 0 {
         loop {
-            let region = CancellableRegion::enter()?;
-            let ret = unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) };
-            drop(region);
+            let ret = with_cancellable_region(|| unsafe {
+                libc::write(fd, data.as_ptr().cast(), data.len())
+            })?;
             if ret >= 0 {
                 break ret;
             }
@@ -633,9 +627,7 @@ fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostRes
                 events: libc::POLLOUT,
                 revents: 0,
             };
-            let region = CancellableRegion::enter()?;
-            let ready = unsafe { libc::poll(&mut pfd, 1, -1) };
-            drop(region);
+            let ready = with_cancellable_region(|| unsafe { libc::poll(&mut pfd, 1, -1) })?;
             if ready < 0 {
                 break -1;
             }
@@ -775,9 +767,7 @@ fn lock_native_file(fd: RawFile, exclusive: bool) -> AsyncHostResult<()> {
     } else {
         libc::LOCK_SH
     };
-    let region = CancellableRegion::enter()?;
-    let result = unsafe { libc::flock(fd, operation) };
-    drop(region);
+    let result = with_cancellable_region(|| unsafe { libc::flock(fd, operation) })?;
     if result < 0 {
         Err(last_native_error())
     } else {
@@ -1008,17 +998,17 @@ fn read_from_native_file(handle: RawFile, buf: &mut [u8], position: i64) -> Asyn
     } else {
         Some(current_file_pointer(handle)?)
     };
-    let region = CancellableRegion::enter()?;
-    let result = unsafe {
-        ReadFile(
-            handle,
-            buf.as_mut_ptr().cast(),
-            u32::try_from(buf.len()).map_err(|_| AsyncHostError::Fault)?,
-            &mut bytes_transferred,
-            overlapped_ptr,
-        )
-    };
-    drop(region);
+    let result = with_cancellable_region(|| -> AsyncHostResult<_> {
+        Ok(unsafe {
+            ReadFile(
+                handle,
+                buf.as_mut_ptr().cast(),
+                u32::try_from(buf.len()).map_err(|_| AsyncHostError::Fault)?,
+                &mut bytes_transferred,
+                overlapped_ptr,
+            )
+        })
+    })??;
     let result = if result != 0 {
         usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
     } else {
@@ -1074,17 +1064,17 @@ fn write_to_native_file(handle: RawFile, data: &[u8], position: i64) -> AsyncHos
     } else {
         Some(current_file_pointer(handle)?)
     };
-    let region = CancellableRegion::enter()?;
-    let result = unsafe {
-        WriteFile(
-            handle,
-            data.as_ptr().cast(),
-            u32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?,
-            &mut bytes_transferred,
-            overlapped_ptr,
-        )
-    };
-    drop(region);
+    let result = with_cancellable_region(|| -> AsyncHostResult<_> {
+        Ok(unsafe {
+            WriteFile(
+                handle,
+                data.as_ptr().cast(),
+                u32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?,
+                &mut bytes_transferred,
+                overlapped_ptr,
+            )
+        })
+    })??;
     let result = if result != 0 {
         usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
     } else {
@@ -1374,9 +1364,8 @@ fn lock_native_file(file: RawFile, exclusive: bool) -> AsyncHostResult<()> {
     } else {
         0
     };
-    let region = CancellableRegion::enter()?;
-    let result = unsafe { LockFileEx(file, flags, 0, 1, 0, &mut overlapped) };
-    drop(region);
+    let result =
+        with_cancellable_region(|| unsafe { LockFileEx(file, flags, 0, 1, 0, &mut overlapped) })?;
     if result == 0 {
         Err(last_native_error())
     } else {

--- a/crates/moonrun/src/process/ambient.rs
+++ b/crates/moonrun/src/process/ambient.rs
@@ -801,7 +801,7 @@ fn wait_for_process_pidfd(pidfd: RawFile, defer_reap: bool) -> AsyncHostResult<i
                 siginfo.si_status()
             }),
         ))
-    })?
+    })
 }
 
 #[cfg(unix)]
@@ -841,7 +841,7 @@ fn wait_for_process_pid(pid: i32, defer_reap: bool) -> AsyncHostResult<i64> {
                 siginfo.si_status()
             }),
         ))
-    })?
+    })
 }
 
 #[cfg(windows)]

--- a/crates/moonrun/src/process/ambient.rs
+++ b/crates/moonrun/src/process/ambient.rs
@@ -31,6 +31,8 @@ use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::windows::io::{AsRawHandle, AsRawSocket};
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
+#[cfg(unix)]
+use crate::async_sys::internal::event_loop::thread_pool::with_cancellable_region;
 use crate::async_sys::internal::fd_util;
 use crate::async_sys::ported_fns;
 use crate::policy::PolicyInheritance;
@@ -787,57 +789,59 @@ fn wait_for_process(
 
 #[cfg(target_os = "linux")]
 fn wait_for_process_pidfd(pidfd: RawFile, defer_reap: bool) -> AsyncHostResult<i64> {
-    let _region = crate::async_sys::internal::event_loop::thread_pool::CancellableRegion::enter()?;
-    let mut siginfo = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
-    // Policy mode reaps only after atomically revoking PID authority.
-    let flags = libc::WEXITED | if defer_reap { libc::WNOWAIT } else { 0 };
-    if unsafe { libc::waitid(libc::P_PIDFD, pidfd as libc::id_t, &mut siginfo, flags) } < 0 {
-        return Err(last_native_error());
-    }
-    Ok(i64::from(
-        crate::async_sys::process::unix_siginfo_exit_code(siginfo.si_code, unsafe {
-            siginfo.si_status()
-        }),
-    ))
+    with_cancellable_region(|| {
+        let mut siginfo = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
+        // Policy mode reaps only after atomically revoking PID authority.
+        let flags = libc::WEXITED | if defer_reap { libc::WNOWAIT } else { 0 };
+        if unsafe { libc::waitid(libc::P_PIDFD, pidfd as libc::id_t, &mut siginfo, flags) } < 0 {
+            return Err(last_native_error());
+        }
+        Ok(i64::from(
+            crate::async_sys::process::unix_siginfo_exit_code(siginfo.si_code, unsafe {
+                siginfo.si_status()
+            }),
+        ))
+    })?
 }
 
 #[cfg(unix)]
 fn wait_for_process_pid(pid: i32, defer_reap: bool) -> AsyncHostResult<i64> {
-    let _region = crate::async_sys::internal::event_loop::thread_pool::CancellableRegion::enter()?;
-    if !defer_reap {
-        let mut status = 0;
-        let ret = unsafe { libc::waitpid(pid, &mut status, 0) };
-        if ret < 0 {
+    with_cancellable_region(|| {
+        if !defer_reap {
+            let mut status = 0;
+            let ret = unsafe { libc::waitpid(pid, &mut status, 0) };
+            if ret < 0 {
+                return Err(last_native_error());
+            }
+            if ret != pid {
+                return Err(AsyncHostError::Inval);
+            }
+            return Ok(i64::from(
+                crate::async_sys::process::unix_wait_status_exit_code(status),
+            ));
+        }
+        let mut siginfo = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
+        // The host reaps after atomically revoking policy PID authority.
+        if unsafe {
+            libc::waitid(
+                libc::P_PID,
+                pid as libc::id_t,
+                &mut siginfo,
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        } < 0
+        {
             return Err(last_native_error());
         }
-        if ret != pid {
+        if unsafe { siginfo.si_pid() } != pid {
             return Err(AsyncHostError::Inval);
         }
-        return Ok(i64::from(
-            crate::async_sys::process::unix_wait_status_exit_code(status),
-        ));
-    }
-    let mut siginfo = unsafe { std::mem::zeroed::<libc::siginfo_t>() };
-    // The host reaps after atomically revoking policy PID authority.
-    if unsafe {
-        libc::waitid(
-            libc::P_PID,
-            pid as libc::id_t,
-            &mut siginfo,
-            libc::WEXITED | libc::WNOWAIT,
-        )
-    } < 0
-    {
-        return Err(last_native_error());
-    }
-    if unsafe { siginfo.si_pid() } != pid {
-        return Err(AsyncHostError::Inval);
-    }
-    Ok(i64::from(
-        crate::async_sys::process::unix_siginfo_exit_code(siginfo.si_code, unsafe {
-            siginfo.si_status()
-        }),
-    ))
+        Ok(i64::from(
+            crate::async_sys::process::unix_siginfo_exit_code(siginfo.si_code, unsafe {
+                siginfo.si_status()
+            }),
+        ))
+    })?
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
- Related issues: Follow-up to #2176
- PR kind: Refactor

## Summary

Worker cancellation used a separately reference-counted state object, and every cancellable syscall reconstructed an owning `Arc` from thread-local storage. The current Job ID was also atomic even though it belongs to one executing Job. Bare integer outcomes made cancellation acknowledgement easy to confuse with Job completion.

Embed cancellation state in the allocation shared by the Worker handle and its thread. Each executing Job installs a stack context borrowing that state and holding its immutable `WorkerCompletionId`. Private guards clear TLS and the region mark before their borrowed storage disappears, including during unwinding. Nested Jobs and syscall regions are rejected before they can overwrite an active binding or clear its region mark. This removes the extra cancellation allocation, per-region reference-count operations, and atomic Job ID.

`with_cancellable_region` accepts a fallible synchronous operation, so cancellation and operation errors use one result. Named `CancellationOutcome` values flow through Workers and the signal-wait cancellation hook; only the guest import encodes them as the existing `0/1/2` values. The internal acknowledgement state is named explicitly, and comments identify the readers and writers of each atomic and the ordering constraints.

Cancellation acknowledgement, retry notification delivery, result publication order, syscall coverage, and the guest ABI retain their existing behavior. The completion queue, retry-slot ownership, scheduling, and teardown are unchanged. Tests cover unwinding, rejected nesting, operation errors, completion-ID reuse, and switching cancellation imports with a retry already pending, alongside the existing signal-race and completion-readiness checks.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
