### PR TITLE
feat(build): add opt-in Wasm hash executor

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -858,6 +858,7 @@ fn run_planned_checks(
             &cfg.with_suppressed_progress(true),
             build_input,
             target_dir,
+            output.user_log(),
         )?;
         let successful = result.successful();
         json.append_build(result, output.user_log());

--- a/crates/moon/tests/test_hash_executor.rs
+++ b/crates/moon/tests/test_hash_executor.rs
@@ -1,0 +1,419 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::{fs, path::Path};
+
+fn moon(root: &Path) -> snapbox::cmd::Command {
+    snapbox::cmd::Command::new(snapbox::cargo_bin!("moon"))
+        .current_dir(root)
+        .env("MOON_TOOLCHAIN_ROOT", moonutil::toolchain::toolchain_root())
+        .env("MOON_BUILD_CACHE", root.join(".cache"))
+        .env("MOON_DEP_CACHE", "off")
+        .env("MOON_HASH_ENGINE", "1")
+}
+
+fn check(root: &Path) -> snapbox::cmd::Command {
+    moon(root).args(["check", "--target", "wasm-gc", "--json"])
+}
+
+#[test]
+fn reuses_outputs_and_replays_warnings_by_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("moon.mod.json"), r#"{"name":"test/hash"}"#).unwrap();
+    fs::write(root.join("moon.pkg.json"), "{}").unwrap();
+    let source = root.join("hello.mbt");
+    let text = "pub fn answer() -> Int { let unused = 1; 42 }\n";
+    fs::write(&source, text).unwrap();
+
+    check(root).assert().success().stdout_eq(
+        r#"{"version":1,"status":"success","diagnostics":[{[..]}],"messages":[],"summary":{"tasks_executed":2,"moon_errors":0,"moon_warnings":0,"diagnostic_errors":0,"diagnostic_warnings":1}}
+"#,
+    );
+    assert!(!root.join("_build/.moon_db").exists());
+    check(root).assert().success().stdout_eq(
+        r#"{"version":1,"status":"success","diagnostics":[{[..]}],"messages":[],"summary":{"tasks_executed":0,"moon_errors":0,"moon_warnings":0,"diagnostic_errors":0,"diagnostic_warnings":1}}
+"#,
+    );
+
+    // Rewriting identical bytes changes the timestamp, not the action identity.
+    fs::write(&source, text).unwrap();
+    check(root).assert().success().stdout_eq(
+        r#"[..]"tasks_executed":0,[..]"diagnostic_warnings":1}}
+"#,
+    );
+    let modified = fs::metadata(&source).unwrap().modified().unwrap();
+    fs::write(&source, text.replace("42", "43")).unwrap();
+    fs::File::options()
+        .write(true)
+        .open(&source)
+        .unwrap()
+        .set_modified(modified)
+        .unwrap();
+    check(root).assert().success().stdout_eq(
+        r#"[..]"tasks_executed":2,[..]"diagnostic_warnings":1}}
+"#,
+    );
+
+    fs::remove_dir_all(root.join("_build")).unwrap();
+    check(root).assert().success().stdout_eq(
+        r#"[..]"tasks_executed":0,[..]"diagnostic_warnings":1}}
+"#,
+    );
+    assert!(root.join("_build/wasm-gc/debug/check/hash.mi").exists());
+}
+
+#[test]
+fn builds_and_runs_both_wasm_backends() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("moon.mod.json"), r#"{"name":"test/hash"}"#).unwrap();
+    fs::create_dir(root.join("lib")).unwrap();
+    fs::write(root.join("lib/moon.pkg.json"), "{}").unwrap();
+    fs::write(root.join("lib/lib.mbt"), "pub fn answer() -> Int { 42 }\n").unwrap();
+    fs::create_dir(root.join("main")).unwrap();
+    fs::write(
+        root.join("main/moon.pkg.json"),
+        r#"{"is-main":true,"import":["test/hash/lib"]}"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("main/main.mbt"),
+        "fn main { println(@lib.answer()) }\ntest { assert_eq(@lib.answer(), 42) }\n",
+    )
+    .unwrap();
+    for backend in ["wasm", "wasm-gc"] {
+        moon(root)
+            .args(["build", "--target", backend])
+            .assert()
+            .success();
+        moon(root)
+            .args(["build", "--target", backend])
+            .assert()
+            .success()
+            .stderr_eq("Finished. moon: no work to do\n");
+        moon(root)
+            .args(["run", "main", "--target", backend])
+            .assert()
+            .success()
+            .stdout_eq("42\n");
+        moon(root)
+            .args(["test", "--target", backend])
+            .assert()
+            .success();
+        moon(root)
+            .args(["test", "--target", backend])
+            .assert()
+            .success();
+        fs::remove_dir_all(root.join("_build").join(backend)).unwrap();
+        moon(root)
+            .args(["build", "--target", backend])
+            .assert()
+            .success()
+            .stderr_eq("Finished. moon: no work to do\n");
+        moon(root)
+            .args(["run", "main", "--target", backend])
+            .assert()
+            .success()
+            .stdout_eq("42\n");
+    }
+    assert!(!root.join("_build/.moon_db").exists());
+}
+
+#[test]
+fn failed_compilations_replay_diagnostics_without_publishing_outputs() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("moon.mod.json"), r#"{"name":"test/hash"}"#).unwrap();
+    fs::write(root.join("moon.pkg.json"), "{}").unwrap();
+    fs::write(root.join("hello.mbt"), "pub fn answer() -> Int { false }\n").unwrap();
+    for invocation in 0..2 {
+        check(root).assert().failure().stdout_eq(
+            r#"{"version":1,"status":"failure","diagnostics":[{[..]}],"messages":[],"summary":{"tasks_executed":null,"moon_errors":0,"moon_warnings":0,"diagnostic_errors":1,"diagnostic_warnings":0}}
+"#);
+        let records = fs::read_dir(root.join(".cache/v1"))
+            .unwrap()
+            .flat_map(|shard| fs::read_dir(shard.unwrap().path()).unwrap())
+            .map(|entry| entry.unwrap().path().join("result/record.json"))
+            .filter(|record| record.exists())
+            .collect::<Vec<_>>();
+        // The failed source action blocks its dependent blackbox check.
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        let result: serde_json::Value = serde_json::from_slice(&fs::read(record).unwrap()).unwrap();
+        assert_ne!(result["exit_code"], 0);
+        assert_eq!(result["outputs"], serde_json::json!([]));
+        assert!(!record.parent().unwrap().join("0").exists());
+        if invocation == 0 {
+            fs::File::options()
+                .write(true)
+                .open(record)
+                .unwrap()
+                .set_modified(std::time::SystemTime::UNIX_EPOCH)
+                .unwrap();
+        } else {
+            // A rerun would republish the record. A hit leaves it untouched.
+            assert_eq!(
+                fs::metadata(record).unwrap().modified().unwrap(),
+                std::time::SystemTime::UNIX_EPOCH
+            );
+        }
+    }
+    fs::write(root.join("hello.mbt"), "pub fn answer() -> Int { 42 }\n").unwrap();
+    check(root).assert().success();
+    check(root)
+        .assert()
+        .success()
+        .stdout_eq("[..]\"tasks_executed\":0,[..]\n");
+}
+
+#[test]
+fn corruption_is_a_miss_and_environment_changes_invalidate() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("moon.mod.json"), r#"{"name":"test/hash"}"#).unwrap();
+    fs::write(root.join("moon.pkg.json"), "{}").unwrap();
+    fs::write(root.join("hello.mbt"), "pub fn answer() -> Int { 42 }\n").unwrap();
+    check(root).assert().success();
+    for blob in ["0", "record.json", "diagnostics"] {
+        for shard in fs::read_dir(root.join(".cache/v1")).unwrap() {
+            for entry in fs::read_dir(shard.unwrap().path()).unwrap() {
+                fs::write(entry.unwrap().path().join("result").join(blob), "corrupt").unwrap();
+            }
+        }
+        check(root)
+            .assert()
+            .success()
+            .stdout_eq("[..]\"tasks_executed\":2,[..]\n");
+        check(root)
+            .assert()
+            .success()
+            .stdout_eq("[..]\"tasks_executed\":0,[..]\n");
+    }
+    check(root)
+        .env("MOON_TEST_HASH_ENV", "changed")
+        .assert()
+        .success()
+        .stdout_eq("[..]\"tasks_executed\":2,[..]\n");
+    check(root)
+        .env("MOON_TEST_HASH_ENV", "changed")
+        .assert()
+        .success()
+        .stdout_eq("[..]\"tasks_executed\":0,[..]\n");
+    check(root)
+        .env("MOON_BUILD_CACHE", "off")
+        .assert()
+        .success()
+        .stdout_eq("[..]\"tasks_executed\":2,[..]\n");
+    check(root)
+        .env("MOON_BUILD_CACHE", "off")
+        .assert()
+        .success()
+        .stdout_eq("[..]\"tasks_executed\":2,[..]\n");
+    assert!(!root.join("_build/.moon_hash").exists());
+}
+
+#[test]
+fn a_waiter_reuses_the_result_published_under_the_directory_lock() {
+    use std::{
+        io::{BufRead, BufReader},
+        process::{Command, Stdio},
+        sync::mpsc,
+        time::Duration,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("moon.mod.json"), r#"{"name":"test/hash"}"#).unwrap();
+    fs::write(root.join("moon.pkg.json"), "{}").unwrap();
+    fs::write(root.join("hello.mbt"), "pub fn answer() -> Int { 42 }\n").unwrap();
+    moon(root)
+        .args(["check", "--target", "wasm-gc"])
+        .assert()
+        .success();
+    let shard = fs::read_dir(root.join(".cache/v1"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let entry = fs::read_dir(shard).unwrap().next().unwrap().unwrap().path();
+    let lock = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(entry.join(moonutil::constants::MOON_LOCK))
+        .unwrap();
+    lock.lock().unwrap();
+    fs::rename(entry.join("result"), entry.join("pending")).unwrap();
+    let mut child = Command::new(snapbox::cargo_bin!("moon"))
+        .current_dir(root)
+        .env("MOON_TOOLCHAIN_ROOT", moonutil::toolchain::toolchain_root())
+        .env("MOON_BUILD_CACHE", root.join(".cache"))
+        .env("MOON_DEP_CACHE", "off")
+        .env("MOON_HASH_ENGINE", "1")
+        .args(["check", "--target", "wasm-gc"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let (send, receive) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        let mut output = String::new();
+        for line in BufReader::new(stderr).lines() {
+            let line = line.unwrap();
+            if line.contains("Blocking waiting for file lock") {
+                let _ = send.send(());
+            }
+            output.push_str(&line);
+            output.push('\n');
+        }
+        output
+    });
+    let waited = receive.recv_timeout(Duration::from_secs(30));
+    fs::rename(entry.join("pending"), entry.join("result")).unwrap();
+    drop(lock);
+    if waited.is_err() {
+        let _ = child.kill();
+    }
+    let output = child.wait_with_output().unwrap();
+    let stderr = reader.join().unwrap();
+    waited.expect("child must actually wait for the cache directory lock");
+    assert!(output.status.success(), "{stderr}");
+    snapbox::assert_data_eq!(
+        stderr,
+        "Blocking waiting for file lock [..] ...\nFinished. moon: no work to do\n"
+    );
+}
+
+#[test]
+fn prebuild_left() {
+    prebuild_helper("left", "right");
+}
+#[test]
+fn prebuild_right() {
+    prebuild_helper("right", "left");
+}
+
+fn prebuild_helper(side: &str, other: &str) {
+    use std::time::{Duration, Instant};
+    let Ok(mode) = std::env::var("MOON_TEST_HASH_PREBUILD") else {
+        return;
+    };
+    let marker = format!(".{side}-ready");
+    fs::write(marker, "ready").unwrap();
+    if mode == "parallel" {
+        let started = Instant::now();
+        while !Path::new(&format!(".{other}-ready")).exists() {
+            assert!(
+                started.elapsed() < Duration::from_secs(20),
+                "independent prebuild actions must run concurrently"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    } else {
+        fs::create_dir(".active-prebuild").expect("--jobs 1 must serialize actions");
+        std::thread::sleep(Duration::from_millis(100));
+        fs::remove_dir(".active-prebuild").unwrap();
+    }
+    // Also exercises arbitrary prebuild output, working directory, and stderr
+    // capture without making that shell action eligible for caching.
+    eprintln!("prebuild {side}");
+    fs::write(
+        format!("{side}/generated.mbt"),
+        "pub fn generated() -> Int { 7 }\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn schedules_dependencies_and_respects_parallelism() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("moon.mod.json"), r#"{"name":"test/hash"}"#).unwrap();
+    let executable = std::env::current_exe().unwrap().display().to_string();
+    for side in ["left", "right"] {
+        fs::create_dir(root.join(side)).unwrap();
+        fs::write(root.join(side).join("input.txt"), "input").unwrap();
+        let test = format!("prebuild_{side}");
+        let command = moonutil::shlex::join_native(
+            [executable.as_str(), "--exact", &test, "--nocapture"].into_iter(),
+        );
+        let manifest = serde_json::json!({"pre-build":[{"input":"input.txt","output":"generated.mbt","command":command}]});
+        fs::write(root.join(side).join("moon.pkg.json"), manifest.to_string()).unwrap();
+    }
+    for (mode, jobs) in [("parallel", "2"), ("serial", "1")] {
+        check(root)
+            .env("MOON_TEST_HASH_PREBUILD", mode)
+            .args(["--jobs", jobs])
+            .assert()
+            .success();
+    }
+    for side in ["left", "right"] {
+        assert_eq!(
+            fs::read_to_string(root.join(side).join("generated.mbt")).unwrap(),
+            "pub fn generated() -> Int { 7 }\n"
+        );
+    }
+    // Unmodeled shell inputs make both prebuild actions and their consumers
+    // ineligible; every invocation must execute them, even with existing outputs.
+    assert_eq!(fs::read_dir(root.join(".cache/v1")).unwrap().count(), 0);
+}
+
+#[test]
+fn executes_and_reuses_response_file_commands() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("moon.mod.json"), r#"{"name":"test/hash"}"#).unwrap();
+    fs::write(root.join("moon.pkg.json"), "{}").unwrap();
+    for i in 0..120 {
+        fs::write(
+            root.join(format!("file_{i}_{}.mbt", "x".repeat(150))),
+            format!("pub fn value{i}() -> Int {{ {i} }}\n"),
+        )
+        .unwrap();
+    }
+    check(root).assert().success();
+    assert!(root.join("_build/wasm-gc/debug/check/hash.mi.rsp").exists());
+    check(root)
+        .assert()
+        .success()
+        .stdout_eq("[..]\"tasks_executed\":0,[..]\n");
+}
+
+#[test]
+fn snapshot_updates_recompute_the_requested_action_closure() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("moon.mod.json"), r#"{"name":"test/hash"}"#).unwrap();
+    fs::write(root.join("moon.pkg.json"), "{}").unwrap();
+    let source = root.join("hello.mbt");
+    fs::write(&source, "test { inspect(1, content=\"0\") }\n").unwrap();
+    moon(root)
+        .args(["test", "--target", "wasm-gc", "--update"])
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read_to_string(&source).unwrap(),
+        "test { inspect(1, content=(\n  #|1\n)) }\n"
+    );
+    moon(root)
+        .args(["test", "--target", "wasm-gc"])
+        .assert()
+        .success();
+    assert!(!root.join("_build/.moon_db").exists());
+}

--- a/crates/moonbuild/Cargo.toml
+++ b/crates/moonbuild/Cargo.toml
@@ -29,6 +29,7 @@ n2.workspace = true
 ariadne.workspace = true
 blake3.workspace = true
 tracing.workspace = true
+tempfile.workspace = true
 anstream.workspace = true
 anstyle.workspace = true
 moonutil.workspace = true
@@ -57,9 +58,5 @@ serde_json.workspace = true
 handlebars.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }
 
-[dev-dependencies]
-tempfile.workspace = true
-
 [target."cfg(windows)".dependencies]
 self-replace.workspace = true
-tempfile.workspace = true

--- a/crates/moonbuild/src/execution/action_identity.rs
+++ b/crates/moonbuild/src/execution/action_identity.rs
@@ -35,18 +35,18 @@ use anyhow::{Context, bail};
 use blake3::Hasher;
 use moonbuild_rupes_recta::{
     build_plan::ArtifactKey,
-    execution_plan::{ExecutionPlan, InputObservation, LoweredCommandExecution},
+    execution_plan::{ActionId, ExecutionPlan, InputObservation, LoweredCommandExecution},
     model::TargetKind,
 };
 
 /// Invocation state observed by every executed action.
 ///
 /// The working directory and environment are passed explicitly so the caller
-/// hashes the same inherited process state that it gives to n2.
+/// hashes the same inherited process state that it gives to child processes.
 #[derive(Clone, Debug)]
 pub struct ActionIdentityContext {
-    inherited_working_directory: PathBuf,
-    inherited_environment: Vec<(OsString, OsString)>,
+    pub(super) inherited_working_directory: PathBuf,
+    pub(super) inherited_environment: Vec<(OsString, OsString)>,
 }
 
 impl ActionIdentityContext {
@@ -102,12 +102,13 @@ impl ActionIdentity {
     }
 }
 
-/// Compute identities in Execution Plan action order.
+/// Compute identities for a dependency-closed selection in the supplied action order.
+#[tracing::instrument(skip_all)]
 pub fn compute_action_identities(
     plan: &ExecutionPlan,
     context: &ActionIdentityContext,
+    action_ids: &[ActionId],
 ) -> anyhow::Result<Vec<ActionIdentity>> {
-    let action_ids = plan.action_ids().collect::<Vec<_>>();
     let index_by_id = action_ids
         .iter()
         .enumerate()
@@ -115,7 +116,7 @@ pub fn compute_action_identities(
         .collect::<HashMap<_, _>>();
 
     let mut actions = Vec::with_capacity(action_ids.len());
-    for id in action_ids {
+    for &id in action_ids {
         let action = plan.action(id);
         let mut dependency_outputs = HashMap::new();
         let mut dependencies = Vec::new();

--- a/crates/moonbuild/src/execution/hash.rs
+++ b/crates/moonbuild/src/execution/hash.rs
@@ -1,0 +1,487 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Content-based execution and cached action results.
+//!
+//! Each digest owns a directory with a stable lock file. A waiter checks the
+//! result after acquiring that lock, so it can reuse the previous owner's work.
+//! The caller separately holds the target lock while mutable outputs are used.
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::mpsc,
+};
+
+use anyhow::{Context, bail, ensure};
+use moonbuild_rupes_recta::execution_plan::{
+    ExecutionAction, InputObservation, LoweredCommandExecution,
+};
+use moonutil::{
+    cache::{CacheKind, resolve_cache_root},
+    locks::lock_directory,
+    target::TargetBackend,
+    user_log::UserLog,
+};
+use serde::{Deserialize, Serialize};
+
+use super::{
+    BuildConfig, BuildInput, CapturedActionOutput, CapturedBuildExecution, ResultCatcher,
+    action_identity::{ActionDigest, ActionIdentityContext, compute_action_identities},
+    resolve_parallelism,
+};
+
+#[tracing::instrument(skip_all)]
+pub(super) fn execute<'a>(
+    cfg: &BuildConfig,
+    input: &BuildInput,
+    outputs: impl IntoIterator<Item = &'a Path>,
+    user_log: &UserLog,
+) -> anyhow::Result<CapturedBuildExecution> {
+    let plan = input.execution_plan.as_ref();
+    // TODO: Enable native backends after their implicit SDK/header inputs and
+    // directory-shaped debug outputs have a reusable execution model.
+    ensure!(
+        input.action_backends.values().all(|backend| {
+            backend.is_none_or(|backend| {
+                matches!(backend, TargetBackend::Wasm | TargetBackend::WasmGC)
+            })
+        }),
+        "the experimental hash engine currently supports only wasm and wasm-gc backends"
+    );
+    let parallelism = resolve_parallelism(cfg.parallelism);
+    ensure!(
+        parallelism > 0,
+        "build parallelism must be greater than zero"
+    );
+
+    let dependencies = plan
+        .action_ids()
+        .map(|id| {
+            let producers = plan
+                .action(id)
+                .inputs()
+                .iter()
+                .filter_map(|observation| match observation {
+                    InputObservation::File(path) => {
+                        plan.declared_output(path).map(|out| out.producer())
+                    }
+                    InputObservation::StandardLibraryInterfaces(_) => None,
+                })
+                .collect::<HashSet<_>>();
+            (id, producers)
+        })
+        .collect::<HashMap<_, _>>();
+    let mut pending = outputs
+        .into_iter()
+        .map(|path| {
+            plan.declared_output(path)
+                .map(|out| out.producer())
+                .with_context(|| format!("unknown requested build output: {}", path.display()))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let mut wanted = HashSet::new();
+    while let Some(id) = pending.pop() {
+        if wanted.insert(id) {
+            pending.extend(&dependencies[&id]);
+        }
+    }
+    let actions = plan
+        .action_ids()
+        .filter(|id| wanted.contains(id))
+        .collect::<Vec<_>>();
+    let context =
+        ActionIdentityContext::new(std::env::current_dir()?, std::env::vars_os().collect());
+    let identities = compute_action_identities(plan, &context, &actions)?;
+    let identities = actions
+        .iter()
+        .copied()
+        .zip(identities)
+        .collect::<HashMap<_, _>>();
+    let configured_cache = resolve_cache_root(CacheKind::BuildArtifacts)?;
+    let cache_root = configured_cache.initialize()?.map(|root| root.join("v1"));
+    if let Some(root) = &cache_root {
+        fs::create_dir_all(root)?;
+    }
+
+    let mut remaining = actions
+        .iter()
+        .map(|id| (*id, dependencies[id].len()))
+        .collect::<HashMap<_, _>>();
+    let mut consumers = HashMap::<_, Vec<_>>::new();
+    for &id in &actions {
+        for &producer in &dependencies[&id] {
+            consumers.entry(producer).or_default().push(id);
+        }
+    }
+    let mut ready = actions
+        .iter()
+        .copied()
+        .filter(|id| remaining[id] == 0)
+        .collect::<VecDeque<_>>();
+    let mut executed = 0;
+    let mut completed = 0;
+    let mut failures = 0;
+    let mut captured = Vec::new();
+    std::thread::scope(|scope| -> anyhow::Result<()> {
+        let (sender, receiver) = mpsc::channel();
+        let mut running = 0;
+        loop {
+            while running < parallelism && failures < 10 {
+                let Some(id) = ready.pop_front() else { break };
+                let sender = sender.clone();
+                let action = plan.action(id);
+                let identity = identities[&id];
+                let cache_dir =
+                    cache_root
+                        .as_ref()
+                        .filter(|_| identity.is_cacheable())
+                        .map(|root| {
+                            let digest = identity.digest().to_hex();
+                            root.join(&digest[..2]).join(&digest[2..])
+                        });
+                let context = &context;
+                scope.spawn(move || {
+                    let result = run_action(
+                        action,
+                        cache_dir.as_deref(),
+                        identity.digest(),
+                        context,
+                        cfg,
+                        user_log,
+                    )
+                    .with_context(|| format!("failed to execute {}", action.description()));
+                    // A scheduler error still joins running children before releasing
+                    // its caller's target lock. Their completed cache results remain valid.
+                    let _ = sender.send((id, result));
+                });
+                running += 1;
+            }
+            if running == 0 {
+                break;
+            }
+            let (id, result) = receiver
+                .recv()
+                .context("hash executor worker disconnected")?;
+            running -= 1;
+            let result = result?;
+            executed += usize::from(result.executed);
+            completed += 1;
+            let mut content = ResultCatcher::default();
+            for line in String::from_utf8_lossy(&result.output)
+                .split('\n')
+                .filter(|line| !line.is_empty())
+            {
+                content.append_content(line);
+            }
+            captured.push(CapturedActionOutput {
+                target_backend: input.action_backends.get(&id).copied().flatten(),
+                content,
+            });
+            if result.exit_code != Some(0) {
+                failures += 1;
+                // Signal termination must not start additional work or publish a
+                // success. Ordinary compiler failures still allow independent actions.
+                if result.exit_code.is_none() {
+                    failures = 10;
+                }
+                continue;
+            }
+            for consumer in consumers.get(&id).into_iter().flatten() {
+                let count = remaining
+                    .get_mut(consumer)
+                    .expect("consumer belongs to requested closure");
+                *count -= 1;
+                if *count == 0 {
+                    ready.push_back(*consumer);
+                }
+            }
+        }
+        ensure!(
+            failures != 0 || completed == actions.len(),
+            "execution action graph contains a cycle"
+        );
+        Ok(())
+    })?;
+    Ok(CapturedBuildExecution {
+        n_tasks_executed: (failures == 0).then_some(executed),
+        action_outputs: captured,
+    })
+}
+
+struct ActionResult {
+    // None denotes signal/abnormal termination. Failed launches are I/O errors.
+    exit_code: Option<i32>,
+    output: Vec<u8>,
+    executed: bool,
+}
+
+fn run_action(
+    action: &ExecutionAction,
+    cache_dir: Option<&Path>,
+    digest: ActionDigest,
+    context: &ActionIdentityContext,
+    cfg: &BuildConfig,
+    user_log: &UserLog,
+) -> anyhow::Result<ActionResult> {
+    let _lock = if let Some(directory) = cache_dir {
+        fs::create_dir_all(directory)?;
+        let lock = lock_directory(directory, user_log)?;
+        if let Some(result) = restore_result(directory, digest, action.outputs())? {
+            return Ok(result);
+        }
+        Some(lock)
+    } else {
+        None
+    };
+
+    // A success must produce every declared file during this execution; an old
+    // output must not make an incomplete command look publishable.
+    if cache_dir.is_some() {
+        for output in action.outputs() {
+            match fs::remove_file(output) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+    let lowered = action.command();
+    let cwd = context
+        .inherited_working_directory
+        .join(lowered.cwd().unwrap_or(Path::new("")));
+    for path in action.outputs() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let command_line = match lowered.execution() {
+        LoweredCommandExecution::Inline(command) => command,
+        LoweredCommandExecution::ResponseFile { command, file } => {
+            let path = cwd.join(&file.path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(path, &file.content)?;
+            command
+        }
+    };
+    if !cfg.suppress_progress {
+        user_log.status(if cfg.verbose {
+            command_line
+        } else {
+            action.description()
+        });
+    }
+    #[cfg(unix)]
+    let mut command = {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", command_line]);
+        command
+    };
+    #[cfg(windows)]
+    let mut command = {
+        use std::os::windows::process::CommandExt;
+        let (program, arguments) = moonutil::shlex::split_argv0_windows(command_line);
+        let mut command = Command::new(program);
+        command.raw_arg(arguments.trim_start());
+        command
+    };
+    // Match the lowered transport and give hashing and execution the same
+    // inherited process state. One pipe retains stdout/stderr byte ordering.
+    let (mut reader, writer) = std::io::pipe()?;
+    let mut child = command
+        .current_dir(cwd)
+        .env_clear()
+        .envs(context.inherited_environment.iter().cloned())
+        .envs(lowered.env().iter().cloned())
+        .stdin(Stdio::null())
+        .stdout(writer.try_clone()?)
+        .stderr(writer)
+        .spawn()?;
+    drop(command); // Drop the parent's write handles before draining to EOF.
+    let mut output = Vec::new();
+    if let Err(error) = reader.read_to_end(&mut output) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error.into());
+    }
+    let status = child.wait()?;
+    // Shell statuses 126/127 denote launch errors, and 128+ can represent
+    // signal termination. Neither is a reusable compiler result.
+    if let Some(exit_code @ 0..=125) = status.code()
+        && let Some(directory) = cache_dir
+    {
+        publish_result(
+            directory,
+            digest,
+            exit_code,
+            if status.success() {
+                action.outputs()
+            } else {
+                &[]
+            },
+            &output,
+        )?;
+    }
+    Ok(ActionResult {
+        exit_code: status.code(),
+        output,
+        executed: true,
+    })
+}
+
+// Failed compiler results contain diagnostics and an exit status, never output
+// artifacts. Filenames are ordinals, never paths supplied by the record.
+#[derive(Deserialize, Serialize)]
+struct Record {
+    action: String,
+    exit_code: i32,
+    outputs: Vec<StoredOutput>,
+    diagnostics: [u8; 32],
+}
+
+#[derive(Deserialize, Serialize)]
+struct StoredOutput {
+    path: PathBuf,
+    digest: [u8; 32],
+}
+
+fn restore_result(
+    directory: &Path,
+    digest: ActionDigest,
+    outputs: &[PathBuf],
+) -> anyhow::Result<Option<ActionResult>> {
+    let result = directory.join("result");
+    let record = match fs::read(result.join("record.json")) {
+        Ok(bytes) => match serde_json::from_slice::<Record>(&bytes) {
+            Ok(record) => record,
+            Err(_) => return Ok(None),
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let outputs = if record.exit_code == 0 { outputs } else { &[] };
+    if record.action != digest.to_hex()
+        || !(0..=125).contains(&record.exit_code)
+        || record.outputs.len() != outputs.len()
+        || record
+            .outputs
+            .iter()
+            .zip(outputs)
+            .any(|(stored, output)| stored.path != *output)
+    {
+        return Ok(None);
+    }
+    // Validate the complete result before replacing any project outputs. A
+    // truncated, missing, or corrupt blob is a miss, never a partial hit.
+    let mut blobs = Vec::new();
+    for (index, stored) in record.outputs.iter().enumerate() {
+        let path = result.join(index.to_string());
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        if *blake3::hash(&bytes).as_bytes() != stored.digest {
+            return Ok(None);
+        }
+        blobs.push((bytes, fs::metadata(path)?.permissions()));
+    }
+    let diagnostics = match fs::read(result.join("diagnostics")) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if *blake3::hash(&diagnostics).as_bytes() != record.diagnostics {
+        return Ok(None);
+    }
+    for ((bytes, permissions), output) in blobs.into_iter().zip(outputs) {
+        // Avoid touching already-correct outputs. In particular, sharing results
+        // with a waiting invocation must not trigger timestamp-based consumers.
+        if fs::read(output).is_ok_and(|existing| existing == bytes) {
+            continue;
+        }
+        let parent = output.parent().context("action output has no parent")?;
+        fs::create_dir_all(parent)?;
+        let mut file = tempfile::NamedTempFile::new_in(parent)?;
+        file.write_all(&bytes)?;
+        file.as_file().set_permissions(permissions)?;
+        file.persist(output)?;
+    }
+    Ok(Some(ActionResult {
+        exit_code: Some(record.exit_code),
+        output: diagnostics,
+        executed: false,
+    }))
+}
+
+fn publish_result(
+    directory: &Path,
+    digest: ActionDigest,
+    exit_code: i32,
+    outputs: &[PathBuf],
+    diagnostics: &[u8],
+) -> anyhow::Result<()> {
+    let staging = tempfile::Builder::new()
+        .prefix("staging-")
+        .tempdir_in(directory)?;
+    let mut stored = Vec::new();
+    for (index, output) in outputs.iter().enumerate() {
+        let metadata = fs::symlink_metadata(output)
+            .with_context(|| format!("successful action did not produce {}", output.display()))?;
+        if !metadata.is_file() {
+            bail!(
+                "hash cache currently requires regular file outputs: {}",
+                output.display()
+            );
+        }
+        let blob = staging.path().join(index.to_string());
+        fs::copy(output, &blob)?;
+        let mut hash = blake3::Hasher::new();
+        hash.update_reader(fs::File::open(&blob)?)?;
+        stored.push(StoredOutput {
+            path: output.clone(),
+            digest: *hash.finalize().as_bytes(),
+        });
+    }
+    fs::write(staging.path().join("diagnostics"), diagnostics)?;
+    let record = Record {
+        action: digest.to_hex(),
+        exit_code,
+        outputs: stored,
+        diagnostics: *blake3::hash(diagnostics).as_bytes(),
+    };
+    fs::write(
+        staging.path().join("record.json"),
+        serde_json::to_vec(&record)?,
+    )?;
+    let result = directory.join("result");
+    match fs::remove_dir_all(&result) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    // All files precede publication; the stable lock directory is never renamed
+    // or removed. A killed writer leaves a miss for the next lock owner.
+    fs::rename(staging.path(), result)?;
+    Ok(())
+}

--- a/crates/moonbuild/src/execution/mod.rs
+++ b/crates/moonbuild/src/execution/mod.rs
@@ -18,7 +18,8 @@
 
 //! Execute a concrete plan and process captured diagnostics.
 //!
-//! The private `n2` module owns graph adaptation, scheduling, and the database.
+//! The private executors own scheduling and incremental state: `n2` uses its
+//! database; `hash` stores action results and replays diagnostics.
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -43,7 +44,8 @@ use tracing::instrument;
 
 use crate::BuildMeta;
 
-pub mod action_identity;
+mod action_identity;
+mod hash;
 mod n2;
 
 /// Execution and diagnostic options. Planning inputs live in `BuildInput`.
@@ -322,7 +324,7 @@ impl CapturedBuildExecution {
 /// artifacts from the planning phase for any metadata they need.
 ///
 /// The caller must hold the target-directory lock. All executions in
-/// that directory share one n2 database, and n2 does not lock it internally.
+/// that directory share mutable output paths, regardless of the chosen engine.
 #[instrument(skip_all)]
 pub fn execute_build(
     cfg: &BuildConfig,
@@ -330,7 +332,13 @@ pub fn execute_build(
     target_dir: &Path,
     user_log: &UserLog,
 ) -> anyhow::Result<BuildStats> {
-    let execution = execute_build_capturing(cfg, input, target_dir)?;
+    let execution = execute(
+        cfg,
+        &input,
+        target_dir,
+        input.execution_plan.default_output_paths(),
+        user_log,
+    )?;
     Ok(finish_captured_build(cfg, &execution, None, user_log))
 }
 
@@ -365,10 +373,17 @@ pub fn execute_build_json(
     cfg: &BuildConfig,
     input: BuildInput,
     target_dir: &Path,
+    user_log: &UserLog,
 ) -> anyhow::Result<JsonBuildOutput> {
-    let execution = execute_build_capturing(cfg, input, target_dir)?;
+    let execution = execute(
+        cfg,
+        &input,
+        target_dir,
+        input.execution_plan.default_output_paths(),
+        user_log,
+    )?;
     // Keep the existing per-backend diagnostic-limit semantics while all
-    // backends execute in one n2 graph. Shared actions have no backend and are
+    // backends execute in one graph. Shared actions have no backend and are
     // collected in their own group.
     let mut sources_by_backend = BTreeMap::new();
     for output in &execution.action_outputs {
@@ -427,7 +442,13 @@ pub fn execute_test_build(
     build_metas: &[&BuildMeta],
     user_log: &UserLog,
 ) -> anyhow::Result<BuildStats> {
-    let execution = execute_build_capturing(cfg, input, target_dir)?;
+    let execution = execute(
+        cfg,
+        &input,
+        target_dir,
+        input.execution_plan.default_output_paths(),
+        user_log,
+    )?;
     let sources = execution.diagnostic_sources(build_metas.iter().copied());
     let processed = process_captured_diagnostics(&sources, cfg);
     processed.warn_if_limited(user_log);
@@ -449,21 +470,26 @@ pub fn execute_build_partial<'a>(
     user_log: &UserLog,
     outputs: impl IntoIterator<Item = &'a Path>,
 ) -> anyhow::Result<BuildStats> {
-    let execution = n2::execute(cfg, &input, target_dir, outputs)?;
+    let execution = execute(cfg, &input, target_dir, outputs, user_log)?;
     Ok(finish_captured_build(cfg, &execution, build_meta, user_log))
 }
 
-fn execute_build_capturing(
+fn execute<'a>(
     cfg: &BuildConfig,
-    input: BuildInput,
+    input: &BuildInput,
     target_dir: &Path,
+    outputs: impl IntoIterator<Item = &'a Path>,
+    user_log: &UserLog,
 ) -> anyhow::Result<CapturedBuildExecution> {
-    n2::execute(
-        cfg,
-        &input,
-        target_dir,
-        input.execution_plan.default_output_paths(),
-    )
+    // Capture engine selection once, here, rather than teaching CLI commands
+    // or planners about the experimental executor.
+    static HASH_ENGINE: LazyLock<bool> =
+        LazyLock::new(|| std::env::var_os("MOON_HASH_ENGINE").is_some_and(|value| value == "1"));
+    if *HASH_ENGINE {
+        hash::execute(cfg, input, outputs, user_log)
+    } else {
+        n2::execute(cfg, input, target_dir, outputs)
+    }
 }
 
 fn finish_captured_build(

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -160,7 +160,8 @@ cargo install --path ./crates/moon --debug --offline
 - `crates/moonbuild`: build execution and shared build support
   - `src/execution`: execution options, plan composition, and diagnostics
     - `n2.rs`: private n2 adaptation, incremental state, scheduling, and output capture
-    - `action_identity.rs`: canonical action hashing, not yet connected to execution
+    - `hash.rs`: experimental Wasm execution and global action-result caching
+    - `action_identity.rs`: private canonical action hashing used by the hash executor
   - `src/{entry, runtest, section_capture}`: test arguments, results, formatting,
     and child-output capture
   - `src/expect.rs`: expect and snapshot comparison and promotion

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -2,13 +2,12 @@
 
 ## Status
 
-This document records the intended direction for global dependency and build
-caches. Cache-root configuration and cleaning are implemented. Standalone
-`moon run` inputs reuse immutable registry dependency sources through the
-dependency cache. The pure canonical identity calculation for execution actions
-is also implemented in `moonbuild::execution::action_identity`, but builds do
-not yet read from or write to the global artifact cache and identity calculation
-is not connected to execution.
+Cache-root configuration, cleaning, and standalone dependency-source reuse are
+implemented. `MOON_HASH_ENGINE=1` enables an experimental hash executor for
+`wasm` and `wasm-gc`. It executes Rupes Recta Execution Plans directly and uses
+the global build cache for complete successful action results and failed
+compiler diagnostics. n2 remains the default. Native backends are rejected explicitly
+by the experimental executor.
 
 ## Problem
 
@@ -72,11 +71,71 @@ dependencies, its `.mooncakes` directory lives under the per-script build root
 (for example, `_build/script.mbtx/.mooncakes`) and follows `--target-dir`.
 Ordinary projects and workspaces retain their project-local dependency
 directories.
-`MOON_BUILD_CACHE` still configures and cleans its future root only.
+With `MOON_HASH_ENGINE=1`, `MOON_BUILD_CACHE` selects the action-result store.
+Setting it to `off` runs the hash executor without result reuse; there is no
+second project-local cache or `.moon_db`. Engine selection is captured once
+inside `moonbuild::execution`, rather than read by individual CLI commands.
 
-Canonical action identity is also implemented as a pure consumer of the Rupes
-Recta `ExecutionPlan`. It is not connected to build execution or either cache
-root yet.
+### Action-result layout
+
+The first two hexadecimal digits shard the action digest so a large cache does
+not put every entry in one directory:
+
+```text
+$MOON_BUILD_CACHE/
+  .moon-cache                    # existing ownership marker
+  v1/
+    ab/
+      <remaining 62 hex digits>/
+        .moon-lock               # stable per-action directory lock
+        result/
+          record.json            # action digest, exit status, output paths and digests
+          diagnostics            # original combined stdout/stderr bytes
+          0                      # first declared output
+          1                      # second declared output, if any
+        staging-<unique>/        # unpublished result while a writer is active
+```
+
+The record binds the exit status, complete output set, and diagnostics to the
+action digest. A failed compiler result stores its nonzero exit status and
+diagnostics without output artifacts. Each output and the diagnostic stream
+has a BLAKE3 content digest. The store
+uses ordinal blob names, never paths from a record, to address cached files.
+Output paths must match the current plan before restoration. The cache contains
+independent file copies, so modifying project outputs cannot modify cached
+results. Unchanged project output bytes are left in place to preserve mtimes.
+
+A writer acquires the action directory lock, then checks for a complete valid
+result. This check happens after waiting: if another process has published a
+result, the waiter restores its exit status and diagnostics without executing
+the command, along with output artifacts when it succeeded. Otherwise it holds
+the lock through execution and publication.
+Distinct action keys have distinct locks and may execute concurrently.
+
+All result files are written in a staging directory before it is renamed to
+`result`. Readers validate every output and the diagnostics before restoring
+anything. Missing or corrupt data is a miss. Ordinary compiler failures are
+replayed and block dependent actions just as fresh failures do. Failed launches
+and interrupted commands publish no result; shell statuses 126 and above are
+also excluded because they can represent launch errors or signal termination.
+An abandoned staging directory is never a hit. The lock file itself is never
+removed or renamed while publishing, preserving the identity used by waiting
+processes.
+
+The existing target-directory lock still protects mutable outputs across
+planning, execution, and consumption. The cache directory lock protects only
+one immutable action result; it does not replace that target lock. Concurrent
+manual cleaning of the build cache is unsupported, as with dependency sources.
+
+The executor schedules only the requested output closure, honors `--jobs`, and
+blocks consumers of failed producers. Actions with unmodeled inputs execute
+normally and are not cached; their ineligibility propagates to consumers.
+Canonical identities include the effective environment and working directory.
+The executor captures inherited values once and passes the same snapshot to
+hashing and child processes. Physical paths remain part of identity, so this
+first store does not promise reuse across relocated projects or private work
+directories. Native input auditing and relocatable actions remain follow-up
+work.
 
 ### Cleaning
 
@@ -316,11 +375,12 @@ Each stage should be useful and reviewable without requiring the next:
    private fallback when caching is off. Other command families remain local.
 3. **Private standalone work:** stop sharing mutable `_build` trees between
    standalone invocations; place `__moonbin__` there.
-4. **Action model (implemented, not execution-wired):** define and test
+4. **Action model (implemented and used by the experimental executor):** define and test
    canonical action inputs at the Rupes Recta compiler boundary, including
    resolved interfaces and target facts.
-5. **Artifact cache:** publish and restore complete `.mi`/`.core` result sets
-   with concurrency and corruption tests.
+5. **Artifact cache (experimental for Wasm backends):** publish and restore
+   complete successful action results and failed compiler diagnostics, with
+   directory locking and corruption tests. Native and relocatable results remain future work.
 6. **Build constraints and cross compilation:** extend the target descriptor
    and action identity without changing storage-path semantics.
 7. **Operations:** add recency tracking, pruning, diagnostics, and format

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -97,13 +97,16 @@ In a broad sense, `moon` subcommands follows this order when executing project-b
    - For a multi-backend invocation, compose the independently lowered
      Execution Plans into one executor graph, sharing compatible physical
      providers such as package prebuild actions. JSON-formatted checks retain
-     each diagnostic's backend through the originating n2 Build ID, so they use
+     each diagnostic's backend through its originating execution action, so they use
      the same composed graph. Backend actions render their backend together
      with any applicable target kind, such as `(wasm, blackbox test)`;
      package-prebuild actions independently render `(prebuild)` before the
      executor receives either description.
-   - Execute the concrete build graph in its executor ([n2][]).
-     The executor ensures the graph is executed incrementally, rebuilding only the changed parts.
+   - Execute the concrete build graph using n2 by default. `MOON_HASH_ENGINE=1`
+     selects the experimental content-based executor for Wasm backends. It
+     restores outputs and replays compiler diagnostics, including failures, from
+     the global cache; misses run with dependency ordering and `--jobs`.
+     See the [cache design](../design/global-build-cache.md) for layout and locking.
 4. Perform other operations required after build
    - Run the built executable.
    - Run the test/bench executables within test/bench environment and collect results.
@@ -113,8 +116,9 @@ Implementation-wise:
 
 - Steps 1 and 2 is handled in the RR pipeline's crate.
   You can also see a low-level implementation doc comment at its [entry point][rr_home].
-- Step 3, as well as wrappers around step 1 and 2 to adapt to the various subcommands,
-  are all located in [the `rr_build` module of the main binary crate][moon_rr_build].
+- Execution in step 3 belongs to `moonbuild::execution`. Metadata generation
+  and wrappers around steps 1 and 2 remain in
+  [the `rr_build` module of the main binary crate][moon_rr_build].
 - Step 4 is handled separately in each individual subcommand.
 
 [^graph]:
@@ -132,7 +136,7 @@ Implementation-wise:
 [rr_home]: /crates/moonbuild-rupes-recta/src/lib.rs
 [n2]: https://github.com/moonbitlang/n2
 
-Rupes Recta executions in one target directory share the n2 database at
+With the default executor, Rupes Recta executions in one target directory share the n2 database at
 `<target-dir>/.moon_db`. Target backend, profile, and run mode are represented
 by concrete output paths and build hashes rather than separate database files.
 Both ordinary projects and standalone scripts execute one complete graph per
@@ -600,11 +604,18 @@ is defined in [its module](/crates/moonbuild-rupes-recta/src/target_layout.rs).
 
 ## Execution of the build graph
 
-For current builds, the execution plan is adapted to an n2 graph and handed to [n2][],
+By default, the execution plan is adapted to an n2 graph and handed to [n2][],
 which executes it in the usual Ninja-style way:
 incrementally (skipping up-to-date nodes)
 and with maximal parallelism subject to dependencies and its job limits.
 `moonbuild` does not add extra scheduling logic on top of `n2`.
+
+With `MOON_HASH_ENGINE=1`, the private `moonbuild::execution::hash` module
+executes Wasm plans directly. It owns dependency scheduling, child processes,
+and the global action-result store, independently of n2. Successful results
+include diagnostics for replay, so warning output does not force a rebuild.
+The [cache design](../design/global-build-cache.md) specifies its layout,
+validation, directory-lock protocol, and current reuse constraints.
 
 The private `moonbuild::execution::n2` module owns n2 adaptation, the `.moon_db`
 location and database access, root lookup, scheduling, and progress capture.


### PR DESCRIPTION
- Related issues: None
- PR kind: Feature

## Summary

Add an experimental executor for `wasm` and `wasm-gc`, enabled with `MOON_HASH_ENGINE=1`. It reuses compiler outputs and replays warnings and errors from the global build cache, avoiding compiler reruns solely to reproduce diagnostics. n2 remains the default.

Action keys include input contents, compiler and standard-library inputs, dependency identities, commands, working directories, and the effective environment. Each action directory has its own lock; a waiter checks for a published result after acquiring it. Results are staged before publication and validated before restoration. Failed compiler results store only their exit status and diagnostics and continue to block dependent actions; launch errors and interrupted commands are not cached.

The executor is a private module in `moonbuild::execution` and consumes the existing Execution Plan, diagnostic renderer, and target-lock contract. `MOON_BUILD_CACHE` selects the global cache root or disables reuse. Native execution, reuse across relocated projects, and automatic eviction remain follow-up work.

Tests cover content-based invalidation, output restoration, warning and failure replay, corruption, lock contention, dependency ordering, parallelism, response files, and snapshot updates.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
