### PR TITLE
fix(moonutil): separate MSVC discovery from PATH probing

### DIFF
--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -632,14 +632,15 @@ fn detect_path_candidate(cc_path: &Path, cc_kind: CCKind) -> anyhow::Result<CC> 
         .with_context(|| format!("failed to use C compiler at {}", cc_path.display()))
 }
 
-fn detect_system_cc() -> anyhow::Result<CC> {
-    let mut errors = Vec::new();
-    for (name, kind) in [
-        ("cl", CCKind::Msvc),
+fn detect_cc_on_path() -> anyhow::Result<CC> {
+    // MSVC discovery separately resolves the target architecture and command environment.
+    let candidates = [
         ("cc", CCKind::SystemCC),
-        ("gcc", CCKind::Gcc),
         ("clang", CCKind::Clang),
-    ] {
+        ("gcc", CCKind::Gcc),
+    ];
+    let mut errors = Vec::new();
+    for (name, kind) in candidates {
         let Ok(cc_path) = which::which(name) else {
             continue;
         };
@@ -650,7 +651,8 @@ fn detect_system_cc() -> anyhow::Result<CC> {
     }
 
     if errors.is_empty() {
-        anyhow::bail!("no system C compiler found; tried cl, cc, gcc, clang")
+        let names = candidates.map(|(name, _)| name).join(", ");
+        anyhow::bail!("no system C compiler found; tried {names}")
     }
     anyhow::bail!(
         "failed to resolve system C compiler candidates: {}",
@@ -658,8 +660,8 @@ fn detect_system_cc() -> anyhow::Result<CC> {
     )
 }
 
-static DETECTED_SYSTEM_CC: std::sync::LazyLock<anyhow::Result<CC>> =
-    std::sync::LazyLock::new(detect_system_cc);
+static DETECTED_CC_ON_PATH: std::sync::LazyLock<anyhow::Result<CC>> =
+    std::sync::LazyLock::new(detect_cc_on_path);
 
 fn cached_cc(result: &std::sync::LazyLock<anyhow::Result<CC>>) -> anyhow::Result<CC> {
     result
@@ -668,8 +670,8 @@ fn cached_cc(result: &std::sync::LazyLock<anyhow::Result<CC>>) -> anyhow::Result
         .map_err(|e| anyhow::anyhow!("{e:#}"))
 }
 
-pub fn try_system_cc() -> anyhow::Result<CC> {
-    cached_cc(&DETECTED_SYSTEM_CC)
+pub fn try_cc_on_path() -> anyhow::Result<CC> {
+    cached_cc(&DETECTED_CC_ON_PATH)
 }
 
 pub fn has_cc_env_override() -> bool {
@@ -684,7 +686,7 @@ fn detected_default_native_toolchain() -> anyhow::Result<Toolchain> {
         }
     }
 
-    try_system_cc().map(Toolchain::from_path_probe)
+    try_cc_on_path().map(Toolchain::from_path_probe)
 }
 
 fn selected_default_native_toolchain() -> anyhow::Result<Toolchain> {

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -636,8 +636,8 @@ fn detect_cc_on_path() -> anyhow::Result<CC> {
     // MSVC discovery separately resolves the target architecture and command environment.
     let candidates = [
         ("cc", CCKind::SystemCC),
-        ("clang", CCKind::Clang),
         ("gcc", CCKind::Gcc),
+        ("clang", CCKind::Clang),
     ];
     let mut errors = Vec::new();
     for (name, kind) in candidates {

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -142,17 +142,20 @@ own debug information.
 
 Tool resolution starts from `crates/moonutil/src/compiler_flags.rs`.
 
-There are three sources of C toolchain selection:
-
-1. global environment override
-2. package-level override
-3. default auto-detection
-
-When a native build step chooses its compiler, the current precedence is:
+For the regular native pipeline, compiler selection uses this precedence:
 
 1. `MOON_CC` / `MOON_AR`
 2. package-level override (`link.native.cc` or `link.native.stub_cc`)
-3. detected default toolchain
+3. Windows only: MSVC discovery through `find-msvc-tools`
+4. PATH probing: `cc`, then `clang`, then `gcc`
+
+`effective_native_toolchain()` applies environment and package overrides before automatic
+selection. `detected_default_native_toolchain()` tries Windows MSVC discovery before the
+cached PATH fallback, `try_cc_on_path()`, whose candidates are defined in `detect_cc_on_path()`.
+
+The Windows MSVC direct object native target uses `windows_msvc_native_toolchain()` instead.
+It requires a cl-compatible driver, warns and ignores an incompatible `MOON_CC`, and has no
+GCC-like fallback.
 
 ## Global Environment Override
 
@@ -185,16 +188,15 @@ When `MOON_CC` is unset and no package-specific override is being applied to tha
 for a default native toolchain.
 
 On Windows, Moon first tries to discover an MSVC toolchain environment for the current 64-bit host
-architecture using the Visual Studio/MSVC discovery logic. The discovery target is
+architecture using `find-msvc-tools`. The discovery target is
 `x86_64-pc-windows-msvc` on x64 Windows hosts and `aarch64-pc-windows-msvc` on ARM64 Windows hosts.
 Moon does not model cross compilation in this path. This discovery is needed so generated-C builds
 can use `cl.exe` outside a Developer Command Prompt. If MSVC discovery fails, or on non-Windows
 hosts, Moon falls back to PATH probing in this order:
 
-1. `cl`
-2. `cc`
+1. `cc`
+2. `clang`
 3. `gcc`
-4. `clang`
 
 Moon does not fall back to a bundled compiler. If no system toolchain is
 available, planning fails with the tool-resolution error.

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -147,7 +147,7 @@ For the regular native pipeline, compiler selection uses this precedence:
 1. `MOON_CC` / `MOON_AR`
 2. package-level override (`link.native.cc` or `link.native.stub_cc`)
 3. Windows only: MSVC discovery through `find-msvc-tools`
-4. PATH probing: `cc`, then `clang`, then `gcc`
+4. PATH probing: `cc`, then `gcc`, then `clang`
 
 `effective_native_toolchain()` applies environment and package overrides before automatic
 selection. `detected_default_native_toolchain()` tries Windows MSVC discovery before the
@@ -195,8 +195,8 @@ can use `cl.exe` outside a Developer Command Prompt. If MSVC discovery fails, or
 hosts, Moon falls back to PATH probing in this order:
 
 1. `cc`
-2. `clang`
-3. `gcc`
+2. `gcc`
+3. `clang`
 
 Moon does not fall back to a bundled compiler. If no system toolchain is
 available, planning fails with the tool-resolution error.


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

Remove `cl` from the generic PATH fallback, leaving Windows MSVC discovery to the existing `find-msvc-tools` path. This prevents generic probing from selecting a bare `cl` after toolchain discovery has failed.

Retain the `cc`, `gcc`, `clang` fallback order and existing environment/package override precedence. Rename the PATH-only detector and derive its error message from the candidate list. Changes are limited to compiler discovery and its reference documentation.

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
